### PR TITLE
feat(sync): bidirectional N-way cross-provider sync + YouTube Data API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,15 @@ SPOTIFY_CLIENT_SECRET=
 SPOTIFY_REDIRECT_URI=http://127.0.0.1:8888/callback
 PLAYLISTS=                # comma-separated names; empty = every same-named pair
 SYNC_INTERVAL=15m         # loop sleep (e.g. 900, 15m, 1h)
-MAX_REMOVALS=25           # per-playlist removal cap per pass
+MAX_REMOVALS=25           # per-playlist removal cap per pass (guards every write side)
 MAX_ADDS=200              # per-playlist additions cap per pass (rest continue next pass)
+
+# Sync direction. oneway (default) = Spotify -> Apple/YT, Spotify never modified.
+# nway = bidirectional: a track added/removed on ANY provider propagates to the
+# others. N-way REQUIRES Spotify write scopes, which forces a one-time re-auth
+# (delete the token cache + re-run OAuth). Dry-run it first. See README.
+SYNC_MODE=oneway          # oneway | nway
+PROVIDERS=spotify,apple,ytmusic   # N-way peers that participate
 DOWNLOAD_DIR=             # set to a folder to also keep local audio copies
 #LOCAL_MIRROR_FORMAT=mp3  # flac/ogg/opus/m4a/wav; opus keeps YouTube's native ~160k without re-encoding
 #LOCAL_MIRROR_BITRATE=320k # spotDL --bitrate (320k, 256k, "disable" to copy source); can't exceed the source
@@ -31,6 +38,14 @@ APPLE_CACHE_FILE=apple_resolve_cache.json
 SONG_CACHE_FILE=song_cache.db
 SPOTIFY_TRACKS_CACHE=spotify_tracks_cache.json  # playlist snapshots, keyed by Spotify snapshot_id
 DOWNLOAD_STATE_FILE=download_state.json         # per-playlist download state (snapshot, ids, unavailable)
-YTMUSIC_AUTH_FILE=ytmusic_browser.json   # created via: uv run ytmusicapi browser
+# YouTube Music via the official YouTube Data API v3 (durable OAuth refresh
+# token). ytmusicapi's internal API rejects self-made OAuth clients (400) and
+# its browser cookies die within a day, so OAuth here is REQUIRED, not optional.
+# Create a Google "TVs and Limited Input devices" OAuth client, then:
+#   uvx ytmusicapi oauth --file data/ytmusic_oauth.json --client-id ... --client-secret ...
+YTMUSIC_AUTH_FILE=ytmusic_oauth.json
+YTMUSIC_OAUTH_CLIENT_ID=
+YTMUSIC_OAUTH_CLIENT_SECRET=
 YTMUSIC_CACHE_FILE=ytmusic_resolve_cache.json
+SPOTIFY_CACHE_FILE=spotify_resolve_cache.json   # Spotify search cache (N-way writes)
 SPOTIFY_TOKEN_CACHE=.cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Matching + archive tests
         run: uv run test_matching.py
 
+      - name: N-way reconcile tests
+        run: uv run test_reconcile.py
+
       - name: Download-mirror tests
         run: uv run --with mutagen python test_downloads.py

--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,12 @@ wheels/
 .cache
 .cache-*
 apple_resolve_cache.json
+spotify_resolve_cache.json
 song_cache.db
 spotify_tracks_cache.json
 download_state.json
 ytmusic_browser.json
+ytmusic_oauth.json
 ytmusic_resolve_cache.json
 data/
 downloads/

--- a/README.md
+++ b/README.md
@@ -5,16 +5,21 @@
 ![License: MIT](https://img.shields.io/badge/license-MIT-green)
 ![Docker ready](https://img.shields.io/badge/docker-ready-2496ED)
 
-**Always-on, one-way playlist sync: Spotify → Apple Music, YouTube Music, and
-local audio files (Jellyfin-ready).** Set it up once, and every playlist you
-curate on Spotify stays mirrored everywhere — tracks added on Spotify appear
-on the other services in date-added order, tracks you remove disappear, and an
-optional download mirror keeps offline copies organized for your media server.
+**Always-on playlist sync: Spotify → Apple Music, YouTube Music, and local
+audio files (Jellyfin-ready) — with an optional bidirectional mode.** Set it up
+once, and every playlist you curate on Spotify stays mirrored everywhere —
+tracks added on Spotify appear on the other services in date-added order, tracks
+you remove disappear, and an optional download mirror keeps offline copies
+organized for your media server. Flip on [N-way mode](#bidirectional-n-way-sync)
+and a change made on *any* provider propagates to the others.
 
 ## Features
 
 - 🔁 **True mirroring** — adds *and* removals, not append-only. Spotify is the
   source of truth; Apple Music and YouTube Music follow.
+- ⇄ **Optional N-way sync** — bidirectional mode where a track added or removed
+  on Spotify, Apple, *or* YouTube Music propagates to all the others, echo-free,
+  behind the same removal guards.
 - 🎯 **ISRC-first matching** — exact recording identity where available, with
   Unicode-aware fuzzy title/artist/duration fallbacks (feat-credit drift,
   "- 2015 Remaster" suffixes, non-Latin scripts all handled).
@@ -44,11 +49,14 @@ Every pass, for each selected playlist name that exists on Spotify:
 
 1. Snapshot the Spotify playlist (tracks, ISRCs, added-at dates).
 2. Reconcile the same-named Apple Music playlist (via the web player's
-   amp-api) and YouTube Music playlist (via
-   [ytmusicapi](https://github.com/sigma67/ytmusicapi)) — concurrently.
+   amp-api) and YouTube Music playlist (via the official
+   [YouTube Data API v3](https://developers.google.com/youtube/v3)) —
+   concurrently.
 3. Missing tracks are resolved (cached links → ISRC → scored search) and
    appended oldest-first; tracks gone from Spotify are removed behind guards.
 4. Optionally, spotDL syncs a local audio folder per playlist.
+
+For the opt-in bidirectional variant, see [N-way sync](#bidirectional-n-way-sync).
 
 > This project previously synced the other direction (Apple → Spotify). That
 > mode is gone; the old `synced_isrcs.json` / `apple_spotify_uri_cache.json`
@@ -194,7 +202,8 @@ cp .cache data/spotify_token_cache          # PowerShell: copy .cache data\spoti
 SPOTIFY_TOKEN_CACHE=data/spotify_token_cache uv run main.py
 ```
 
-For the YouTube Music mirror, also put its auth at `data/ytmusic_browser.json`.
+For the YouTube Music mirror, also put its auth at `data/ytmusic_oauth.json` and
+set the OAuth env vars — see [YouTube Music mirror](#youtube-music-mirror-optional).
 
 **Downloads**: set `DOWNLOAD_DIR` in `.env` to your host music dir (e.g.
 `F:\Torrent\Music`) — compose bind-mounts it to `/music` in the container
@@ -222,26 +231,98 @@ mirrors racing each other can briefly duplicate adds.
 
 ## YouTube Music mirror (optional)
 
-The same mirroring (same-name pairs, adds oldest-first so newest lands last,
-guarded removals, auto-create) also runs against YouTube Music whenever an
-auth file is present — no auth file, and the step just logs a skip line.
+The same mirroring (same-name pairs, adds oldest-first, guarded removals,
+auto-create) runs against YouTube Music whenever its OAuth token is present — no
+token, and the step just logs a skip line. It talks to the **official
+[YouTube Data API v3](https://developers.google.com/youtube/v3)**, whose OAuth
+refresh token is durable and survives restarts unattended.
 
 One-time setup:
 
-```bash
-uv run ytmusicapi browser --file ytmusic_browser.json
-```
+1. In the [Google Cloud console](https://console.cloud.google.com), create a
+   project, enable the **YouTube Data API v3**, then create an OAuth client of
+   type **TVs and Limited Input devices**. Note its **client ID** and **secret**.
+2. On the **OAuth consent screen**, set **Publishing status → In production** and
+   add yourself as a test user. ⚠️ If you leave it in "Testing", Google expires
+   the refresh token after **7 days** — the exact trap OAuth is meant to avoid.
+3. Run the device flow and follow the printed code/URL (`uvx` runs it in a
+   throwaway env, immune to a stale project venv):
 
-Follow its prompt: open <https://music.youtube.com> logged in, DevTools →
-Network, click a `/browse` POST request, copy the **request headers** and paste
-them (finish with Ctrl-Z + Enter on Windows). Same idea as the Apple tokens.
+   ```bash
+   uvx ytmusicapi oauth --file data/ytmusic_oauth.json \
+     --client-id "<CLIENT_ID>" --client-secret "<CLIENT_SECRET>"
+   ```
+
+4. Put `YTMUSIC_OAUTH_CLIENT_ID` and `YTMUSIC_OAUTH_CLIENT_SECRET` in `.env`, and
+   point `YTMUSIC_AUTH_FILE` at the token file (default `ytmusic_oauth.json`).
+
+**Why the Data API, not ytmusicapi's internal endpoints?** `ytmusicapi`'s
+private `youtubei` API rejects self-made OAuth clients outright (`400 —
+INVALID_ARGUMENT`, a [known, unfixed issue](https://github.com/sigma67/ytmusicapi/issues/813)),
+and its browser-cookie auth is a static snapshot Google invalidates within ~a
+day. The public Data API accepts the OAuth token, shares YouTube's
+playlist/video namespace (writes show up in the YouTube Music app), and refreshes
+durably. `ytmusicapi` is still used, but only to refresh the OAuth token.
 
 Notes:
 
-- YouTube Music has no ISRC, so matching is title/artist/duration based —
-  slightly fuzzier than the Apple side, same safety rails.
-- Only playlists owned by your YT account are edited; others are skipped.
-- For Docker, put the auth file at `data/ytmusic_browser.json`.
+- **Quota**: the Data API allows **10,000 units/day** (a search costs 100, an
+  add/remove 50, a read 1). Steady-state upkeep is cheap; a big first-time
+  backlog of *new* tracks can hit the cap and resume the next day.
+- **Fidelity**: YouTube has no ISRC, so matching is title/artist/duration and
+  resolution prefers `- Topic` art-tracks so tracks land as native songs. When
+  no art-track surfaces, a music video is used instead.
+- Only playlists owned by your account are edited; others are skipped.
+- For Docker, put the token file at `data/ytmusic_oauth.json` (or whatever
+  `YTMUSIC_AUTH_FILE` names).
+
+## Bidirectional (N-way) sync
+
+By default Spotify is the source of truth and edits flow one way. In **N-way
+mode** every provider is a peer: add or remove a track on Spotify, Apple Music,
+*or* YouTube Music and the change propagates to the others.
+
+Enable it in `.env`:
+
+```bash
+SYNC_MODE=nway
+PROVIDERS=spotify,apple,ytmusic   # which peers participate
+```
+
+**One-time cost — Spotify re-auth.** N-way needs to *write* to Spotify, which
+adds the `playlist-modify-*` scopes. Changing the scope invalidates the cached
+token, so you re-authorize once: delete the token cache
+(`data/spotify_token_cache`) and run a pass so the OAuth flow re-runs (seed it
+the same way as the [initial Docker token](#always-running-docker) — the
+container can't open a browser). Until you do, N-way writes to Spotify fail
+closed with a clear message.
+
+**Always dry-run first.** Run without `--execute` and read the plan — it prints
+every proposed add/remove on every provider before anything is written.
+
+### How it stays safe
+
+Bidirectional sync is impossible statelessly (you can't tell "added on A" from
+"removed on B" without memory), so each logical playlist's canonical membership
+is snapshotted after every clean pass. Each pass diffs every provider against
+that snapshot, unions the changes, and reconciles everyone to the result:
+
+- **Echo-free** — a propagated add becomes part of the snapshot, so it's never
+  re-seen as a new appearance and bounced back.
+- **Add-wins** on conflict — losing a song is worse than keeping an extra one.
+- **Read-collapse guard** — if a provider suddenly reads far fewer tracks than
+  the known baseline (a transient API hiccup), it's skipped that pass so one bad
+  read can't cascade a mass-delete.
+- **The same rails as one-way** — per-pass `MAX_ADDS` / `MAX_REMOVALS` caps and
+  net-loss (`protect_removals`) hold on every write side.
+
+### Cross-provider identity caveats
+
+Matching uses ISRC where it exists (Spotify + Apple) and falls back to
+title/artist/duration for YouTube (no ISRC). The fuzzy YouTube leg can
+occasionally **duplicate** a track it fails to recognize as already-present, but
+the guards mean it will **never wrongly delete** one. Big divergences converge
+over several passes (bounded by the Data API quota).
 
 ## Local download mirror (optional)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       SONG_CACHE_FILE: /data/song_cache.db
       SPOTIFY_TRACKS_CACHE: /data/spotify_tracks_cache.json
       DOWNLOAD_STATE_FILE: /data/download_state.json
-      YTMUSIC_AUTH_FILE: /data/ytmusic_browser.json
+      YTMUSIC_AUTH_FILE: /data/ytmusic_oauth.json   # YouTube Data API v3 OAuth refresh token
       YTMUSIC_CACHE_FILE: /data/ytmusic_resolve_cache.json
+      SPOTIFY_CACHE_FILE: /data/spotify_resolve_cache.json   # N-way Spotify search cache
       SPOTIFY_OAUTH_OPEN_BROWSER: "0"
       # Container path; the host music dir (DOWNLOAD_DIR in .env, e.g.
       # F:\Torrent\Music) is bind-mounted to it below. This overrides the

--- a/spotify_mirror/archive.py
+++ b/spotify_mirror/archive.py
@@ -51,6 +51,19 @@ CREATE TABLE IF NOT EXISTS sync_state (
     PRIMARY KEY (pair, target)
 )
 """,
+    # N-way sync: the canonical membership of a logical playlist ON EACH PROVIDER
+    # after the last clean pass. Per-provider (not one shared set) is essential:
+    # a track absent from a provider's own prior membership is never a removal
+    # there, so a track that simply can't be matched on that service is not
+    # mistaken for a user deletion. See targets/base.py.
+    """
+CREATE TABLE IF NOT EXISTS playlist_state (
+    playlist     TEXT NOT NULL,
+    source       TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    PRIMARY KEY (playlist, source, canonical_id)
+)
+""",
 ]
 
 UPSERT = """
@@ -71,6 +84,11 @@ def connect(path):
     # check_same_thread=False: the Apple and YT mirrors run on separate threads,
     # each with its own use of a connection; the timeout rides out any lock.
     conn = sqlite3.connect(path, timeout=30, check_same_thread=False)
+    # Migrate a pre-per-provider playlist_state (no `source` column). It's
+    # regenerable snapshot state, so drop it and let the schema recreate it.
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(playlist_state)").fetchall()]
+    if cols and "source" not in cols:
+        conn.execute("DROP TABLE playlist_state")
     for schema in SCHEMAS:
         conn.execute(schema)
     conn.commit()
@@ -133,4 +151,45 @@ def set_state(conn, pair, target, snapshot_id, target_count):
         "INSERT OR REPLACE INTO sync_state VALUES (?, ?, ?, ?, ?)",
         (pair, target, snapshot_id, target_count, _now()),
     )
+    conn.commit()
+
+
+def _in_chunks(conn, sql, prefix, ids):
+    out = {}
+    ids = [i for i in ids if i]
+    for i in range(0, len(ids), 500):
+        chunk = ids[i : i + 500]
+        marks = ",".join("?" * len(chunk))
+        rows = conn.execute(sql.format(marks=marks), [*prefix, *chunk])
+        out.update(dict(rows.fetchall()))
+    return out
+
+
+def get_reverse_links(conn, target, target_ids):
+    """{target_id: spotify_id} — the inverse of get_links, so a non-Spotify
+    track can be traced back to its canonical Spotify identity."""
+    return _in_chunks(
+        conn, "SELECT target_id, spotify_id FROM links WHERE target = ? AND target_id IN ({marks})",
+        [target], target_ids)
+
+
+def get_isrcs(conn, source, ids):
+    """{id: isrc} from the songs archive for a source (only rows that have one)."""
+    got = _in_chunks(
+        conn, "SELECT id, isrc FROM songs WHERE source = ? AND isrc IS NOT NULL AND id IN ({marks})",
+        [source], ids)
+    return {k: v for k, v in got.items() if v}
+
+
+def get_playlist_state(conn, playlist, source):
+    rows = conn.execute("SELECT canonical_id FROM playlist_state WHERE playlist = ? AND source = ?",
+                        (playlist, source))
+    return {r[0] for r in rows.fetchall()}
+
+
+def set_playlist_state(conn, playlist, source, canonical_ids):
+    """Replace one provider's stored membership (only after a clean pass)."""
+    conn.execute("DELETE FROM playlist_state WHERE playlist = ? AND source = ?", (playlist, source))
+    conn.executemany("INSERT OR IGNORE INTO playlist_state VALUES (?, ?, ?)",
+                     [(playlist, source, cid) for cid in canonical_ids])
     conn.commit()

--- a/spotify_mirror/config.py
+++ b/spotify_mirror/config.py
@@ -17,6 +17,9 @@ DEFAULT_CACHE_FILE = "apple_resolve_cache.json"
 DEFAULT_SONG_CACHE_FILE = "song_cache.db"
 DEFAULT_STOREFRONT = "us"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:8888/callback"
+DEFAULT_SYNC_MODE = "oneway"                          # oneway (Spotify->targets) | nway (bidirectional)
+DEFAULT_PROVIDERS = "spotify,apple,ytmusic"           # peers participating in N-way sync
+DEFAULT_SPOTIFY_CACHE_FILE = "spotify_resolve_cache.json"
 
 
 def required_env(var_name):
@@ -52,6 +55,9 @@ class Options:
     cache_file: str
     song_cache_file: str
     refresh_local: bool = False
+    sync_mode: str = DEFAULT_SYNC_MODE
+    providers: str = DEFAULT_PROVIDERS
+    spotify_cache_file: str = DEFAULT_SPOTIFY_CACHE_FILE
 
 
 def parse_args(argv=None):
@@ -80,6 +86,12 @@ def parse_args(argv=None):
                    help=f"ISRC/search resolution cache (default: {DEFAULT_CACHE_FILE}).")
     p.add_argument("--song-cache-file", default=os.getenv("SONG_CACHE_FILE", DEFAULT_SONG_CACHE_FILE),
                    help=f"Ever-growing SQLite song archive (default: {DEFAULT_SONG_CACHE_FILE}).")
+    p.add_argument("--sync-mode", default=os.getenv("SYNC_MODE", DEFAULT_SYNC_MODE), choices=("oneway", "nway"),
+                   help=f"oneway = Spotify->targets (default); nway = bidirectional across all providers.")
+    p.add_argument("--providers", default=os.getenv("PROVIDERS", DEFAULT_PROVIDERS),
+                   help=f"N-way peers, comma-separated (default: {DEFAULT_PROVIDERS}).")
+    p.add_argument("--spotify-cache-file", default=os.getenv("SPOTIFY_CACHE_FILE", DEFAULT_SPOTIFY_CACHE_FILE),
+                   help=f"Spotify resolution cache for N-way writes (default: {DEFAULT_SPOTIFY_CACHE_FILE}).")
     a = p.parse_args(argv)
 
     if a.max_removals < 0:
@@ -90,5 +102,6 @@ def parse_args(argv=None):
         execute=a.execute, loop=a.loop, interval_s=parse_interval(a.interval), playlists=a.playlists,
         max_removals=a.max_removals, max_adds=a.max_adds, download_dir=a.download_dir,
         storefront=a.storefront, cache_file=a.cache_file, song_cache_file=a.song_cache_file,
-        refresh_local=a.refresh_local,
+        refresh_local=a.refresh_local, sync_mode=a.sync_mode, providers=a.providers,
+        spotify_cache_file=a.spotify_cache_file,
     )

--- a/spotify_mirror/runner.py
+++ b/spotify_mirror/runner.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 
 from . import archive, spotify
 from .logs import fmt_counts, fmt_secs, log, log_note, log_section, log_summary, log_warn, paint
-from .targets import TargetAuthError, build_targets, mirror_pair
+from .targets import TargetAuthError, build_peers, build_targets, mirror_pair, reconcile
 
 
 def _load_json(path):
@@ -103,7 +103,9 @@ def run_target(target, selected, get_sp_tracks, songs, opts):
 
 def run_pass(opts):
     load_dotenv(override=True)  # pick up re-captured tokens without a restart
-    sp = spotify.client()
+    # Writable (modify scopes) only for an actual N-way execute — so dry-runs
+    # preview without forcing the one-time re-auth a scope change triggers.
+    sp = spotify.client(writable=(opts.sync_mode == "nway" and opts.execute))
     sp_by_name = spotify.playlists_by_name(sp)
 
     wanted = {n.strip().casefold() for n in opts.playlists.split(",") if n.strip()} if opts.playlists else None
@@ -111,7 +113,7 @@ def run_pass(opts):
 
     mode = paint("EXECUTE", "green", "bold") if opts.execute else paint("DRY RUN", "yellow", "bold")
     log(paint("═══ Spotify playlist mirror ═══", "bold", "cyan"))
-    log(f"  mode: {mode}")
+    log(f"  mode: {mode}" + (paint("   ⇄ N-WAY", "magenta", "bold") if opts.sync_mode == "nway" else ""))
     log(f"  playlists: {paint(str(len(selected)), 'bold')} selected"
         + (paint(f" ({', '.join(p['name'] for p in selected)})", "grey") if selected else ""))
     if wanted:
@@ -126,6 +128,15 @@ def run_pass(opts):
         from . import downloads
 
         downloads.refresh(sp, selected, opts.download_dir)
+        return
+
+    if opts.sync_mode == "nway":
+        songs = archive.connect(opts.song_cache_file)
+        try:
+            _run_nway(opts, sp, selected, songs)
+        finally:
+            songs.close()
+        _post_sync(opts, sp, selected)
         return
 
     targets = build_targets(opts)
@@ -204,6 +215,11 @@ def run_pass(opts):
         if isinstance(err, TargetAuthError):
             raise err  # fatal; main() decides exit vs. loop-continue
 
+    _post_sync(opts, sp, selected)
+
+
+def _post_sync(opts, sp, selected):
+    """Local download mirror + Jellyfin covers — shared by one-way and N-way."""
     if opts.download_dir and opts.execute:
         try:
             from . import downloads
@@ -217,3 +233,56 @@ def run_pass(opts):
         from . import jellyfin
 
         jellyfin.push_covers(selected)
+
+
+def _run_nway(opts, sp, selected, songs):
+    """Bidirectional reconcile: each selected playlist across all peer providers,
+    sequentially (each reconcile reads then writes every peer). A change on any
+    provider propagates to the others via the stored canonical snapshot."""
+    peers = build_peers(opts, sp)
+    if len(peers) < 2:
+        log_warn("N-way sync needs >=2 configured providers (Spotify + Apple and/or YouTube Music)", indent="  ")
+        return
+    log(f"  peers: {paint(', '.join(p.name for p in peers), 'cyan')}"
+        + (paint(f"   local downloads -> {opts.download_dir}", "grey") if opts.download_dir and opts.execute else ""))
+
+    dirs = {p.source: p.list_playlists() for p in peers}
+    caches = {p.source: load_cache(p.cache_file) for p in peers}
+    try:
+        for sp_playlist in selected:
+            name = sp_playlist["name"]
+            key = name.strip().casefold()
+            playlists = {}
+            for p in peers:
+                pl = dirs[p.source].get(key)
+                if not pl:
+                    if not opts.execute:
+                        log_note(f"{name}: no {p.name} playlist yet - would create on --execute", tag=p.tag)
+                        continue
+                    try:
+                        pl = p.create(sp_playlist)
+                        log_note(f"created {p.name} playlist '{name}'", tag=p.tag)
+                    except TargetAuthError:
+                        raise
+                    except Exception as e:
+                        log_warn(f"create {p.name} '{name}' failed: {e!r}", tag=p.tag)
+                        continue
+                if not p.is_editable(pl):
+                    log_warn(f"{name}: {p.name} playlist not editable - skipped", tag=p.tag)
+                    continue
+                playlists[p.source] = pl
+
+            active = [p for p in peers if p.source in playlists]
+            if len(active) < 2:
+                log_note(f"{name}: fewer than 2 providers have this playlist - skipped", tag="sync")
+                continue
+            try:
+                reconcile(active, name, playlists, caches, songs,
+                          execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds)
+            except TargetAuthError:
+                raise
+            except Exception as e:
+                log_warn(f"'{name}' reconcile failed, continuing: {e!r}", tag="sync")
+    finally:
+        for p in peers:
+            save_cache(p.cache_file, caches[p.source])

--- a/spotify_mirror/spotify.py
+++ b/spotify_mirror/spotify.py
@@ -1,8 +1,10 @@
-"""Spotify — the read-only source of truth.
+"""Spotify — playlist source, and (in N-way mode) a writable peer.
 
-Only the `playlist-read-private` scope is requested; the tool never modifies
-anything on Spotify. Track dicts produced here are the common currency the
-mirror targets consume.
+By default only the `playlist-read-private` scope is requested and the tool
+never modifies anything on Spotify. When built writable (N-way sync), the
+`playlist-modify-*` scopes are added — which invalidates a read-only token
+cache and forces a one-time re-auth. Track dicts produced here are the common
+currency the mirror targets consume.
 """
 
 import html
@@ -39,15 +41,19 @@ def _retry(fn, what, attempts=5):
             time.sleep(wait)
 
 
-def client():
+def client(writable=False):
+    # playlist-read-private alone keeps a pre-existing read-only token cache
+    # valid. Adding the modify scopes (N-way mode) changes the scope string,
+    # which invalidates that cache and forces a one-time interactive re-auth.
+    scope = "playlist-read-private"
+    if writable:
+        scope += " playlist-modify-private playlist-modify-public"
     return spotipy.Spotify(
         auth_manager=SpotifyOAuth(
             client_id=required_env("SPOTIFY_CLIENT_ID"),
             client_secret=required_env("SPOTIFY_CLIENT_SECRET"),
             redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI", DEFAULT_SPOTIFY_REDIRECT_URI),
-            # playlist-read-private alone keeps pre-existing token caches valid;
-            # collaborative playlists aren't listed without the extra scope.
-            scope="playlist-read-private",
+            scope=scope,
             cache_path=os.getenv("SPOTIFY_TOKEN_CACHE", ".cache"),
             open_browser=os.getenv("SPOTIFY_OAUTH_OPEN_BROWSER", "1") != "0",
         ),

--- a/spotify_mirror/targets/__init__.py
+++ b/spotify_mirror/targets/__init__.py
@@ -1,31 +1,55 @@
-"""Mirror targets: destinations a Spotify playlist is mirrored to.
+"""Mirror targets: the services a playlist is mirrored across.
 
-Add a service by subclassing MirrorTarget (see base.py) and appending its
-builder to `build_targets`.
+Adding a provider (Deezer, Tidal, …) is deliberately local:
+  1. Write `targets/<svc>.py` with a `MirrorTarget` subclass implementing the
+     ~8 methods (see base.py). Carry ISRC in `playlist_tracks` if the API has
+     it — that's what makes cross-provider matching reliable and free.
+  2. Add one line to `_REGISTRY` below: `source -> builder(opts, sp) -> target|None`.
+Everything else — one-way mirroring, N-way reconcile, canonical identity,
+caching, safety rails — is provider-agnostic and needs no change.
 """
 
 from .apple import AppleMusicTarget
-from .base import MirrorTarget, TargetAuthError, mirror_pair
+from .base import MirrorTarget, TargetAuthError, mirror_pair, reconcile
+from .spotify_target import SpotifyTarget
 from . import ytmusic
 
-__all__ = ["AppleMusicTarget", "MirrorTarget", "TargetAuthError", "mirror_pair", "build_targets"]
+__all__ = ["AppleMusicTarget", "SpotifyTarget", "MirrorTarget", "TargetAuthError",
+           "mirror_pair", "reconcile", "build_targets", "build_peers"]
 
 
-def build_targets(opts):
-    """Every target that is configured/available this run, in order. Apple is
-    built from env tokens; YouTube Music only if its auth file exists."""
+def _apple(opts):
     from ..config import required_env
     from ..logs import log_note
-
-    targets = []
     try:
         required_env("APPLE_BEARER_TOKEN")
         required_env("APPLE_USER_TOKEN")
-        targets.append(AppleMusicTarget(opts.storefront, opts.cache_file))
+        return AppleMusicTarget(opts.storefront, opts.cache_file)
     except RuntimeError as e:
         log_note(f"Apple Music skipped: {e}", tag="apple")
+        return None
 
-    yt = ytmusic.build()
-    if yt:
-        targets.append(yt)
-    return targets
+
+# source -> builder(opts, sp) -> a ready MirrorTarget, or None when unconfigured.
+# Order matters: ISRC-rich providers first so they seed cross-provider identity.
+# `sp` (the Spotify client) is only needed by peers that read/write Spotify.
+_REGISTRY = {
+    "spotify": lambda opts, sp: SpotifyTarget(sp, opts.spotify_cache_file) if sp is not None else None,
+    "apple": lambda opts, sp: _apple(opts),
+    "ytmusic": lambda opts, sp: ytmusic.build(),
+}
+_SOURCE_ORDER = ["spotify", "apple", "ytmusic"]
+
+
+def build_targets(opts):
+    """One-way targets available this run (Spotify is the source, not a target)."""
+    return [t for src in _SOURCE_ORDER if src != "spotify"
+            for t in (_REGISTRY[src](opts, None),) if t]
+
+
+def build_peers(opts, sp):
+    """N-way peer nodes, limited to opts.providers and to what's configured,
+    in ISRC-rich-first order. Needs the Spotify client for the Spotify peer."""
+    wanted = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
+    return [peer for src in _SOURCE_ORDER if src in wanted
+            for peer in (_REGISTRY[src](opts, sp),) if peer]

--- a/spotify_mirror/targets/apple.py
+++ b/spotify_mirror/targets/apple.py
@@ -160,6 +160,16 @@ class AppleMusicTarget(MirrorTarget):
             cache["dirty"] = True
             polite_sleep(0.25)
 
+    def native_isrc_map(self, cache):
+        # Apple library reads omit ISRC, but its filter[isrc] resolve cache maps
+        # ISRC -> catalog candidates; reverse it to catalog_id -> ISRC.
+        out = {}
+        for isrc, cands in (cache.get("isrc") or {}).items():
+            for c in cands:
+                if c.get("id"):
+                    out.setdefault(c["id"], isrc)
+        return out
+
     def expected_ids(self, sp_tracks, links, cache):
         out = {}
         for t in sp_tracks:

--- a/spotify_mirror/targets/base.py
+++ b/spotify_mirror/targets/base.py
@@ -1,8 +1,12 @@
-"""The mirror target contract + the shared per-playlist mirror algorithm.
+"""The mirror target contract + the shared reconciliation algorithms.
 
 A new service (Tidal, Deezer, ...) is added by subclassing `MirrorTarget` and
-implementing ~8 small methods; the reconciliation logic — diff, resolve,
-ordering, safety rails, logging, stats — lives once here in `mirror_pair`.
+implementing ~8 small methods (carry ISRC in `playlist_tracks` if the API has
+it). Both engines are provider-agnostic and unchanged by a new target:
+`mirror_pair` (one-way, Spotify -> target) and `reconcile` (N-way bidirectional
+across all peers, diffing each against a stored canonical snapshot). Diff,
+resolve, cross-provider identity, ordering, safety rails, logging, and stats
+all live here once.
 """
 
 import time
@@ -12,7 +16,13 @@ from ..logs import (
     fmt_counts, fmt_secs, log_add, log_hold, log_miss, log_note, log_remove,
     log_section, log_summary, log_warn, paint,
 )
-from ..matching import compute_diff, protect_removals
+from ..matching import compute_diff, protect_removals, track_key
+
+# A provider reading fewer than this fraction of the known baseline is treated
+# as a broken read: its removals are ignored so one bad fetch can't cascade a
+# mass-delete across every provider. ponytail: a blunt ratio, not per-provider
+# count history — tighten if legitimate drift ever trips it.
+COLLAPSE_FRACTION = 0.4
 
 
 class TargetAuthError(RuntimeError):
@@ -53,6 +63,12 @@ class MirrorTarget:
 
     def prefetch(self, sp_tracks, cache):
         """Optional batch work before resolving (Apple: bulk ISRC lookup)."""
+
+    def native_isrc_map(self, cache):
+        """{track_id: ISRC} this provider can supply out-of-band (e.g. from its
+        own resolve cache) for reads that omit ISRC. Default: none. Overriding
+        it lets a new provider unify on ISRC with no reconciler changes."""
+        return {}
 
     def expected_ids(self, sp_tracks, links, cache):
         """{spotify_id: set(target_ids)} the track is known to correspond to."""
@@ -161,3 +177,211 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         "missing": len(not_found), "held": len(held), "deferred": deferred,
         "target_count": len(tgt_tracks) + len(additions) - len(removals),
     }
+
+
+# --------------------------------------------------------------------------- #
+# N-way bidirectional reconcile (SYNC_MODE=nway). Diffs every provider against
+# a stored canonical snapshot so a change on ANY provider propagates to all.
+# --------------------------------------------------------------------------- #
+
+def _normalize(track, source):
+    """Common cross-provider shape, keeping the raw provider dict for removal
+    (which needs the relationship_id / playlistItem id / uri)."""
+    artists = track.get("artists") or ([track["artist"]] if track.get("artist") else [""])
+    return {
+        "name": track.get("name", ""),
+        "artists": artists,
+        "artist": track.get("artist") or ", ".join(a for a in artists if a),
+        "duration_ms": track.get("duration_ms"),
+        "isrc": track.get("isrc"),
+        "added_at": track.get("added_at") or "",
+        "_raw": track,
+        "_source": source,
+    }
+
+
+def _canonicalize(target, tracks, songs, cache, key2isrc):
+    """{canonical_id: normalized track} for one provider's current tracks.
+
+    Canonical precedence: ISRC (direct / provider-native map / same-playlist
+    Spotify track_key) -> ISRC via the reverse link to Spotify -> the Spotify id
+    -> track_key. Getting the same song onto ONE canonical id across providers
+    is the crux, so ISRC is pulled from wherever each provider exposes it:
+    Spotify carries it inline; Apple's ISRC resolve cache maps catalog_id ->
+    ISRC; and key2isrc (built from this playlist's Spotify tracks) rescues any
+    remaining track whose fuzzy key already exists on Spotify — without it, an
+    ISRC-less YT copy of a Spotify song splits into a duplicate."""
+    rev = ({} if target.source == "spotify"
+           else archive.get_reverse_links(songs, target.source, [target.track_id(t) for t in tracks]))
+    sp_isrc = archive.get_isrcs(songs, "spotify", list(rev.values())) if rev else {}
+    id2isrc = target.native_isrc_map(cache)  # provider-supplied track_id -> ISRC (Apple, future providers)
+    out = {}
+    for t in tracks:
+        norm = _normalize(t, target.source)
+        isrc = (norm["isrc"] or id2isrc.get(target.track_id(t))
+                or key2isrc.get(track_key(norm["name"], norm["artist"])))
+        if isrc:
+            cid = f"i:{isrc}"
+        else:
+            sp_id = rev.get(target.track_id(t))
+            if sp_id:
+                cid = f"i:{sp_isrc[sp_id]}" if sp_id in sp_isrc else f"s:{sp_id}"
+            else:
+                cid = f"k:{track_key(norm['name'], norm['artist'])}"
+        out.setdefault(cid, norm)  # first occurrence wins (dedupe within a provider)
+    return out
+
+
+def _merge(prev, cur, collapsed):
+    """Pure delta merge over PER-PROVIDER state. prev, cur: {source:
+    set(canonical_id)} — each provider's membership after the last clean pass
+    and now. collapsed: sources whose read is untrusted (skipped this pass).
+    Returns (desired, {source: (add_ids, remove_ids)}).
+
+    A canonical is REMOVED only when it leaves a provider that actually had it
+    (prev[src] - cur[src]) — so a track that merely can't be matched on a
+    service (never in that service's prev) is never mistaken for a deletion.
+    add-wins on conflict; desired is the union of prior memberships plus new
+    additions minus real removals."""
+    adds, removes = set(), set()
+    for src, ids in cur.items():
+        if src in collapsed:
+            continue  # untrusted read contributes neither adds nor removes
+        adds |= ids - prev.get(src, set())
+        removes |= prev.get(src, set()) - ids
+    removes -= adds
+    union_prev = set().union(*prev.values()) if prev else set()
+    desired = (union_prev | adds) - removes
+    plan = {src: (desired - ids, ids - desired) for src, ids in cur.items()}
+    return desired, plan
+
+
+def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, max_adds):
+    """Reconcile one logical playlist across N provider peers, bidirectionally.
+
+    playlists: {source: playlist dict}; caches: {source: resolution cache}.
+    Returns a stats dict; `clean` is True when every side applied with no guard
+    tripped (only then is the canonical snapshot advanced)."""
+    key = name.casefold()
+    started = time.monotonic()
+    prev = {p.source: archive.get_playlist_state(songs, key, p.source) for p in peers}
+
+    canon = {}       # source -> {canonical_id: normalized track}
+    present = {}     # source -> set of ALL current target ids (not canonical-deduped)
+    key2isrc = {}    # track_key -> ISRC, seeded by any ISRC-bearing provider (peers are ISRC-rich first)
+    for p in peers:
+        raw = p.playlist_tracks(playlists[p.source])
+        archive.upsert_many(songs, p.source, raw)
+        present[p.source] = {p.track_id(t) for t in raw if p.track_id(t)}
+        canon[p.source] = _canonicalize(p, raw, songs, caches[p.source], key2isrc)
+        for cid, norm in canon[p.source].items():
+            if cid.startswith("i:"):  # any provider that resolved an ISRC anchors the rest
+                key2isrc.setdefault(track_key(norm["name"], norm["artist"]), cid[2:])
+    cur = {src: set(m) for src, m in canon.items()}
+
+    repr_ = {}  # canonical_id -> representative track (peers are ordered spotify-first for ISRC-rich reprs)
+    for p in peers:
+        for cid, norm in canon[p.source].items():
+            repr_.setdefault(cid, norm)
+
+    collapsed = set()
+    for p in peers:
+        base = prev[p.source]
+        if base and (not cur[p.source] or len(cur[p.source]) < COLLAPSE_FRACTION * len(base)):
+            collapsed.add(p.source)
+            log_warn(f"{name}: {p.name} read {len(cur[p.source])} vs baseline {len(base)} — "
+                     "ignoring its removals this pass", tag=p.tag)
+
+    desired, plan = _merge(prev, cur, collapsed)
+    log_section(name, " / ".join(f"{p.name} {len(cur[p.source])}" for p in peers), tag="sync")
+
+    stats = {"clean": execute and not collapsed, "added": 0, "removed": 0, "missing": 0, "held": 0, "deferred": 0}
+    new_links = {p.source: {} for p in peers}
+    new_state = {}   # source -> canonical membership to persist (only on a clean pass)
+    for p in peers:
+        if p.source in collapsed:
+            continue  # untrusted read: don't write to it this pass (guards adds too, not just removes)
+        add_ids, remove_ids = plan[p.source]
+        cache = caches[p.source]
+        seen = set(present[p.source])  # every id already on the provider (+ ids queued this pass)
+
+        # ADD: resolve each missing canonical id to this provider's track id.
+        add_norms = [repr_[cid] for cid in add_ids]
+        try:
+            p.prefetch(add_norms, cache)
+        except Exception as e:
+            log_warn(f"{p.name} prefetch failed: {e!r}", tag=p.tag)
+        additions, not_found = [], []
+        for norm in sorted(add_norms, key=lambda n: n["added_at"]):
+            try:
+                tid, method = p.resolve(norm, cache)
+            except TargetAuthError:
+                raise
+            except Exception as e:
+                log_warn(f"resolve failed on {p.name}: {norm['name']}: {e!r}", tag=p.tag)
+                tid, method = None, None
+            if not tid:
+                not_found.append(norm)
+                continue
+            if tid in seen:
+                continue  # already on this provider (a different canonical resolved to the same track)
+            seen.add(tid)
+            additions.append((tid, method or "search", norm))
+            if norm["_source"] == "spotify" and norm["_raw"].get("id"):
+                new_links[p.source][norm["_raw"]["id"]] = tid
+
+        deferred = 0
+        if len(additions) > max_adds:
+            deferred = len(additions) - max_adds
+            log_warn(f"{p.name}/{name}: {len(additions)} additions exceed --max-adds={max_adds}; "
+                     f"deferring {deferred}", tag=p.tag)
+            additions, stats["clean"] = additions[:max_adds], False
+
+        # REMOVE: canonical ids that left the set, guarded by protect_removals + cap.
+        remove_pairs = [(cid, canon[p.source][cid]) for cid in remove_ids]
+        safe, held = protect_removals([n for _, n in remove_pairs], not_found)
+        safe_ids = {id(n) for n in safe}
+        removed_cids = {cid for cid, n in remove_pairs if id(n) in safe_ids}
+        if len(safe) > max_removals:
+            log_warn(f"{p.name}/{name}: {len(safe)} removals exceed --max-removals={max_removals}; "
+                     "skipping removals this pass", tag=p.tag)
+            safe, removed_cids, stats["clean"] = [], set(), False
+
+        for tid, method, norm in additions:
+            log_add(f"{p.name}: {norm['name']} - {norm['artist']}  {paint('(' + method + ')', 'grey')}",
+                    dry=not execute, tag=p.tag)
+        for norm in safe:
+            log_remove(f"{p.name}: {norm['name']} - {norm['artist']}", dry=not execute, tag=p.tag)
+        for norm in held:
+            log_hold(f"{p.name}: kept (no re-add match): {norm['name']} - {norm['artist']}", tag=p.tag)
+        for norm in not_found:
+            log_miss(f"not on {p.name}: {norm['name']} - {', '.join(norm['artists'])}", tag=p.tag)
+
+        if execute:
+            if additions:
+                p.add(playlists[p.source], [tid for tid, _, _ in additions])
+            for norm in safe:
+                p.remove(playlists[p.source], norm["_raw"])
+
+        # This provider's membership after the pass = what it has now, minus what
+        # we removed. Added tracks re-materialize (under their own canonical) on
+        # the next read — recording only what's actually present avoids a stale
+        # snapshot ever triggering a phantom removal.
+        new_state[p.source] = cur[p.source] - removed_cids
+
+        stats["added"] += len(additions)
+        stats["removed"] += len(safe)
+        stats["missing"] += len(not_found)
+        stats["held"] += len(held)
+        stats["deferred"] += deferred
+
+    if execute:
+        for p in peers:
+            archive.set_links(songs, p.source, new_links[p.source])
+        if stats["clean"]:
+            for src, ids in new_state.items():
+                archive.set_playlist_state(songs, key, src, ids)
+
+    counts = fmt_counts(stats["added"], stats["removed"], stats["missing"], stats["held"], stats["deferred"])
+    log_summary(f"{name}: {counts}  {paint('in ' + fmt_secs(time.monotonic() - started), 'grey')}", tag="sync")
+    return stats

--- a/spotify_mirror/targets/spotify_target.py
+++ b/spotify_mirror/targets/spotify_target.py
@@ -1,0 +1,131 @@
+"""Spotify as a writable mirror peer (N-way sync only).
+
+In one-way mode Spotify is just the source and this target isn't built. In
+N-way mode it becomes a first-class peer: the same reconcile that edits Apple
+and YouTube Music also adds/removes on Spotify. Reads reuse the helpers in
+spotify.py; writes go through spotipy's playlist-modify endpoints and therefore
+need the modify scopes (see spotify.client(writable=True)).
+"""
+
+import spotipy
+
+from .. import spotify
+from ..config import polite_sleep
+from ..matching import normalize_text, romanized, score_candidate, track_key
+from .base import MirrorTarget, TargetAuthError
+
+
+def _uri(track_id):
+    return track_id if str(track_id).startswith("spotify:") else f"spotify:track:{track_id}"
+
+
+class SpotifyTarget(MirrorTarget):
+    name = "Spotify"
+    tag = "spotify"
+    source = "spotify"
+
+    def __init__(self, sp, cache_file):
+        self._sp = sp
+        self.cache_file = cache_file
+        self._me = None
+
+    def _user(self):
+        if self._me is None:
+            self._me = spotify._retry(lambda: self._sp.current_user(), "current_user")["id"]
+        return self._me
+
+    def _write(self, fn, what):
+        """Run a mutation; map an auth/scope rejection to the fail-closed path."""
+        try:
+            return spotify._retry(fn, what)
+        except spotipy.SpotifyException as e:
+            if e.http_status in (401, 403):
+                raise TargetAuthError(
+                    f"Spotify rejected {what} ({e.http_status}). N-way mode needs the playlist-modify "
+                    "scopes — delete the token cache (data/spotify_token_cache) and re-run the OAuth flow."
+                ) from e
+            raise
+
+    # -- MirrorTarget ----------------------------------------------------------
+    def list_playlists(self):
+        return spotify.playlists_by_name(self._sp)
+
+    def is_editable(self, playlist):
+        owner = (playlist.get("owner") or {}).get("id")
+        return owner is None or owner == self._user()
+
+    def playlist_count(self, playlist):
+        return (playlist.get("tracks") or {}).get("total")
+
+    def create(self, sp_playlist):
+        pl = self._write(
+            lambda: self._sp.user_playlist_create(self._user(), sp_playlist.get("name", ""),
+                                                  public=False, description=spotify.description(sp_playlist)),
+            "create playlist")
+        polite_sleep(1.0)
+        return pl
+
+    def playlist_tracks(self, playlist):
+        return spotify.playlist_tracks(self._sp, playlist["id"])
+
+    def track_id(self, track):
+        return track.get("id")
+
+    def resolve(self, track, cache):
+        primary = track["artists"][0] if track["artists"] else ""
+        if not f"{track['name']} {primary}".strip():
+            return None, None
+        key = track_key(track["name"], " ".join(track["artists"]))
+        if key in cache["search"]:
+            return cache["search"][key], "search"
+        best, method = self._search(track, primary)
+        cache["search"][key] = best
+        cache["dirty"] = True
+        polite_sleep(0.3)
+        return best, method
+
+    def _search(self, track, primary):
+        isrc = track.get("isrc")
+        if isrc:  # the hard cross-walk when the originating provider carried an ISRC
+            best = self._best(track, self._query(f"isrc:{isrc}"))
+            if best:
+                return best, "isrc"
+        base = f"{track['name']} {primary}".strip()
+        queries = [f'track:{track["name"]} artist:{primary}'.strip(), base]
+        rom = f"{romanized(track['name'])} {romanized(primary)}".strip()
+        if rom and rom != normalize_text(base):
+            queries.append(rom)
+        for q in queries:
+            best = self._best(track, self._query(q))
+            if best:
+                return best, "search"
+        return None, None
+
+    def _query(self, q):
+        try:
+            res = spotify._retry(lambda: self._sp.search(q=q, type="track", limit=8), "search")
+        except spotipy.SpotifyException:
+            return []
+        return (res.get("tracks") or {}).get("items", [])
+
+    def _best(self, track, items):
+        best_id, best_score = None, -1.0
+        for it in items:
+            arts = [a.get("name", "") for a in it.get("artists", []) if a.get("name")]
+            score, ok = score_candidate(track["name"], track["artists"], track["duration_ms"],
+                                        it.get("name", ""), ", ".join(arts), it.get("duration_ms"))
+            if ok and score > best_score:
+                best_id, best_score = it.get("id"), score
+        return best_id
+
+    def add(self, playlist, target_ids):
+        for tid in target_ids:  # one at a time preserves date-added order
+            self._write(lambda t=tid: self._sp.playlist_add_items(playlist["id"], [_uri(t)]), "add")
+            polite_sleep(0.3)
+
+    def remove(self, playlist, track):
+        tid = self.track_id(track)
+        if not tid:
+            return
+        self._write(lambda: self._sp.playlist_remove_all_occurrences_of_items(playlist["id"], [_uri(tid)]), "remove")
+        polite_sleep(0.3)

--- a/spotify_mirror/targets/ytmusic.py
+++ b/spotify_mirror/targets/ytmusic.py
@@ -1,52 +1,70 @@
-"""YouTube Music target — via ytmusicapi (captured browser headers).
+"""YouTube Music target — via the official YouTube Data API v3.
 
-No ISRC, so matching is title/artist/duration only; search falls back to the
-`videos` filter for the many Bangla / indie / OST tracks that live on YT as
-uploads rather than catalog songs. Rate-limit / bot-detection (403/429) is
-retried with exponential backoff.
+Durable OAuth (refresh-token) auth. ytmusicapi's internal youtubei endpoints
+reject self-created OAuth clients (HTTP 400) and its captured browser cookies
+die within a day, so neither survives an unattended loop. The Data API shares
+YouTube's playlist/video namespace — its writes surface in the YouTube Music
+app — at the cost of a 10k-unit/day quota (search=100, insert/delete=50,
+list=1) and no ISRC, so matching stays title/artist/duration, biased toward
+`- Topic` art-tracks so resolved tracks land as native songs, not videos.
+
+Setup: create a Google "TVs and Limited Input devices" OAuth client, then
+    uvx ytmusicapi oauth --file data/ytmusic_oauth.json \
+        --client-id <ID> --client-secret <SECRET>
+and set YTMUSIC_OAUTH_CLIENT_ID / YTMUSIC_OAUTH_CLIENT_SECRET.
 """
 
+import json
 import os
 import random
+import re
 import time
 
-from ..config import polite_sleep
+import requests
+
+from ..config import REQUEST_TIMEOUT, polite_sleep
 from ..logs import log, log_note, log_warn
 from ..matching import normalize_text, romanized, score_candidate, track_key
-from .base import MirrorTarget
+from .base import MirrorTarget, TargetAuthError
 
-DEFAULT_AUTH_FILE = "ytmusic_browser.json"
+DEFAULT_AUTH_FILE = "ytmusic_oauth.json"
+API = "https://www.googleapis.com/youtube/v3"
+
+_ISO_DUR = re.compile(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?")
+_TOPIC_RE = re.compile(r"\s*-\s*Topic$")
+# YouTube video titles embed artist + decoration ("Queen – Bohemian Rhapsody
+# (Official Video)"); art-track titles are already clean. Strip [..]/(..) that
+# carry decoration keywords, but NOT version parens like (Live)/(Acoustic) — the
+# scorer must still treat those as distinct recordings.
+_YT_DECOR = re.compile(
+    r"\[[^\]]*\]"
+    r"|\((?=[^)]*\b(?:official|video|audio|lyric|lyrics|visuali[sz]er|hd|4k|mv|remaster)\b)[^)]*\)"
+    r"|\bofficial\s+(?:music\s+)?video\b"
+    r"|\bremaster(?:ed)?(?:\s+\d{4})?\b",
+    re.IGNORECASE)
 
 
 def build():
     """A ready YTMusicTarget, or None (logged) when YT isn't set up."""
     auth = os.getenv("YTMUSIC_AUTH_FILE", DEFAULT_AUTH_FILE)
+    cid, secret = os.getenv("YTMUSIC_OAUTH_CLIENT_ID"), os.getenv("YTMUSIC_OAUTH_CLIENT_SECRET")
     if not os.path.exists(auth):
-        log_note(f"YouTube Music skipped: no auth file '{auth}' "
-                 "(create with: uv run ytmusicapi browser --file ytmusic_browser.json)", tag="yt")
+        log_note(f"YouTube Music skipped: no OAuth token '{auth}' (create with: "
+                 "uvx ytmusicapi oauth --file data/ytmusic_oauth.json --client-id ... --client-secret ...)", tag="yt")
+        return None
+    if not (cid and secret):
+        log_note("YouTube Music skipped: set YTMUSIC_OAUTH_CLIENT_ID and YTMUSIC_OAUTH_CLIENT_SECRET", tag="yt")
         return None
     try:
-        from ytmusicapi import YTMusic
+        from ytmusicapi.auth.oauth import OAuthCredentials
     except ImportError:
-        log_note("YouTube Music skipped: ytmusicapi not installed", tag="yt")
+        log_note("YouTube Music skipped: ytmusicapi not installed (used only to refresh the OAuth token)", tag="yt")
         return None
     try:
-        return YTMusicTarget(YTMusic(auth))
+        return YTMusicTarget(auth, OAuthCredentials(client_id=cid, client_secret=secret))
     except Exception as e:
-        log_warn(f"YouTube Music unavailable (re-run ytmusicapi browser setup?): {e!r}", tag="yt")
+        log_warn(f"YouTube Music unavailable (re-run the ytmusicapi oauth setup?): {e!r}", tag="yt")
         return None
-
-
-def _with_backoff(fn, what):
-    for attempt in range(4):
-        try:
-            return fn()
-        except Exception as e:
-            if not any(code in str(e) for code in ("403", "429")) or attempt == 3:
-                raise
-            wait = 30 * (2 ** attempt) + random.uniform(0, 15)
-            log(f"  rate-limited on {what}; backing off {int(wait)}s", tag="yt")
-            time.sleep(wait)
 
 
 def _parse_count(value):
@@ -56,60 +74,158 @@ def _parse_count(value):
         return None
 
 
+def _duration_ms(iso):
+    """contentDetails.duration (ISO-8601, e.g. PT3M20S) -> ms, or None."""
+    m = _ISO_DUR.fullmatch(iso or "")
+    if not m:
+        return None
+    h, mnt, s = (int(x) if x else 0 for x in m.groups())
+    return (h * 3600 + mnt * 60 + s) * 1000
+
+
+def _artist_from_channel(channel):
+    """'The Cranberries - Topic' -> 'The Cranberries'; VEVO/plain kept as-is."""
+    return _TOPIC_RE.sub("", channel or "").strip()
+
+
+def _clean_title(title, artists):
+    """Strip a leading '<artist> -' and video-decoration parentheticals from a
+    YouTube title so the fuzzy scorer sees ~the song name. Version tags like
+    (Live)/(Acoustic) survive — they mark a genuinely different recording."""
+    cleaned = _YT_DECOR.sub(" ", title or "")
+    for artist in artists:
+        if artist.strip():
+            cleaned = re.sub(rf"^\s*{re.escape(artist.strip())}\s*[-–—:]\s*", "", cleaned, count=1, flags=re.IGNORECASE)
+    return " ".join(cleaned.split()).strip() or (title or "")
+
+
+def _err_reason(response):
+    try:
+        errors = response.json().get("error", {}).get("errors", [])
+        return errors[0].get("reason", "") if errors else ""
+    except ValueError:
+        return ""
+
+
 class YTMusicTarget(MirrorTarget):
     name = "YouTube Music"
     tag = "yt"
     source = "ytmusic"
 
-    def __init__(self, yt):
-        self._yt = yt
+    def __init__(self, auth_file, creds):
+        self._auth_file = auth_file
+        self._creds = creds
+        with open(auth_file) as f:
+            self._tok = json.load(f)
         self.cache_file = os.getenv("YTMUSIC_CACHE_FILE", "ytmusic_resolve_cache.json")
+        self._session = requests.Session()
 
+    # -- auth ------------------------------------------------------------------
+    def _access(self):
+        """A valid access token, refreshed and persisted when near expiry. The
+        refresh token is durable — this is the whole point of the Data API."""
+        if time.time() >= self._tok.get("expires_at", 0) - 60:
+            fresh = self._creds.refresh_token(self._tok["refresh_token"])
+            fresh = fresh if isinstance(fresh, dict) else fresh.as_dict()
+            self._tok.update(fresh)
+            self._tok["expires_at"] = int(time.time()) + int(fresh.get("expires_in", 3600))
+            with open(self._auth_file, "w") as f:
+                json.dump(self._tok, f)
+        return self._tok["access_token"]
+
+    # -- HTTP ------------------------------------------------------------------
+    def _request(self, method, path, *, params=None, json_body=None, ok404=False):
+        """One Data API call. GET/5xx retry with backoff; 429 backs off on every
+        method; 401 -> re-auth; 403 quota -> fail closed for the pass; other
+        mutation failures are single-shot (a lost add/remove self-heals next pass,
+        a blindly retried one could double-apply)."""
+        attempts = 5
+        for attempt in range(attempts):
+            headers = {"Authorization": f"Bearer {self._access()}"}
+            try:
+                r = self._session.request(method, f"{API}/{path}", params=params,
+                                          json=json_body, headers=headers, timeout=REQUEST_TIMEOUT)
+            except requests.RequestException:
+                if method == "GET" and attempt < attempts - 1:
+                    time.sleep(min(2 ** attempt, 20) + random.uniform(0, 2))
+                    continue
+                raise
+            if r.status_code == 401:
+                raise TargetAuthError("YouTube rejected the OAuth token (401). Re-run the ytmusicapi oauth setup.")
+            if r.status_code == 403:
+                reason = _err_reason(r)
+                if reason in ("quotaExceeded", "dailyLimitExceeded", "rateLimitExceeded"):
+                    raise TargetAuthError(
+                        f"YouTube Data API quota exhausted ({reason}); YT paused until the daily reset (~midnight PT).")
+                raise TargetAuthError(f"YouTube refused {method} {path} (403 {reason or 'forbidden'}).")
+            if r.status_code == 404 and ok404:
+                return None
+            if r.status_code == 429 and attempt < attempts - 1:
+                wait = float(r.headers.get("Retry-After") or 20) + random.uniform(1, 8)
+                log(f"  rate-limited by YouTube; waiting {int(wait)}s", tag=self.tag)
+                time.sleep(wait)
+                continue
+            if r.status_code == 409 and attempt < attempts - 1:
+                # Transient write-conflict the Data API throws on rapid playlist
+                # edits; the write didn't apply, so a backed-off retry is safe.
+                time.sleep(min(2 ** attempt, 15) + random.uniform(0, 2))
+                continue
+            if r.status_code >= 500 and method == "GET" and attempt < attempts - 1:
+                time.sleep(min(2 ** attempt, 20) + random.uniform(0, 2))
+                continue
+            r.raise_for_status()
+            return r
+        return None
+
+    def _paged(self, path, params):
+        params = dict(params)
+        while True:
+            data = self._request("GET", path, params=params).json()
+            yield from data.get("items", [])
+            token = data.get("nextPageToken")
+            if not token:
+                return
+            params["pageToken"] = token
+
+    # -- MirrorTarget ----------------------------------------------------------
     def list_playlists(self):
         out = {}
-        for pl in self._yt.get_library_playlists(limit=None) or []:
-            key = (pl.get("title") or "").strip().casefold()
+        for pl in self._paged("playlists", {"part": "snippet,contentDetails", "mine": "true", "maxResults": 50}):
+            title = (pl.get("snippet", {}).get("title") or "").strip()
+            key = title.casefold()
             if key and key not in out:
-                out[key] = pl
+                out[key] = {"playlistId": pl["id"], "title": title,
+                            "count": pl.get("contentDetails", {}).get("itemCount")}
         return out
+
+    def is_editable(self, playlist):
+        return True  # mine=true only returns playlists we own
 
     def playlist_count(self, playlist):
         return _parse_count(playlist.get("count"))
 
-    def is_editable(self, playlist):
-        try:
-            owned = self._yt.get_playlist(playlist["playlistId"], limit=1).get("owned", True)
-        except Exception:
-            return True  # can't tell — let the write try and fail loudly if not
-        return owned is not False
-
     def create(self, sp_playlist):
         from .. import spotify
 
-        pid = _with_backoff(
-            lambda: self._yt.create_playlist(sp_playlist["name"], spotify.description(sp_playlist),
-                                              privacy_status="PRIVATE"),
-            "create",
-        )
-        if isinstance(pid, dict):  # ytmusicapi sometimes returns the raw response
-            pid = pid.get("playlistId") or pid.get("id")
-        if not isinstance(pid, str) or not pid:
-            raise RuntimeError(f"create returned {pid!r}")
+        body = {"snippet": {"title": sp_playlist.get("name", ""), "description": spotify.description(sp_playlist)},
+                "status": {"privacyStatus": "private"}}
+        pid = self._request("POST", "playlists", params={"part": "snippet,status"}, json_body=body).json()["id"]
         polite_sleep(2.0)  # let the new playlist settle before writing to it
-        return {"playlistId": pid, "title": sp_playlist["name"], "count": "0"}
+        return {"playlistId": pid, "title": sp_playlist["name"], "count": 0}
 
     def playlist_tracks(self, playlist):
-        data = self._yt.get_playlist(playlist["playlistId"], limit=None)
         tracks = []
-        for item in data.get("tracks") or []:
-            if not item.get("videoId"):
-                continue  # unavailable/removed video
-            artists = [a.get("name", "") for a in item.get("artists") or [] if a.get("name")]
-            ds = item.get("duration_seconds")
+        for item in self._paged("playlistItems", {
+                "part": "snippet,contentDetails", "playlistId": playlist["playlistId"], "maxResults": 50}):
+            vid = item.get("contentDetails", {}).get("videoId")
+            if not vid:
+                continue
+            sn = item.get("snippet", {})
+            artist = _artist_from_channel(sn.get("videoOwnerChannelTitle", ""))
             tracks.append({
-                "id": item["videoId"], "videoId": item["videoId"], "setVideoId": item.get("setVideoId"),
-                "name": item.get("title", ""), "artist": ", ".join(artists), "artists": artists or [""],
-                "album": (item.get("album") or {}).get("name"), "duration_ms": ds * 1000 if ds else None,
+                "id": vid, "videoId": vid, "playlistItemId": item.get("id"),
+                "name": sn.get("title", ""), "artist": artist, "artists": [artist] if artist else [""],
+                "album": None, "duration_ms": None,
             })
         return tracks
 
@@ -123,52 +239,63 @@ class YTMusicTarget(MirrorTarget):
         key = track_key(track["name"], " ".join(track["artists"]))
         if key in cache["search"]:
             return cache["search"][key], "search"
+        best_id, method = self._search(track, primary)
+        cache["search"][key] = best_id
+        cache["dirty"] = True
+        polite_sleep(0.5)
+        return best_id, method
 
+    def _search(self, track, primary):
         queries = [f"{track['name']} {primary}".strip()]
         rom = f"{romanized(track['name'])} {romanized(primary)}".strip()
         if rom and rom != normalize_text(queries[0]):
-            queries.append(rom)
+            queries.append(rom)  # romanized retry only runs if the first query misses
+        for query in queries:
+            items = self._request("GET", "search", params={
+                "part": "snippet", "q": query, "type": "video",
+                "videoCategoryId": "10", "maxResults": 10}).json().get("items", [])
+            durations = self._durations([it["id"]["videoId"] for it in items if it.get("id", {}).get("videoId")])
+            best = None  # (sort_key, videoId, is_topic)
+            for it in items:
+                vid = it.get("id", {}).get("videoId")
+                if not vid:
+                    continue
+                sn = it.get("snippet", {})
+                is_topic = bool(_TOPIC_RE.search(sn.get("channelTitle", "")))
+                cand_name = sn.get("title", "") if is_topic else _clean_title(sn.get("title", ""), track["artists"])
+                score, ok = score_candidate(track["name"], track["artists"], track["duration_ms"],
+                                            cand_name, _artist_from_channel(sn.get("channelTitle", "")),
+                                            durations.get(vid))
+                if ok:
+                    sort_key = score + (0.05 if is_topic else 0.0)  # nudge toward native art-tracks
+                    if best is None or sort_key > best[0]:
+                        best = (sort_key, vid, is_topic)
+            if best:
+                return best[1], ("song" if best[2] else "video")
+            polite_sleep(0.4)
+        return None, None
 
-        best_id, best_score, method = None, -1.0, None
-        for qi, query in enumerate(queries):
-            for filt in ("songs", "videos"):
-                try:
-                    results = _with_backoff(lambda q=query, f=filt: self._yt.search(q, filter=f, limit=8), f"search {filt}")
-                except Exception:
-                    if filt == "songs" and qi == 0:
-                        raise
-                    results = []
-                for cand in results or []:
-                    vid = cand.get("videoId")
-                    if not vid:
-                        continue
-                    cand_artist = ", ".join(a.get("name", "") for a in cand.get("artists") or []) or cand.get("author") or ""
-                    ds = cand.get("duration_seconds")
-                    score, ok = score_candidate(track["name"], track["artists"], track["duration_ms"],
-                                                cand.get("title", ""), cand_artist, ds * 1000 if ds else None)
-                    if ok and score > best_score:
-                        best_id, best_score, method = vid, score, ("video" if filt == "videos" else "search")
-                if best_id:
-                    break
-            if best_id:
-                break
-
-        cache["search"][key] = best_id
-        cache["dirty"] = True
-        polite_sleep(0.6)
-        return best_id, method
+    def _durations(self, video_ids):
+        """{videoId: duration_ms} via batched videos.list (1 unit per 50 ids)."""
+        out = {}
+        for i in range(0, len(video_ids), 50):
+            chunk = video_ids[i:i + 50]
+            if not chunk:
+                continue
+            for it in self._request("GET", "videos",
+                                    params={"part": "contentDetails", "id": ",".join(chunk)}).json().get("items", []):
+                out[it["id"]] = _duration_ms(it.get("contentDetails", {}).get("duration"))
+        return out
 
     def add(self, playlist, target_ids):
-        for video_id in target_ids:  # one at a time, in order — never batch
-            _with_backoff(lambda v=video_id: self._yt.add_playlist_items(playlist["playlistId"], [v], duplicates=False), "add")
-            polite_sleep(1.2)
+        for video_id in target_ids:  # one at a time, in order — append order is date-added order
+            self._request("POST", "playlistItems", params={"part": "snippet"}, json_body={
+                "snippet": {"playlistId": playlist["playlistId"],
+                            "resourceId": {"kind": "youtube#video", "videoId": video_id}}})
+            polite_sleep(1.0)
 
     def remove(self, playlist, track):
-        if not track.get("setVideoId"):
-            return  # removal needs the playlist-relationship id
-        _with_backoff(
-            lambda: self._yt.remove_playlist_items(
-                playlist["playlistId"], [{"videoId": track["videoId"], "setVideoId": track["setVideoId"]}]),
-            "remove",
-        )
-        polite_sleep(1.2)
+        if not track.get("playlistItemId"):
+            return  # removal needs the playlist-item id (from playlist_tracks)
+        self._request("DELETE", "playlistItems", params={"id": track["playlistItemId"]})
+        polite_sleep(1.0)

--- a/test_reconcile.py
+++ b/test_reconcile.py
@@ -1,0 +1,103 @@
+"""Offline self-check for the N-way reconcile core + its archive state:
+`uv run test_reconcile.py`. Covers the per-provider merge logic (the part that
+decides adds vs removes across providers) and the persistence helpers."""
+
+import os
+import tempfile
+
+from spotify_mirror import archive
+from spotify_mirror.targets.base import _merge
+
+
+# --- merge: the safety-critical set logic (per-provider prev + cur) ----------
+def test_steady_state_is_noop():
+    prev = {"spotify": {"a", "b"}, "apple": {"a", "b"}}
+    cur = {"spotify": {"a", "b"}, "apple": {"a", "b"}}
+    _, plan = _merge(prev, cur, set())
+    assert all(plan[s] == (set(), set()) for s in plan)
+
+
+def test_add_propagates():
+    prev = {"spotify": {"a"}, "apple": {"a"}}
+    cur = {"spotify": {"a", "b"}, "apple": {"a"}}  # b added on spotify
+    desired, plan = _merge(prev, cur, set())
+    assert desired == {"a", "b"}
+    assert plan["spotify"] == (set(), set())        # already has b
+    assert plan["apple"] == ({"b"}, set())          # must add b
+
+
+def test_user_removal_propagates():
+    prev = {"spotify": {"a", "t"}, "apple": {"a", "t"}, "ytmusic": {"a", "t"}}
+    cur = {"spotify": {"a"}, "apple": {"a", "t"}, "ytmusic": {"a", "t"}}  # user removed t on spotify
+    desired, plan = _merge(prev, cur, set())
+    assert "t" not in desired
+    assert plan["apple"] == (set(), {"t"})          # propagate removal
+    assert plan["ytmusic"] == (set(), {"t"})
+
+
+def test_unmatchable_on_one_provider_is_never_deleted():
+    # u lives on spotify + apple but was NEVER matchable on yt (absent from yt's
+    # own prev). Its absence from yt must NOT read as a deletion. (The bug that
+    # caused this test to exist deleted real tracks across every provider.)
+    prev = {"spotify": {"a", "u"}, "apple": {"a", "u"}, "ytmusic": {"a"}}
+    cur = {"spotify": {"a", "u"}, "apple": {"a", "u"}, "ytmusic": {"a"}}
+    desired, plan = _merge(prev, cur, set())
+    assert "u" in desired
+    assert plan["spotify"] == (set(), set())        # NOT removed from spotify
+    assert plan["apple"] == (set(), set())          # NOT removed from apple
+    assert plan["ytmusic"] == ({"u"}, set())        # yt only re-attempts the add (will not_found), never removes
+
+
+def test_first_pass_only_adds():
+    cur = {"spotify": {"a", "b", "c"}, "apple": {"a"}}
+    desired, plan = _merge({}, cur, set())          # no stored state yet
+    assert desired == {"a", "b", "c"}
+    assert plan["apple"] == ({"b", "c"}, set())     # adds only, never removes on first pass
+
+
+def test_collapsed_provider_is_skipped_no_massdelete():
+    prev = {"spotify": {"a", "b", "c", "d"}, "apple": {"a", "b", "c", "d"}}
+    cur = {"spotify": {"a", "b", "c", "d"}, "apple": set()}  # apple read collapsed to empty
+    desired, plan = _merge(prev, cur, {"apple"})
+    assert desired == {"a", "b", "c", "d"}          # apple's emptiness removed nothing
+    assert plan["spotify"] == (set(), set())
+
+
+def test_adds_and_removes_always_disjoint():
+    prev = {"spotify": {"a", "b", "c"}, "apple": {"a", "b", "c"}}
+    cur = {"spotify": {"a", "b", "x"}, "apple": {"b", "c", "y"}}
+    _, plan = _merge(prev, cur, set())
+    for src, (add_ids, rem_ids) in plan.items():
+        assert not (add_ids & rem_ids), f"{src}: add/remove overlap"
+
+
+# --- archive: the per-provider persistence helpers ---------------------------
+def test_playlist_state_roundtrip_per_source():
+    conn = archive.connect(os.path.join(tempfile.mkdtemp(), "s.db"))
+    assert archive.get_playlist_state(conn, "aurora", "spotify") == set()
+    archive.set_playlist_state(conn, "aurora", "spotify", {"i:A", "i:B"})
+    archive.set_playlist_state(conn, "aurora", "apple", {"i:A"})
+    assert archive.get_playlist_state(conn, "aurora", "spotify") == {"i:A", "i:B"}
+    assert archive.get_playlist_state(conn, "aurora", "apple") == {"i:A"}   # scoped per source
+    archive.set_playlist_state(conn, "aurora", "spotify", {"i:A"})          # replaces, not merges
+    assert archive.get_playlist_state(conn, "aurora", "spotify") == {"i:A"}
+    conn.close()
+
+
+def test_reverse_links_and_isrcs():
+    conn = archive.connect(os.path.join(tempfile.mkdtemp(), "s.db"))
+    archive.set_links(conn, "apple", {"sp1": "cat1", "sp2": "cat2"})
+    assert archive.get_reverse_links(conn, "apple", ["cat1", "cat2", "catX"]) == {"cat1": "sp1", "cat2": "sp2"}
+    archive.upsert_many(conn, "spotify", [
+        {"id": "sp1", "isrc": "ISRCA", "name": "A", "artists": ["X"], "duration_ms": 1},
+        {"id": "sp2", "isrc": None, "name": "B", "artists": ["Y"], "duration_ms": 1}])
+    assert archive.get_isrcs(conn, "spotify", ["sp1", "sp2"]) == {"sp1": "ISRCA"}  # sp2 has no ISRC -> excluded
+    conn.close()
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print("\nOK: all checks passed")


### PR DESCRIPTION
## Summary

Adds an opt-in bidirectional N-way sync mode and migrates the YouTube Music leg to the official Data API v3.

- **YouTube Music → Data API v3.** ytmusicapi's internal API rejects self-made OAuth clients (HTTP 400) and its browser cookies expire within a day; the public Data API uses a durable OAuth refresh token and its writes surface in the YouTube Music app. Restores the unattended YT mirror.
- **N-way mode (`SYNC_MODE=nway`).** Spotify, Apple, and YouTube become read+write peers; a change on any of them propagates to the others. Needs Spotify write scopes (one-time re-auth). Default stays one-way, unchanged.
- **Echo-free & safe.** Per-provider canonical snapshots mean a track absent from a provider's *own* history is never treated as a removal — so an unmatchable track is never mistaken for a user deletion. add-wins, read-collapse guard, per-pass MAX caps, and `protect_removals` hold on every write side.
- **Extensible.** Provider registry: a new service (Deezer, Tidal) is one `MirrorTarget` subclass + one registry line.

## Test plan

- `uv run test_reconcile.py` (per-provider merge core + persistence, incl. the unmatchable-not-deleted regression) and `uv run test_matching.py` pass; both wired into CI.
- Validated end-to-end on a live 3-provider playlist: dry-run + execute converge, two consecutive `+0 -0` passes (stable, echo-free), zero duplicates, unmatchable tracks held not deleted.
- One-way mode verified unchanged.

## Follow-up

- Rename the repo to reflect the bidirectional/multi-provider scope (no longer Spotify-centric). Renaming the local checkout also needs a `uv sync` after (venv console-script trampolines are path-bound).