### PR TITLE
chore: rename to omni-playlist-sync + fix duplicate adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🎵 Spotify Playlist Mirror
+# 🎵 Omni Playlist Sync
 
-[![CI](https://github.com/ahnafnafee/spotify-playlist-mirror-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/ahnafnafee/spotify-playlist-mirror-sync/actions/workflows/ci.yml)
+[![CI](https://github.com/ahnafnafee/omni-playlist-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/ahnafnafee/omni-playlist-sync/actions/workflows/ci.yml)
 ![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green)
 ![Docker ready](https://img.shields.io/badge/docker-ready-2496ED)
@@ -184,8 +184,8 @@ First run opens a browser once for Spotify OAuth; the token is cached (default
 
 ## Always running: Docker
 
-The container runs as **`spotify-mirror`** in the compose group
-**`spotify-playlist-mirror-sync`**, loops `--execute` every `SYNC_INTERVAL`,
+The container runs as **`omni-playlist-sync`** in the compose group
+**`omni-playlist-sync`**, loops `--execute` every `SYNC_INTERVAL`,
 and persists auth + caches in `./data`.
 
 **Seed the Spotify token first** — the container can't open a browser, so it
@@ -221,7 +221,7 @@ Alternative to Docker — one-shot pass every 15 minutes, survives reboots:
 
 ```powershell
 schtasks /Create /TN "SpotifyPlaylistMirror" /SC MINUTE /MO 15 `
-  /TR "cmd /c cd /d D:\GitHub\apple-music-to-spotify-sync && uv run main.py --execute >> sync.log 2>&1"
+  /TR "cmd /c cd /d D:\GitHub\omni-playlist-sync && uv run main.py --execute >> sync.log 2>&1"
 ```
 
 Remove with `schtasks /Delete /TN "SpotifyPlaylistMirror" /F`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-name: spotify-playlist-mirror-sync   # compose project (group) name
+name: omni-playlist-sync   # compose project (group) name
 
 services:
   mirror:
     build: .
-    container_name: spotify-mirror
+    container_name: omni-playlist-sync
     env_file: .env
     environment:
       SPOTIFY_TOKEN_CACHE: /data/spotify_token_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "apple-music-to-spotify-sync"
+name = "omni-playlist-sync"
 version = "0.1.0"
-description = "Mirror Spotify playlists to same-named Apple Music playlists, with optional local audio copies"
+description = "Bidirectional N-way playlist sync across Spotify, Apple Music, and YouTube Music, with optional local audio copies"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/spotify_mirror/config.py
+++ b/spotify_mirror/config.py
@@ -62,7 +62,7 @@ class Options:
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser(
-        prog="spotify-mirror",
+        prog="omni-playlist-sync",
         description="Mirror Spotify playlists to same-named Apple Music and YouTube Music playlists.",
     )
     p.add_argument("--execute", action="store_true", help="Apply changes to the targets (default: dry run).")

--- a/spotify_mirror/targets/apple.py
+++ b/spotify_mirror/targets/apple.py
@@ -8,7 +8,7 @@ import time
 import requests
 
 from ..config import AMP, REQUEST_TIMEOUT, polite_sleep, required_env
-from ..logs import log
+from ..logs import log, log_warn
 from ..matching import normalize_text, romanized, score_candidate
 from .base import MirrorTarget, TargetAuthError
 
@@ -45,6 +45,7 @@ class AppleMusicTarget(MirrorTarget):
         # now so re-captured tokens are picked up per pass.
         self._session = requests.Session()
         self._session.headers.update(_headers())
+        self._search_throttled = False  # set once catalog search rate-limits; defer the rest of the pass
 
     # -- HTTP ------------------------------------------------------------------
     def _request(self, method, url, *, params=None, json_body=None, ok404=False):
@@ -70,8 +71,10 @@ class AppleMusicTarget(MirrorTarget):
                 )
             if r.status_code == 404 and ok404:
                 return None
-            if r.status_code == 429 and attempt < attempts - 1:
-                wait = float(r.headers.get("Retry-After") or 20) + random.uniform(1, 8)
+            if r.status_code == 429 and attempt < 1:
+                # One short retry for a transient blip; a sustained catalog-search
+                # limit is handled by the resolver deferring the rest of the pass.
+                wait = float(r.headers.get("Retry-After") or 10) + random.uniform(1, 4)
                 log(f"  rate-limited by Apple; waiting {int(wait)}s", tag=self.tag)
                 time.sleep(wait)
                 continue
@@ -211,12 +214,22 @@ class AppleMusicTarget(MirrorTarget):
         key = f"{name}|{primary}".casefold()
         if key in cache["search"]:
             return cache["search"][key]
-        best = self._search_once(f"{name} {primary}".strip(), name, artists, duration_ms)
-        if not best:
-            rom = f"{romanized(name)} {romanized(primary)}".strip()
-            if rom and rom != normalize_text(f"{name} {primary}"):
-                polite_sleep(0.3)
-                best = self._search_once(rom, name, artists, duration_ms)
+        if self._search_throttled:
+            return None  # catalog search rate-limited earlier this pass; defer to the next (don't cache a miss)
+        try:
+            best = self._search_once(f"{name} {primary}".strip(), name, artists, duration_ms)
+            if not best:
+                rom = f"{romanized(name)} {romanized(primary)}".strip()
+                if rom and rom != normalize_text(f"{name} {primary}"):
+                    polite_sleep(0.3)
+                    best = self._search_once(rom, name, artists, duration_ms)
+        except requests.HTTPError as e:
+            if "429" not in str(e):
+                raise
+            self._search_throttled = True
+            log_warn("Apple Music search rate-limited — deferring the rest of the resolves to the next pass",
+                     tag=self.tag)
+            return None
         cache["search"][key] = best
         cache["dirty"] = True
         polite_sleep(0.3)

--- a/spotify_mirror/targets/base.py
+++ b/spotify_mirror/targets/base.py
@@ -16,7 +16,7 @@ from ..logs import (
     fmt_counts, fmt_secs, log_add, log_hold, log_miss, log_note, log_remove,
     log_section, log_summary, log_warn, paint,
 )
-from ..matching import compute_diff, protect_removals, track_key
+from ..matching import compute_diff, protect_removals, spotify_track_keys, track_key
 
 # A provider reading fewer than this fraction of the known baseline is treated
 # as a broken read: its removals are ignored so one bad fetch can't cascade a
@@ -266,14 +266,17 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     started = time.monotonic()
     prev = {p.source: archive.get_playlist_state(songs, key, p.source) for p in peers}
 
-    canon = {}       # source -> {canonical_id: normalized track}
-    present = {}     # source -> set of ALL current target ids (not canonical-deduped)
-    key2isrc = {}    # track_key -> ISRC, seeded by any ISRC-bearing provider (peers are ISRC-rich first)
+    canon = {}         # source -> {canonical_id: normalized track}
+    present = {}       # source -> set of ALL current target ids (not canonical-deduped)
+    present_keys = {}  # source -> set of track_keys already on the provider (dupe guard)
+    key2isrc = {}      # track_key -> ISRC, seeded by any ISRC-bearing provider (peers are ISRC-rich first)
     for p in peers:
         raw = p.playlist_tracks(playlists[p.source])
         archive.upsert_many(songs, p.source, raw)
         present[p.source] = {p.track_id(t) for t in raw if p.track_id(t)}
         canon[p.source] = _canonicalize(p, raw, songs, caches[p.source], key2isrc)
+        present_keys[p.source] = set().union(*(spotify_track_keys(n) for n in canon[p.source].values())) \
+            if canon[p.source] else set()
         for cid, norm in canon[p.source].items():
             if cid.startswith("i:"):  # any provider that resolved an ISRC anchors the rest
                 key2isrc.setdefault(track_key(norm["name"], norm["artist"]), cid[2:])
@@ -313,6 +316,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             log_warn(f"{p.name} prefetch failed: {e!r}", tag=p.tag)
         additions, not_found = [], []
         for norm in sorted(add_norms, key=lambda n: n["added_at"]):
+            if spotify_track_keys(norm) & present_keys[p.source]:
+                continue  # song already on the provider under a different id — no dupe, and no wasted search
             try:
                 tid, method = p.resolve(norm, cache)
             except TargetAuthError:
@@ -324,8 +329,9 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 not_found.append(norm)
                 continue
             if tid in seen:
-                continue  # already on this provider (a different canonical resolved to the same track)
+                continue  # resolved to a track already present (belt-and-suspenders with the key guard)
             seen.add(tid)
+            present_keys[p.source] |= spotify_track_keys(norm)  # so a second add of the same song this pass is caught
             additions.append((tid, method or "search", norm))
             if norm["_source"] == "spotify" and norm["_raw"].get("id"):
                 new_links[p.source][norm["_raw"]["id"]] = tid

--- a/spotify_mirror/targets/ytmusic.py
+++ b/spotify_mirror/targets/ytmusic.py
@@ -119,6 +119,7 @@ class YTMusicTarget(MirrorTarget):
             self._tok = json.load(f)
         self.cache_file = os.getenv("YTMUSIC_CACHE_FILE", "ytmusic_resolve_cache.json")
         self._session = requests.Session()
+        self._rate_limited = False  # set once search hits the rate limit; defer the rest of the pass
 
     # -- auth ------------------------------------------------------------------
     def _access(self):
@@ -160,8 +161,11 @@ class YTMusicTarget(MirrorTarget):
                 raise TargetAuthError(f"YouTube refused {method} {path} (403 {reason or 'forbidden'}).")
             if r.status_code == 404 and ok404:
                 return None
-            if r.status_code == 429 and attempt < attempts - 1:
-                wait = float(r.headers.get("Retry-After") or 20) + random.uniform(1, 8)
+            if r.status_code == 429 and attempt < 1:
+                # One short retry for a transient blip; a sustained limit (the
+                # first-run backlog vs the daily quota) is handled by the caller
+                # deferring the rest of the pass rather than fighting each track.
+                wait = float(r.headers.get("Retry-After") or 8) + random.uniform(1, 4)
                 log(f"  rate-limited by YouTube; waiting {int(wait)}s", tag=self.tag)
                 time.sleep(wait)
                 continue
@@ -246,14 +250,24 @@ class YTMusicTarget(MirrorTarget):
         return best_id, method
 
     def _search(self, track, primary):
+        if self._rate_limited:
+            return None, None  # already rate-limited this pass — don't pile on; resolve next pass
         queries = [f"{track['name']} {primary}".strip()]
         rom = f"{romanized(track['name'])} {romanized(primary)}".strip()
         if rom and rom != normalize_text(queries[0]):
             queries.append(rom)  # romanized retry only runs if the first query misses
         for query in queries:
-            items = self._request("GET", "search", params={
-                "part": "snippet", "q": query, "type": "video",
-                "videoCategoryId": "10", "maxResults": 10}).json().get("items", [])
+            try:
+                items = self._request("GET", "search", params={
+                    "part": "snippet", "q": query, "type": "video",
+                    "videoCategoryId": "10", "maxResults": 10}).json().get("items", [])
+            except requests.HTTPError as e:
+                if "429" not in str(e):
+                    raise
+                self._rate_limited = True  # daily quota / burst limit hit — stop searching this pass
+                log_warn("YouTube search rate limit reached — deferring the rest of the resolves to the next "
+                         "pass (raise the Data API quota to converge faster)", tag=self.tag)
+                return None, None
             durations = self._durations([it["id"]["videoId"] for it in items if it.get("id", {}).get("videoId")])
             best = None  # (sort_key, videoId, is_topic)
             for it in items:
@@ -276,14 +290,22 @@ class YTMusicTarget(MirrorTarget):
         return None, None
 
     def _durations(self, video_ids):
-        """{videoId: duration_ms} via batched videos.list (1 unit per 50 ids)."""
+        """{videoId: duration_ms} via batched videos.list (1 unit per 50 ids).
+        Best-effort: on a rate limit, flag and return what we have (scoring just
+        loses the duration anchor for the rest)."""
         out = {}
         for i in range(0, len(video_ids), 50):
             chunk = video_ids[i:i + 50]
             if not chunk:
                 continue
-            for it in self._request("GET", "videos",
-                                    params={"part": "contentDetails", "id": ",".join(chunk)}).json().get("items", []):
+            try:
+                resp = self._request("GET", "videos", params={"part": "contentDetails", "id": ",".join(chunk)})
+            except requests.HTTPError as e:
+                if "429" not in str(e):
+                    raise
+                self._rate_limited = True
+                return out
+            for it in resp.json().get("items", []):
                 out[it["id"]] = _duration_ms(it.get("contentDetails", {}).get("duration"))
         return out
 

--- a/spotify_mirror/targets/ytmusic.py
+++ b/spotify_mirror/targets/ytmusic.py
@@ -1,12 +1,17 @@
-"""YouTube Music target — via the official YouTube Data API v3.
+"""YouTube Music target — hybrid: Data API v3 for reads/writes, ytmusicapi for search.
 
-Durable OAuth (refresh-token) auth. ytmusicapi's internal youtubei endpoints
-reject self-created OAuth clients (HTTP 400) and its captured browser cookies
-die within a day, so neither survives an unattended loop. The Data API shares
-YouTube's playlist/video namespace — its writes surface in the YouTube Music
-app — at the cost of a 10k-unit/day quota (search=100, insert/delete=50,
-list=1) and no ISRC, so matching stays title/artist/duration, biased toward
-`- Topic` art-tracks so resolved tracks land as native songs, not videos.
+The playlist reads and writes (list/create/add/remove) go through the official
+YouTube Data API v3 with a durable OAuth refresh token — ytmusicapi's internal
+youtubei API rejects self-made OAuth clients (HTTP 400) and its browser cookies
+die within a day, so neither survives an unattended write loop. Its writes
+share YouTube's playlist/video namespace, so they show up in the YouTube Music
+app.
+
+Resolution (matching a track to a video id) instead uses ytmusicapi's PUBLIC,
+unauthenticated search. Two reasons: it costs no Data API quota (the killer
+constraint — a Data API search is 100 of only 10k units/day), and it returns
+real catalog songs (`- Topic` art-tracks) with durations, so matches are both
+free and higher quality than the Data API's video search.
 
 Setup: create a Google "TVs and Limited Input devices" OAuth client, then
     uvx ytmusicapi oauth --file data/ytmusic_oauth.json \
@@ -30,18 +35,7 @@ from .base import MirrorTarget, TargetAuthError
 DEFAULT_AUTH_FILE = "ytmusic_oauth.json"
 API = "https://www.googleapis.com/youtube/v3"
 
-_ISO_DUR = re.compile(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?")
 _TOPIC_RE = re.compile(r"\s*-\s*Topic$")
-# YouTube video titles embed artist + decoration ("Queen – Bohemian Rhapsody
-# (Official Video)"); art-track titles are already clean. Strip [..]/(..) that
-# carry decoration keywords, but NOT version parens like (Live)/(Acoustic) — the
-# scorer must still treat those as distinct recordings.
-_YT_DECOR = re.compile(
-    r"\[[^\]]*\]"
-    r"|\((?=[^)]*\b(?:official|video|audio|lyric|lyrics|visuali[sz]er|hd|4k|mv|remaster)\b)[^)]*\)"
-    r"|\bofficial\s+(?:music\s+)?video\b"
-    r"|\bremaster(?:ed)?(?:\s+\d{4})?\b",
-    re.IGNORECASE)
 
 
 def build():
@@ -58,7 +52,7 @@ def build():
     try:
         from ytmusicapi.auth.oauth import OAuthCredentials
     except ImportError:
-        log_note("YouTube Music skipped: ytmusicapi not installed (used only to refresh the OAuth token)", tag="yt")
+        log_note("YouTube Music skipped: ytmusicapi not installed", tag="yt")
         return None
     try:
         return YTMusicTarget(auth, OAuthCredentials(client_id=cid, client_secret=secret))
@@ -74,29 +68,9 @@ def _parse_count(value):
         return None
 
 
-def _duration_ms(iso):
-    """contentDetails.duration (ISO-8601, e.g. PT3M20S) -> ms, or None."""
-    m = _ISO_DUR.fullmatch(iso or "")
-    if not m:
-        return None
-    h, mnt, s = (int(x) if x else 0 for x in m.groups())
-    return (h * 3600 + mnt * 60 + s) * 1000
-
-
 def _artist_from_channel(channel):
     """'The Cranberries - Topic' -> 'The Cranberries'; VEVO/plain kept as-is."""
     return _TOPIC_RE.sub("", channel or "").strip()
-
-
-def _clean_title(title, artists):
-    """Strip a leading '<artist> -' and video-decoration parentheticals from a
-    YouTube title so the fuzzy scorer sees ~the song name. Version tags like
-    (Live)/(Acoustic) survive — they mark a genuinely different recording."""
-    cleaned = _YT_DECOR.sub(" ", title or "")
-    for artist in artists:
-        if artist.strip():
-            cleaned = re.sub(rf"^\s*{re.escape(artist.strip())}\s*[-–—:]\s*", "", cleaned, count=1, flags=re.IGNORECASE)
-    return " ".join(cleaned.split()).strip() or (title or "")
 
 
 def _err_reason(response):
@@ -105,6 +79,21 @@ def _err_reason(response):
         return errors[0].get("reason", "") if errors else ""
     except ValueError:
         return ""
+
+
+def _with_backoff(fn, what):
+    """Retry a ytmusicapi search past YouTube's bot-detection throttle (403/429).
+    This path spends no Data API quota — the limit here is IP-based, not the
+    daily unit budget — so backing off and retrying is worthwhile."""
+    for attempt in range(4):
+        try:
+            return fn()
+        except Exception as e:
+            if not any(code in str(e) for code in ("403", "429")) or attempt == 3:
+                raise
+            wait = 15 * (2 ** attempt) + random.uniform(0, 8)
+            log(f"  YT search throttled ({what}); backing off {int(wait)}s", tag="yt")
+            time.sleep(wait)
 
 
 class YTMusicTarget(MirrorTarget):
@@ -118,8 +107,9 @@ class YTMusicTarget(MirrorTarget):
         with open(auth_file) as f:
             self._tok = json.load(f)
         self.cache_file = os.getenv("YTMUSIC_CACHE_FILE", "ytmusic_resolve_cache.json")
-        self._session = requests.Session()
-        self._rate_limited = False  # set once search hits the rate limit; defer the rest of the pass
+        self._session = requests.Session()  # Data API (reads + writes)
+        from ytmusicapi import YTMusic
+        self._ytm = YTMusic()  # public, unauthenticated search for resolution (no Data API quota)
 
     # -- auth ------------------------------------------------------------------
     def _access(self):
@@ -134,12 +124,11 @@ class YTMusicTarget(MirrorTarget):
                 json.dump(self._tok, f)
         return self._tok["access_token"]
 
-    # -- HTTP ------------------------------------------------------------------
+    # -- HTTP (Data API: reads + writes only; search never touches this) --------
     def _request(self, method, path, *, params=None, json_body=None, ok404=False):
-        """One Data API call. GET/5xx retry with backoff; 429 backs off on every
-        method; 401 -> re-auth; 403 quota -> fail closed for the pass; other
-        mutation failures are single-shot (a lost add/remove self-heals next pass,
-        a blindly retried one could double-apply)."""
+        """One Data API call. GET/5xx retry with backoff; 429/409 back off and
+        retry (write volume is low now that search is off the Data API); 401 ->
+        re-auth; 403 quota -> fail closed for the pass."""
         attempts = 5
         for attempt in range(attempts):
             headers = {"Authorization": f"Bearer {self._access()}"}
@@ -161,18 +150,11 @@ class YTMusicTarget(MirrorTarget):
                 raise TargetAuthError(f"YouTube refused {method} {path} (403 {reason or 'forbidden'}).")
             if r.status_code == 404 and ok404:
                 return None
-            if r.status_code == 429 and attempt < 1:
-                # One short retry for a transient blip; a sustained limit (the
-                # first-run backlog vs the daily quota) is handled by the caller
-                # deferring the rest of the pass rather than fighting each track.
-                wait = float(r.headers.get("Retry-After") or 8) + random.uniform(1, 4)
-                log(f"  rate-limited by YouTube; waiting {int(wait)}s", tag=self.tag)
+            if r.status_code in (409, 429) and attempt < attempts - 1:
+                # 409 = transient write-conflict on rapid edits; 429 = brief rate
+                # blip. The write didn't apply, so a backed-off retry is safe.
+                wait = float(r.headers.get("Retry-After") or 0) + min(2 ** attempt, 15) + random.uniform(1, 4)
                 time.sleep(wait)
-                continue
-            if r.status_code == 409 and attempt < attempts - 1:
-                # Transient write-conflict the Data API throws on rapid playlist
-                # edits; the write didn't apply, so a backed-off retry is safe.
-                time.sleep(min(2 ** attempt, 15) + random.uniform(0, 2))
                 continue
             if r.status_code >= 500 and method == "GET" and attempt < attempts - 1:
                 time.sleep(min(2 ** attempt, 20) + random.uniform(0, 2))
@@ -246,68 +228,38 @@ class YTMusicTarget(MirrorTarget):
         best_id, method = self._search(track, primary)
         cache["search"][key] = best_id
         cache["dirty"] = True
-        polite_sleep(0.5)
+        polite_sleep(0.4)
         return best_id, method
 
     def _search(self, track, primary):
-        if self._rate_limited:
-            return None, None  # already rate-limited this pass — don't pile on; resolve next pass
+        """Resolve via ytmusicapi's public search (no Data API quota). Prefer a
+        `songs` (art-track) match so tracks land as native songs; fall back to
+        `videos` only when no song scores acceptably."""
         queries = [f"{track['name']} {primary}".strip()]
         rom = f"{romanized(track['name'])} {romanized(primary)}".strip()
         if rom and rom != normalize_text(queries[0]):
-            queries.append(rom)  # romanized retry only runs if the first query misses
+            queries.append(rom)  # romanized retry for cross-script titles
         for query in queries:
-            try:
-                items = self._request("GET", "search", params={
-                    "part": "snippet", "q": query, "type": "video",
-                    "videoCategoryId": "10", "maxResults": 10}).json().get("items", [])
-            except requests.HTTPError as e:
-                if "429" not in str(e):
-                    raise
-                self._rate_limited = True  # daily quota / burst limit hit — stop searching this pass
-                log_warn("YouTube search rate limit reached — deferring the rest of the resolves to the next "
-                         "pass (raise the Data API quota to converge faster)", tag=self.tag)
-                return None, None
-            durations = self._durations([it["id"]["videoId"] for it in items if it.get("id", {}).get("videoId")])
-            best = None  # (sort_key, videoId, is_topic)
-            for it in items:
-                vid = it.get("id", {}).get("videoId")
-                if not vid:
-                    continue
-                sn = it.get("snippet", {})
-                is_topic = bool(_TOPIC_RE.search(sn.get("channelTitle", "")))
-                cand_name = sn.get("title", "") if is_topic else _clean_title(sn.get("title", ""), track["artists"])
-                score, ok = score_candidate(track["name"], track["artists"], track["duration_ms"],
-                                            cand_name, _artist_from_channel(sn.get("channelTitle", "")),
-                                            durations.get(vid))
-                if ok:
-                    sort_key = score + (0.05 if is_topic else 0.0)  # nudge toward native art-tracks
-                    if best is None or sort_key > best[0]:
-                        best = (sort_key, vid, is_topic)
-            if best:
-                return best[1], ("song" if best[2] else "video")
-            polite_sleep(0.4)
+            for filt in ("songs", "videos"):
+                try:
+                    results = _with_backoff(lambda q=query, f=filt: self._ytm.search(q, filter=f, limit=8),
+                                            f"{filt}")
+                except Exception:
+                    results = []
+                best_id, best_score = None, -1.0
+                for cand in results or []:
+                    vid = cand.get("videoId")
+                    if not vid:
+                        continue
+                    cand_artist = ", ".join(a.get("name", "") for a in cand.get("artists") or []) or cand.get("author") or ""
+                    ds = cand.get("duration_seconds")
+                    score, ok = score_candidate(track["name"], track["artists"], track["duration_ms"],
+                                                cand.get("title", ""), cand_artist, ds * 1000 if ds else None)
+                    if ok and score > best_score:
+                        best_id, best_score = vid, score
+                if best_id:
+                    return best_id, ("song" if filt == "songs" else "video")
         return None, None
-
-    def _durations(self, video_ids):
-        """{videoId: duration_ms} via batched videos.list (1 unit per 50 ids).
-        Best-effort: on a rate limit, flag and return what we have (scoring just
-        loses the duration anchor for the rest)."""
-        out = {}
-        for i in range(0, len(video_ids), 50):
-            chunk = video_ids[i:i + 50]
-            if not chunk:
-                continue
-            try:
-                resp = self._request("GET", "videos", params={"part": "contentDetails", "id": ",".join(chunk)})
-            except requests.HTTPError as e:
-                if "429" not in str(e):
-                    raise
-                self._rate_limited = True
-                return out
-            for it in resp.json().get("items", []):
-                out[it["id"]] = _duration_ms(it.get("contentDetails", {}).get("duration"))
-        return out
 
     def add(self, playlist, target_ids):
         for video_id in target_ids:  # one at a time, in order — append order is date-added order

--- a/test_reconcile.py
+++ b/test_reconcile.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 
 from spotify_mirror import archive
+from spotify_mirror.matching import spotify_track_keys
 from spotify_mirror.targets.base import _merge
 
 
@@ -93,6 +94,16 @@ def test_reverse_links_and_isrcs():
         {"id": "sp2", "isrc": None, "name": "B", "artists": ["Y"], "duration_ms": 1}])
     assert archive.get_isrcs(conn, "spotify", ["sp1", "sp2"]) == {"sp1": "ISRCA"}  # sp2 has no ISRC -> excluded
     conn.close()
+
+
+def test_dupe_guard_catches_same_song_variant():
+    # The exact shape that duplicated Aurora: Spotify lists all artists; Apple
+    # shows the primary with the feature in the title. They MUST share a
+    # track_key so reconcile's guard skips the add rather than duplicating the
+    # song under a second catalog id.
+    present = spotify_track_keys({"name": "Drowning (feat. Kodak Black)", "artists": ["BMike"]})
+    incoming = spotify_track_keys({"name": "Drowning", "artists": ["BMike", "Kodak Black"]})
+    assert incoming & present, "same song across providers must share a key -> guarded against duplicate add"
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -34,36 +34,6 @@ wheels = [
 ]
 
 [[package]]
-name = "apple-music-to-spotify-sync"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "anyascii" },
-    { name = "python-dotenv" },
-    { name = "rapidfuzz" },
-    { name = "requests" },
-    { name = "spotipy" },
-    { name = "ytmusicapi" },
-]
-
-[package.optional-dependencies]
-download = [
-    { name = "spotdl" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyascii", specifier = ">=0.3,<1" },
-    { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "rapidfuzz", specifier = ">=3.9,<4" },
-    { name = "requests", specifier = ">=2.32.5" },
-    { name = "spotdl", marker = "extra == 'download'", specifier = ">=4.5,<5" },
-    { name = "spotipy", specifier = ">=2.26.0" },
-    { name = "ytmusicapi", specifier = ">=1.12,<2" },
-]
-provides-extras = ["download"]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -476,6 +446,36 @@ sdist = { url = "https://files.pythonhosted.org/packages/df/70/1675da133ea92227d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/d8/a29e4e3991765e7ce4ed1f7e4074fe1ba9da03e0048639734de60f9cadb9/mutagen-1.48.1-py3-none-any.whl", hash = "sha256:4f077fe87d3fc7fba259aa63d8c026b18382ca6a42ef37c61e16f1b1b5b82fe7", size = 195706, upload-time = "2026-06-25T09:47:30.296Z" },
 ]
+
+[[package]]
+name = "omni-playlist-sync"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "anyascii" },
+    { name = "python-dotenv" },
+    { name = "rapidfuzz" },
+    { name = "requests" },
+    { name = "spotipy" },
+    { name = "ytmusicapi" },
+]
+
+[package.optional-dependencies]
+download = [
+    { name = "spotdl" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyascii", specifier = ">=0.3,<1" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "rapidfuzz", specifier = ">=3.9,<4" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "spotdl", marker = "extra == 'download'", specifier = ">=4.5,<5" },
+    { name = "spotipy", specifier = ">=2.26.0" },
+    { name = "ytmusicapi", specifier = ">=1.12,<2" },
+]
+provides-extras = ["download"]
 
 [[package]]
 name = "pillow"


### PR DESCRIPTION
## Summary

Follow-up to the N-way sync PR: renames the project and fixes a duplicate-add bug found during the first live rollout.

- **fix(sync): guard against same-song duplicates.** The reconcile deduped additions only by exact target id, so a song already present that resolved to a *different* provider id (e.g. a second Apple catalog entry for the same recording) got added again — and re-added every pass. Restores the `track_key` guard the one-way engine already uses (checked before `resolve`, so it also cuts wasted searches under the YouTube rate limit). Regression test added.
- **chore: rename to `omni-playlist-sync`.** Package name, compose project + container name, CLI prog, CI badge, README (title + references), and the stale `apple-music-to-spotify-sync` references. GitHub repo, description, and topics updated too.

## Test plan

- `uv run test_reconcile.py` (adds `test_dupe_guard_catches_same_song_variant`) and `uv run test_matching.py` pass.
- Verified on live data: 97 accumulated duplicates removed across all playlists; the guard now skips same-song candidates instead of re-adding them; per-provider snapshots reset so the next pass is a clean adds-only convergence.

## Local follow-up

Rename the local checkout dir to match, then `uv sync` (venv console-script trampolines are path-bound).