### PR TITLE
feat(web): same-provider transfers, followed playlists, and removal reconciliation

### DIFF
--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -1,0 +1,96 @@
+# Adding a music provider (Tidal, Qobuz, Deezer, …)
+
+## The short version
+
+A provider that carries **ISRC** (every hi-fi service does) drops in with **no changes
+to the sync / reconcile / transfer / browse core**. You write two small classes — a
+`MirrorTarget` (how the engine *uses* the service) and a `Connector` (how the UI
+*authenticates* it) — register each with one line, and add branding. ISRC is what makes
+cross-provider matching free: a track with an ISRC unifies with the same song on every
+other provider automatically, no per-pair code.
+
+The core (`mirror_pair`, `reconcile`, `browse`, `transfer`, the runner, the web routers)
+is provider-agnostic and never changes.
+
+## The five touchpoints
+
+### 1. Engine target — `omni_sync/engine/targets/<svc>.py`
+
+Subclass `MirrorTarget` (`targets/base.py`). **Required** (no default — must implement):
+
+| Method | Returns |
+|---|---|
+| `list_playlists()` | `{casefolded name: playlist}` — the sync engine's name-keyed map |
+| `create(sp_playlist)` | a new same-named playlist (copy name + description) |
+| `playlist_tracks(playlist)` | existing tracks as dicts — **carry `isrc`** here; also `name`, `artists`/`artist`, `duration_ms`, `added_at`, and a stable id |
+| `track_id(track)` | the provider's stable id for one of its tracks |
+| `resolve(sp_track, cache)` | `(target_id, method)` for a track not yet linked — your search |
+| `add(playlist, target_ids)` | append in order, **one request per id** (never batch — preserves date-added order) |
+| `remove(playlist, track)` | remove one existing track |
+
+**Override only if your dict shape differs from Spotify's** (`{"id", "name", "images", ...}`):
+`playlist_id`, `playlist_name`, `playlist_description`, `playlist_count`. See `apple.py`
+(`attributes.name`) and `ytmusic.py` (`playlistId`/`title`) for non-Spotify shapes.
+
+**Override if the service exposes followed / non-owned playlists** (like Spotify):
+`browse_playlists()` — return the full, un-deduped list, tagging each dict with `_owned`
+(owner is the current user). The default returns `list(self.list_playlists().values())`
+with everything treated as owned, which is correct for a service whose list API only
+returns your own playlists (Apple, YouTube Music). `find_playlist()` scans
+`browse_playlists()`, so you get correct id lookup for free.
+
+**Optional performance/quality hooks:** `prefetch()` (batch work before resolving —
+Apple bulk-fetches ISRCs), `native_isrc_map()` (expose `{track_id: ISRC}` your resolve
+cache already knows), `expected_ids()`, `is_editable()`.
+
+### 2. Targets registry — `omni_sync/engine/targets/__init__.py`
+
+Two lines: add a builder to `_REGISTRY` (`source -> builder(opts, sp) -> target | None`,
+returning `None` when unconfigured) and the id to `_SOURCE_ORDER`. **Put ISRC-rich
+providers first** — they seed cross-provider identity for the rest.
+
+### 3. Connector (auth) — `omni_sync/services/accounts/<svc>.py`
+
+Subclass `Connector` (`accounts/base.py`). Pick an `auth_kind`
+(`oauth_redirect` | `oauth_device` | `token_paste` | `api_key`), set `config_fields`
+(what the wizard asks the user for), and implement `status()` plus the methods for that
+kind (e.g. `begin_redirect`/`complete_redirect` for OAuth, or `submit` for a pasted
+token/key). The engine reads whatever the connector saves to the `SettingsStore`.
+
+### 4. Connectors registry — `omni_sync/services/accounts/__init__.py`
+
+One line in `CONNECTORS`. The service now appears in the accounts wizard, the
+source/target pickers, and transfers automatically.
+
+### 5. Frontend branding — `frontend/src/lib/constants.ts` (+ two more)
+
+- `SERVICE_STYLES`: a `{ label, dot, soft, text }` entry keyed by the provider id.
+- `serviceLogoId()`: map the id to a logo id.
+- `--color-svc-<svc>` / `-soft` CSS vars (where the other `svc-*` colors are defined) and
+  the brand SVG in the `ServiceLogo` component.
+
+Skip this and the provider still works — it just falls back to a neutral dot/label
+(`DEFAULT_SERVICE_STYLE`) instead of its brand color and mark.
+
+## Why the `== "spotify"` branches aren't your problem
+
+A grep shows a handful of `source == "spotify"` checks in the engine. They are all
+Spotify's role as the **identity anchor**, not per-provider special-casing:
+
+- the archive `links` table maps `spotify_id -> target_id`, so links are only
+  consulted/written when Spotify is the source (`base.py`);
+- only Spotify exposes a `snapshot_id`, so the read-cache skip optimization keys on it
+  (`runner.py`);
+- `_canonicalize` skips the reverse-link lookup for Spotify because it *is* the anchor
+  (`base.py`).
+
+A new provider added as a **write target** or an **N-way peer** touches none of these — it
+unifies through ISRC (or, lacking one, a fuzzy `track_key`). You would only revisit them
+to make a *new* provider a second canonical hub, which isn't needed.
+
+## Verify
+
+- Unit-test your target's dict-shape accessors and any resolve/matching quirks — see
+  `tests/test_targets_accessors.py` (accessors) and `tests/test_reconcile.py` (merge
+  behavior). Fakes there are the template.
+- `.venv/Scripts/python.exe -m pytest tests/ -q` and `pnpm -C frontend build`.

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -1099,17 +1099,16 @@ async function main() {
       console.log(`${activeChecked === 'true' ? 'ok        ' : 'FAIL      '} Wizard Schedule (step 4): Active reflects the job's own enabled field (aria-checked="${activeChecked}")`)
       if (activeChecked !== 'true') results.push({ label: 'wizard schedule active', overflow: true })
 
-      // Next must disable when the interval is invalid, and re-enable once
-      // it's fixed — Direction/Services/Playlists have no such gate.
-      const intervalInput = page.getByLabel('Interval', { exact: true })
-      await intervalInput.fill('not-an-interval')
-      const nextDisabledWhenInvalid = await page.getByRole('button', { name: 'Next', exact: true }).isDisabled()
-      console.log(`${nextDisabledWhenInvalid ? 'ok        ' : 'FAIL      '} Wizard Schedule: Next disables when the interval is invalid`)
-      if (!nextDisabledWhenInvalid) results.push({ label: 'wizard next disabled invalid interval', overflow: true })
-      await intervalInput.fill('30m')
-      const nextEnabledWhenValid = await page.getByRole('button', { name: 'Next', exact: true }).isEnabled()
-      console.log(`${nextEnabledWhenValid ? 'ok        ' : 'FAIL      '} Wizard Schedule: Next re-enables once the interval is valid again`)
-      if (!nextEnabledWhenValid) results.push({ label: 'wizard next enabled valid interval', overflow: true })
+      // Interval is a preset dropdown now (it was a free-text field with a
+      // validity gate) — selecting a preset applies it, and a dropdown has no
+      // invalid state. Keep it on 30m: the review + save-round-trip checks below
+      // assert on that value. The Next-disable gate is still covered by the
+      // numeric caps on the Limits step.
+      const intervalSelect = page.getByLabel('Interval', { exact: true })
+      await intervalSelect.selectOption('30m')
+      const intervalValue = await intervalSelect.inputValue()
+      console.log(`${intervalValue === '30m' ? 'ok        ' : 'FAIL      '} Wizard Schedule: interval preset dropdown applies the choice (got "${intervalValue}")`)
+      if (intervalValue !== '30m') results.push({ label: 'wizard interval preset', overflow: true })
       await checkOverflow(page, `Wizard step 4 Schedule @ ${width}`, results)
       await shot(page, `wizard-step4-schedule-${width}`)
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -97,6 +97,9 @@ export const api = {
   deleteSync: (id: string) => request<OkResponse>(`/api/syncs/${encodeURIComponent(id)}`, { method: 'DELETE' }),
   runSyncJob: (id: string, execute: boolean) =>
     request<RunResponse>(`/api/syncs/${encodeURIComponent(id)}/run?execute=${execute ? 1 : 0}`, { method: 'POST' }),
+  pauseSyncJob: (id: string) => request<OkResponse>(`/api/syncs/${encodeURIComponent(id)}/pause`, { method: 'POST' }),
+  stopSyncJob: (id: string) => request<OkResponse>(`/api/syncs/${encodeURIComponent(id)}/stop`, { method: 'POST' }),
+  resumeSyncJob: (id: string) => request<OkResponse>(`/api/syncs/${encodeURIComponent(id)}/resume`, { method: 'POST' }),
 
   // Playlists (browse)
   getPlaylists: (provider: string) =>

--- a/frontend/src/components/accounts/ConnectWizardModal.tsx
+++ b/frontend/src/components/accounts/ConnectWizardModal.tsx
@@ -140,7 +140,9 @@ const CONNECT_GUIDES: Record<string, ConnectGuideContent> = {
     intro: 'Optional: connect Jellyfin to push real playlist cover art. You need the server URL and an API key.',
     steps: [
       <>
-        <strong>Server URL</strong>: where Jellyfin runs, e.g. <Code>http://localhost:8096</Code>.
+        <strong>Server URL</strong>: where Jellyfin runs, e.g. <Code>http://localhost:8096</Code>. If this
+        app runs in Docker, use <Code>http://host.docker.internal:8096</Code> — inside the container{' '}
+        <Code>localhost</Code> is the container itself, not your host.
       </>,
       <>
         In Jellyfin, open <strong>Dashboard → API Keys</strong> (under Advanced).

--- a/frontend/src/components/dashboard/NeedsALook.tsx
+++ b/frontend/src/components/dashboard/NeedsALook.tsx
@@ -14,9 +14,9 @@ interface NeedsLookItem {
   action?: { label: string; to: string }
 }
 
-/** Every item here traces back to a real field — account state/detail, or
- * the last pass's own ok flag and per-target held/deferred counts. Nothing
- * is invented (no fabricated "last synced" claims). */
+/** Every item here traces back to a real field — account state/detail, or the
+ * last pass's own ok flag and per-target held/deferred/removals-skipped counts.
+ * Nothing is invented (no fabricated "last synced" claims). */
 function buildItems(accounts: Account[] | null, status: SyncStatus | null): NeedsLookItem[] {
   const items: NeedsLookItem[] = []
 
@@ -63,8 +63,20 @@ function buildItems(accounts: Account[] | null, status: SyncStatus | null): Need
       key: 'held',
       icon: LuTriangleAlert,
       title: `${heldTotal} change${heldTotal === 1 ? '' : 's'} held from the last pass`,
-      description: 'A removal passed your safety cap, or a service needs a follow-up pass. Nothing was lost.',
+      description: 'A service needs a follow-up pass — an unmatched track was kept, or additions exceeded the cap. Nothing was lost.',
       action: { label: 'Review caps', to: '/sync' },
+    })
+  }
+
+  const removalsSkipped = status?.last?.per_target.reduce((sum, t) => sum + (t.removals_skipped ?? 0), 0) ?? 0
+  if (removalsSkipped > 0) {
+    items.push({
+      key: 'removals-skipped',
+      icon: LuTriangleAlert,
+      title: `${removalsSkipped} removal${removalsSkipped === 1 ? '' : 's'} held back for safety`,
+      description:
+        'They exceeded the per-pass removal cap. Turn on "Apply large removals" for the sync to delete them in batches over the next passes.',
+      action: { label: 'Open sync', to: '/sync' },
     })
   }
 

--- a/frontend/src/components/dashboard/SyncsPanel.tsx
+++ b/frontend/src/components/dashboard/SyncsPanel.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { LuArrowRight } from 'react-icons/lu'
 
+import { SyncControls } from '@/components/sync/SyncControls'
 import { SyncRunButtons } from '@/components/sync/SyncRunButtons'
 import { formatClockTime } from '@/lib/format'
 import { buildSyncSummaryRows, syncPeersOf } from '@/lib/syncSummary'
@@ -55,6 +56,8 @@ export function SyncsPanel({
             const jobStatus = status?.jobs.find((j) => j.id === job.id)
             const running = jobStatus?.running ?? false
             const queued = jobStatus?.queued ?? false
+            const paused = jobStatus?.paused ?? false
+            const pending = jobStatus?.pending ?? null
             return (
               <li key={job.id} className="flex flex-col gap-2.5 px-4 py-3.5 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-w-0 flex-1">
@@ -74,7 +77,10 @@ export function SyncsPanel({
                   <p className="mt-0.5 truncate text-xs text-text-3">{summary}</p>
                   <p className="mt-0.5 font-mono text-[10px] tracking-wide text-text-3">Next run: {nextRunText(job, status)}</p>
                 </div>
-                <SyncRunButtons job={job} disabled={running || queued} onChanged={onChanged} />
+                <div className="flex flex-wrap items-center gap-2">
+                  <SyncRunButtons job={job} disabled={running || queued} onChanged={onChanged} />
+                  <SyncControls jobId={job.id} running={running} paused={paused} pending={pending} onChanged={onChanged} />
+                </div>
               </li>
             )
           })}

--- a/frontend/src/components/sync/SyncControls.tsx
+++ b/frontend/src/components/sync/SyncControls.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { LuPause, LuPlay, LuSquare } from 'react-icons/lu'
+
+import { api, errorMessage } from '@/api'
+import { Button } from '@/components/ui/Button'
+
+interface Props {
+  jobId: string
+  /** This job's pass is currently running — show Pause + Stop. */
+  running: boolean
+  /** Its last pass was paused — show Resume (re-runs; reconcile is idempotent). */
+  paused: boolean
+  /** A pause/stop already requested but not yet in effect — the buttons read
+   * "Pausing…"/"Stopping…" until the pass halts at its next checkpoint. */
+  pending: 'pause' | 'stop' | null
+  onChanged: () => void
+  onError?: (message: string) => void
+}
+
+/** Stop/Pause a running sync pass, or Resume a paused one — the mid-run
+ * counterpart to the schedule on/off toggle. Shared by the Sync-page card and
+ * the dashboard panel so both surfaces behave identically. An interrupt takes
+ * effect at the next checkpoint (mid-playlist), so while it's pending the button
+ * reflects that rather than looking like nothing happened. */
+export function SyncControls({ jobId, running, paused, pending, onChanged, onError }: Props) {
+  const [busy, setBusy] = useState(false)
+
+  async function control(action: 'pause' | 'stop' | 'resume') {
+    setBusy(true)
+    try {
+      if (action === 'pause') await api.pauseSyncJob(jobId)
+      else if (action === 'stop') await api.stopSyncJob(jobId)
+      else await api.resumeSyncJob(jobId)
+      onChanged()
+    } catch (err) {
+      onError?.(errorMessage(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (running) {
+    return (
+      <>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={busy || pending === 'pause'}
+          icon={<LuPause className="size-3.5" aria-hidden="true" />}
+          onClick={() => void control('pause')}
+        >
+          {pending === 'pause' ? 'Pausing…' : 'Pause'}
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={busy || pending === 'stop'}
+          icon={<LuSquare className="size-3.5" aria-hidden="true" />}
+          onClick={() => void control('stop')}
+        >
+          {pending === 'stop' ? 'Stopping…' : 'Stop'}
+        </Button>
+      </>
+    )
+  }
+  if (paused) {
+    return (
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={busy}
+        icon={<LuPlay className="size-3.5" aria-hidden="true" />}
+        onClick={() => void control('resume')}
+      >
+        Resume
+      </Button>
+    )
+  }
+  return null
+}

--- a/frontend/src/components/sync/SyncJobCard.tsx
+++ b/frontend/src/components/sync/SyncJobCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LuClock, LuPause, LuPencil, LuPlay, LuSquare, LuTrash2 } from 'react-icons/lu'
+import { LuClock, LuPencil, LuTrash2 } from 'react-icons/lu'
 
 import { api, errorMessage } from '@/api'
 import { Button } from '@/components/ui/Button'
@@ -10,6 +10,7 @@ import { cn } from '@/lib/cn'
 import { buildSyncSummaryRows } from '@/lib/syncSummary'
 import type { Account, SyncJob } from '@/types'
 
+import { SyncControls } from './SyncControls'
 import { SyncRunButtons } from './SyncRunButtons'
 
 interface Props {
@@ -27,6 +28,8 @@ interface Props {
   /** Its last pass was cut short by Pause, per `jobs[].paused` — shows a Resume
    * button (re-runs; reconcile is idempotent so it picks up the remainder). */
   paused: boolean
+  /** While running, a pause/stop requested but not yet in effect ("Pausing…"). */
+  pending: 'pause' | 'stop' | null
   onEdit: () => void
   onChanged: () => void
 }
@@ -37,29 +40,11 @@ interface Props {
  * (matching AccountCard's pattern) — the wizard (via Edit) is the only
  * place the job's actual config fields are changed; this card is for
  * at-a-glance management. */
-export function SyncJobCard({ job, peers, running, queued, paused, onEdit, onChanged }: Props) {
+export function SyncJobCard({ job, peers, running, queued, paused, pending, onEdit, onChanged }: Props) {
   const [togglingEnabled, setTogglingEnabled] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
-  const [controlling, setControlling] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  // Pause/Stop a running pass, or Resume a paused one — the mid-run counterpart to
-  // the schedule on/off toggle above. Halts at the next playlist boundary.
-  async function control(action: 'pause' | 'stop' | 'resume') {
-    setControlling(true)
-    setError(null)
-    try {
-      if (action === 'pause') await api.pauseSyncJob(job.id)
-      else if (action === 'stop') await api.stopSyncJob(job.id)
-      else await api.resumeSyncJob(job.id)
-      onChanged()
-    } catch (err) {
-      setError(errorMessage(err))
-    } finally {
-      setControlling(false)
-    }
-  }
 
   const summary = buildSyncSummaryRows(job, peers)
     .filter((r) => r.label !== 'Schedule')
@@ -140,39 +125,7 @@ export function SyncJobCard({ job, peers, running, queued, paused, onEdit, onCha
 
       <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
         <SyncRunButtons job={job} disabled={running || queued} onChanged={onChanged} />
-        {running && (
-          <>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={controlling}
-              icon={<LuPause className="size-3.5" aria-hidden="true" />}
-              onClick={() => void control('pause')}
-            >
-              Pause
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={controlling}
-              icon={<LuSquare className="size-3.5" aria-hidden="true" />}
-              onClick={() => void control('stop')}
-            >
-              Stop
-            </Button>
-          </>
-        )}
-        {paused && !running && (
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={controlling}
-            icon={<LuPlay className="size-3.5" aria-hidden="true" />}
-            onClick={() => void control('resume')}
-          >
-            Resume
-          </Button>
-        )}
+        <SyncControls jobId={job.id} running={running} paused={paused} pending={pending} onChanged={onChanged} onError={setError} />
         <Button variant="secondary" size="sm" icon={<LuPencil className="size-3.5" aria-hidden="true" />} onClick={onEdit}>
           Edit
         </Button>

--- a/frontend/src/components/sync/SyncJobCard.tsx
+++ b/frontend/src/components/sync/SyncJobCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LuClock, LuPencil, LuTrash2 } from 'react-icons/lu'
+import { LuClock, LuPause, LuPencil, LuPlay, LuSquare, LuTrash2 } from 'react-icons/lu'
 
 import { api, errorMessage } from '@/api'
 import { Button } from '@/components/ui/Button'
@@ -24,6 +24,9 @@ interface Props {
    * queued up while one runs). Shows a "Queued" badge and, like `running`,
    * guards against re-triggering this same job. */
   queued: boolean
+  /** Its last pass was cut short by Pause, per `jobs[].paused` — shows a Resume
+   * button (re-runs; reconcile is idempotent so it picks up the remainder). */
+  paused: boolean
   onEdit: () => void
   onChanged: () => void
 }
@@ -34,11 +37,29 @@ interface Props {
  * (matching AccountCard's pattern) — the wizard (via Edit) is the only
  * place the job's actual config fields are changed; this card is for
  * at-a-glance management. */
-export function SyncJobCard({ job, peers, running, queued, onEdit, onChanged }: Props) {
+export function SyncJobCard({ job, peers, running, queued, paused, onEdit, onChanged }: Props) {
   const [togglingEnabled, setTogglingEnabled] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [controlling, setControlling] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Pause/Stop a running pass, or Resume a paused one — the mid-run counterpart to
+  // the schedule on/off toggle above. Halts at the next playlist boundary.
+  async function control(action: 'pause' | 'stop' | 'resume') {
+    setControlling(true)
+    setError(null)
+    try {
+      if (action === 'pause') await api.pauseSyncJob(job.id)
+      else if (action === 'stop') await api.stopSyncJob(job.id)
+      else await api.resumeSyncJob(job.id)
+      onChanged()
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setControlling(false)
+    }
+  }
 
   const summary = buildSyncSummaryRows(job, peers)
     .filter((r) => r.label !== 'Schedule')
@@ -119,6 +140,39 @@ export function SyncJobCard({ job, peers, running, queued, onEdit, onChanged }: 
 
       <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
         <SyncRunButtons job={job} disabled={running || queued} onChanged={onChanged} />
+        {running && (
+          <>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={controlling}
+              icon={<LuPause className="size-3.5" aria-hidden="true" />}
+              onClick={() => void control('pause')}
+            >
+              Pause
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={controlling}
+              icon={<LuSquare className="size-3.5" aria-hidden="true" />}
+              onClick={() => void control('stop')}
+            >
+              Stop
+            </Button>
+          </>
+        )}
+        {paused && !running && (
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={controlling}
+            icon={<LuPlay className="size-3.5" aria-hidden="true" />}
+            onClick={() => void control('resume')}
+          >
+            Resume
+          </Button>
+        )}
         <Button variant="secondary" size="sm" icon={<LuPencil className="size-3.5" aria-hidden="true" />} onClick={onEdit}>
           Edit
         </Button>

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -5,6 +5,7 @@ import { api, errorMessage } from '@/api'
 import { Button } from '@/components/ui/Button'
 import { Modal } from '@/components/ui/Modal'
 import { RadioCard } from '@/components/ui/RadioCard'
+import { SelectField } from '@/components/ui/SelectField'
 import { ServiceLogo } from '@/components/ui/ServiceLogo'
 import { SettingsGroup } from '@/components/ui/SettingsGroup'
 import { TextField } from '@/components/ui/TextField'
@@ -30,6 +31,7 @@ interface JobFormState {
   interval: string
   max_adds: string
   max_removals: string
+  apply_large_removals: boolean
   download: boolean
 }
 
@@ -43,6 +45,7 @@ const NEW_JOB_DEFAULTS: JobFormState = {
   interval: '15m',
   max_adds: '200',
   max_removals: '25',
+  apply_large_removals: false,
   download: false,
 }
 
@@ -58,9 +61,21 @@ function formFromJob(job: SyncJob | null): JobFormState {
     interval: job.interval,
     max_adds: String(job.max_adds),
     max_removals: String(job.max_removals),
+    apply_large_removals: job.apply_large_removals,
     download: job.download,
   }
 }
+
+const INTERVAL_PRESETS: Array<{ value: string; label: string }> = [
+  { value: '15m', label: 'Every 15 minutes' },
+  { value: '30m', label: 'Every 30 minutes' },
+  { value: '1h', label: 'Every hour' },
+  { value: '2h', label: 'Every 2 hours' },
+  { value: '3h', label: 'Every 3 hours' },
+  { value: '6h', label: 'Every 6 hours' },
+  { value: '12h', label: 'Every 12 hours' },
+  { value: '24h', label: 'Once a day' },
+]
 
 // The wizard's five steps, in order. `intro` is the one friendly sentence
 // shown above each step's fields; `label` is what the stepper shows.
@@ -310,6 +325,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     interval: form.interval,
     max_adds: Number(form.max_adds) || 0,
     max_removals: Number(form.max_removals) || 0,
+    apply_large_removals: form.apply_large_removals,
     download: form.download,
   }
   const summaryRows = buildSyncSummaryRows(previewJob, syncPeers, settings?.DOWNLOAD_DIR)
@@ -329,6 +345,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
         interval: form.interval,
         max_adds: Number(form.max_adds),
         max_removals: Number(form.max_removals),
+        apply_large_removals: form.apply_large_removals,
         download: form.download,
       }
       if (job) await api.updateSync(job.id, values)
@@ -468,12 +485,16 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     : 'Paused, skipped by its schedule and by "Run all enabled". You can still sync it manually.'
                 }
               />
-              <TextField
+              <SelectField
                 label="Interval"
-                help="How often this sync runs automatically, e.g. 15m, 1h, 900."
+                help="How often this sync runs automatically."
                 value={form.interval}
                 onChange={(e) => setField('interval', e.target.value)}
-                error={!intervalValid ? 'Use a number optionally followed by s, m, or h, e.g. 15m.' : undefined}
+                options={
+                  INTERVAL_PRESETS.some((o) => o.value === form.interval)
+                    ? INTERVAL_PRESETS
+                    : [{ value: form.interval, label: form.interval || '(unset)' }, ...INTERVAL_PRESETS]
+                }
               />
             </>
           )}
@@ -509,6 +530,12 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     instead of writing it. You'll see held rows in the feed and can review before anything is lost.
                   </p>
                 </div>
+                <Toggle
+                  checked={form.apply_large_removals}
+                  onChange={(v) => setField('apply_large_removals', v)}
+                  label="Apply large removals"
+                  description="Off (default): removals beyond the cap are held back for safety. On: they're deleted in capped batches over successive passes until cleared."
+                />
               </div>
 
               <div className="border-t border-border pt-3.5">

--- a/frontend/src/components/transfers/TransferSetupForm.tsx
+++ b/frontend/src/components/transfers/TransferSetupForm.tsx
@@ -49,19 +49,9 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
   // Only sync/transfer peers can be an endpoint — browse-only services like
   // Jellyfin (a local mirror the download step feeds) are filtered out.
   const transferable = useMemo(() => accounts.filter((a) => a.transferable), [accounts])
-  const destProviderOptions = useMemo(
-    () => transferable.filter((a) => a.id !== sourceProvider),
-    [transferable, sourceProvider],
-  )
-
-  // A source change invalidates a same-provider destination selection —
-  // clear it rather than let a stale, now-hidden option linger.
-  useEffect(() => {
-    if (destProvider && destProvider === sourceProvider) {
-      setDestProvider('')
-      setDestPlaylistId('')
-    }
-  }, [sourceProvider, destProvider])
+  // Same-provider transfers are allowed (e.g. copy a followed Spotify list into a
+  // new owned Spotify playlist), so the destination service list isn't filtered.
+  const destProviderOptions = transferable
 
   // Default "create new"'s name to the source playlist's name — re-derives
   // whenever the source playlist or the create-new choice changes, but a
@@ -75,9 +65,20 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
   const sourcePlaylist = entries[sourceProvider]?.playlists.find((p) => p.id === sourcePlaylistId)
   const destPlaylist = destMode === 'existing' ? entries[destProvider]?.playlists.find((p) => p.id === destPlaylistId) : undefined
 
-  const formValid = Boolean(
-    sourceProvider && sourcePlaylistId && destProvider && (destMode === 'create' ? destName.trim() : destPlaylistId),
-  )
+  // A transfer writes tracks, so an existing destination must be a playlist you
+  // OWN — followed (read-only) playlists are excluded from the destination picker.
+  const destPlaylists = (entries[destProvider]?.playlists ?? []).filter((p) => p.owned !== false)
+
+  // Copying a playlist into itself is a no-op — block only the exact same-provider,
+  // same-id case; same-provider "Create new" (or a different existing list) is fine.
+  const sameTarget =
+    sourceProvider === destProvider &&
+    destMode === 'existing' &&
+    Boolean(destPlaylistId) &&
+    destPlaylistId === sourcePlaylistId
+  const formValid =
+    Boolean(sourceProvider && sourcePlaylistId && destProvider && (destMode === 'create' ? destName.trim() : destPlaylistId)) &&
+    !sameTarget
 
   async function handleStart() {
     setStarting(true)
@@ -214,7 +215,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                   <PlaylistPickerField
                     label="Existing playlist"
                     placeholder={destProvider ? 'Choose a playlist…' : 'Choose a destination service first'}
-                    playlists={entries[destProvider]?.playlists ?? []}
+                    playlists={destPlaylists}
                     loading={entries[destProvider]?.loading}
                     value={destPlaylistId}
                     disabled={!destProvider}
@@ -243,6 +244,11 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
           </div>
 
           {error && <p className="text-sm text-danger">{error}</p>}
+          {sameTarget && (
+            <p className="text-sm text-text-3">
+              That's the same playlist as the source. Pick a different destination, or choose "Create new".
+            </p>
+          )}
 
           <div>
             <Button onClick={() => setConfirming(true)} disabled={!formValid}>

--- a/frontend/src/components/ui/PlaylistPickerField.tsx
+++ b/frontend/src/components/ui/PlaylistPickerField.tsx
@@ -118,6 +118,43 @@ export function PlaylistPickerField({
     }
   }, [open])
 
+  // Only Spotify sets `owned` today; when a list mixes owned and followed we split
+  // it under Created/Followed headers, owned first. All-one-kind lists stay flat.
+  const ownedPlaylists = useMemo(() => filtered.filter((p) => p.owned !== false), [filtered])
+  const followedPlaylists = useMemo(() => filtered.filter((p) => p.owned === false), [filtered])
+  const grouped = ownedPlaylists.length > 0 && followedPlaylists.length > 0
+
+  const renderOption = (p: ProviderPlaylist) => {
+    const reason = optionDisabledReason?.(p)
+    return (
+      <button
+        key={p.id}
+        type="button"
+        role="option"
+        aria-selected={p.id === value}
+        aria-disabled={reason ? true : undefined}
+        disabled={Boolean(reason)}
+        title={reason}
+        onClick={() => select(p.id)}
+        className={cn(
+          'flex items-center gap-2.5 rounded-control px-2 py-1.5 text-left transition-colors duration-fast',
+          reason ? 'cursor-not-allowed opacity-50' : p.id === value ? 'bg-accent-soft' : 'hover:bg-surface-2',
+        )}
+      >
+        <CoverArt image={p.image} />
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">{p.name}</span>
+        {reason ? (
+          <span className="shrink-0 font-mono text-[10.5px] text-text-3">{reason}</span>
+        ) : (
+          formatTrackCount(p.count) && (
+            <span className="shrink-0 font-mono text-[11px] text-text-3">{formatTrackCount(p.count)}</span>
+          )
+        )}
+        {p.id === value && <LuCheck className="size-3.5 shrink-0 text-accent" aria-hidden="true" />}
+      </button>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-1.5">
       <label htmlFor={fieldId} className="text-[12.5px] font-semibold text-text-2">
@@ -182,41 +219,19 @@ export function PlaylistPickerField({
             <div id={listboxId} role="listbox" aria-label={label} className="thin-scrollbar flex max-h-56 flex-col gap-0.5 overflow-y-auto">
               {filtered.length === 0 ? (
                 <p className="px-2 py-3 text-center text-xs text-text-3">No playlists match "{search}".</p>
+              ) : grouped ? (
+                <>
+                  <div className="px-2 pb-0.5 pt-1 font-mono text-[9.5px] font-bold uppercase tracking-[0.12em] text-text-3">
+                    Created
+                  </div>
+                  {ownedPlaylists.map(renderOption)}
+                  <div className="mt-1 border-t border-border px-2 pb-0.5 pt-2 font-mono text-[9.5px] font-bold uppercase tracking-[0.12em] text-text-3">
+                    Followed
+                  </div>
+                  {followedPlaylists.map(renderOption)}
+                </>
               ) : (
-                filtered.map((p) => {
-                  const reason = optionDisabledReason?.(p)
-                  return (
-                    <button
-                      key={p.id}
-                      type="button"
-                      role="option"
-                      aria-selected={p.id === value}
-                      aria-disabled={reason ? true : undefined}
-                      disabled={Boolean(reason)}
-                      title={reason}
-                      onClick={() => select(p.id)}
-                      className={cn(
-                        'flex items-center gap-2.5 rounded-control px-2 py-1.5 text-left transition-colors duration-fast',
-                        reason
-                          ? 'cursor-not-allowed opacity-50'
-                          : p.id === value
-                            ? 'bg-accent-soft'
-                            : 'hover:bg-surface-2',
-                      )}
-                    >
-                      <CoverArt image={p.image} />
-                      <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">{p.name}</span>
-                      {reason ? (
-                        <span className="shrink-0 font-mono text-[10.5px] text-text-3">{reason}</span>
-                      ) : (
-                        formatTrackCount(p.count) && (
-                          <span className="shrink-0 font-mono text-[11px] text-text-3">{formatTrackCount(p.count)}</span>
-                        )
-                      )}
-                      {p.id === value && <LuCheck className="size-3.5 shrink-0 text-accent" aria-hidden="true" />}
-                    </button>
-                  )
-                })
+                filtered.map(renderOption)
               )}
             </div>
           </div>,

--- a/frontend/src/lib/syncSummary.ts
+++ b/frontend/src/lib/syncSummary.ts
@@ -74,7 +74,8 @@ export function buildSyncSummaryRows(job: SyncJob, peers: Account[], downloadDir
   else playlistsValue = `${playlistNames.slice(0, 3).join(', ')} +${playlistNames.length - 3} more`
   rows.push({ label: 'Playlists', value: playlistsValue })
 
-  rows.push({ label: 'Limits', value: `≤${job.max_adds} adds, ≤${job.max_removals} removals / pass` })
+  const removalNote = job.apply_large_removals ? ' (large removals drained in batches)' : ''
+  rows.push({ label: 'Limits', value: `≤${job.max_adds} adds, ≤${job.max_removals} removals / pass${removalNote}` })
 
   rows.push({
     label: 'Downloads',

--- a/frontend/src/pages/Sync.tsx
+++ b/frontend/src/pages/Sync.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from 'react'
 import { LuPlus } from 'react-icons/lu'
 
+import { LiveFeed } from '@/components/dashboard/LiveFeed'
 import { SyncJobCard } from '@/components/sync/SyncJobCard'
 import { SyncWizard } from '@/components/sync/SyncWizard'
 import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { LoadingStatus, Skeleton } from '@/components/ui/Skeleton'
 import { useAccounts } from '@/hooks/useAccounts'
@@ -74,6 +76,7 @@ export default function Sync() {
               running={status?.jobs.find((j) => j.id === job.id)?.running ?? false}
               queued={status?.jobs.find((j) => j.id === job.id)?.queued ?? false}
               paused={status?.jobs.find((j) => j.id === job.id)?.paused ?? false}
+              pending={status?.jobs.find((j) => j.id === job.id)?.pending ?? null}
               onEdit={() => openEdit(job)}
               onChanged={refreshAll}
             />
@@ -89,6 +92,12 @@ export default function Sync() {
             </Button>
           }
         />
+      )}
+
+      {syncs && syncs.length > 0 && (
+        <Card className="p-4 sm:p-5">
+          <LiveFeed />
+        </Card>
       )}
 
       <SyncWizard

--- a/frontend/src/pages/Sync.tsx
+++ b/frontend/src/pages/Sync.tsx
@@ -73,6 +73,7 @@ export default function Sync() {
               peers={peers}
               running={status?.jobs.find((j) => j.id === job.id)?.running ?? false}
               queued={status?.jobs.find((j) => j.id === job.id)?.queued ?? false}
+              paused={status?.jobs.find((j) => j.id === job.id)?.paused ?? false}
               onEdit={() => openEdit(job)}
               onChanged={refreshAll}
             />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -102,6 +102,9 @@ export interface SyncJobStatus {
   queued: boolean
   /** Its last pass was cut short by Pause and can be resumed (re-run). */
   paused: boolean
+  /** While running, a pause/stop requested but not yet in effect (it halts at the
+   * next checkpoint) — drives the "Pausing…" / "Stopping…" label. */
+  pending: 'pause' | 'stop' | null
   next_run_at: number | null
   last: PassSummary | null
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -73,6 +73,9 @@ export interface TargetSummary {
   missing: number
   held: number
   deferred: number
+  /** Removals held back this pass because they exceeded max_removals and the sync
+   * hasn't opted into draining them — surfaced so the skip isn't silent. */
+  removals_skipped: number
   created: number
   skipped: number
 }
@@ -142,6 +145,9 @@ export interface SyncJob {
   interval: string
   max_adds: number
   max_removals: number
+  /** When true, removals over max_removals drain in capped batches across passes
+   * instead of being held back. Default false (held back for safety). */
+  apply_large_removals: boolean
   download: boolean
 }
 
@@ -182,6 +188,9 @@ export interface ProviderPlaylist {
   name: string
   count: number | null
   image: string
+  /** False for a followed (non-owned) playlist. Only Spotify distinguishes the
+   * two today; absent/true elsewhere. Drives the Created/Followed grouping. */
+  owned?: boolean
 }
 
 export type LinkDirection = 'oneway' | 'nway'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -100,6 +100,8 @@ export interface SyncJobStatus {
   /** Triggered but waiting behind the currently-running pass (passes are
    * serialized). Drives the "Queued" badge. */
   queued: boolean
+  /** Its last pass was cut short by Pause and can be resumed (re-run). */
+  paused: boolean
   next_run_at: number | null
   last: PassSummary | null
 }

--- a/omni_sync/engine/archive.py
+++ b/omni_sync/engine/archive.py
@@ -64,6 +64,18 @@ CREATE TABLE IF NOT EXISTS playlist_state (
     PRIMARY KEY (playlist, source, canonical_id)
 )
 """,
+    # Ordered per-provider snapshots of each playlist, kept as a short history.
+    # A recovery / forensics trail (what did this playlist look like, in order,
+    # and when) — the sync logic itself never reads these back.
+    """
+CREATE TABLE IF NOT EXISTS playlist_order (
+    playlist    TEXT NOT NULL,
+    source      TEXT NOT NULL,
+    captured_at TEXT NOT NULL,
+    tracks      TEXT NOT NULL,
+    PRIMARY KEY (playlist, source, captured_at)
+)
+""",
 ]
 
 UPSERT = """
@@ -179,6 +191,37 @@ def get_isrcs(conn, source, ids):
         conn, "SELECT id, isrc FROM songs WHERE source = ? AND isrc IS NOT NULL AND id IN ({marks})",
         [source], ids)
     return {k: v for k, v in got.items() if v}
+
+
+ORDER_HISTORY_KEEP = 12
+
+
+def record_order(conn, playlist, source, entries):
+    """Append one ordered snapshot ([[track_id, name, artist], ...]) of a
+    provider's playlist — skipped when identical to the newest stored one, and
+    pruned to the last ORDER_HISTORY_KEEP per (playlist, source)."""
+    payload = json.dumps(entries, ensure_ascii=False)
+    last = conn.execute(
+        "SELECT tracks FROM playlist_order WHERE playlist = ? AND source = ? "
+        "ORDER BY captured_at DESC LIMIT 1", (playlist, source)).fetchone()
+    if last and last[0] == payload:
+        return
+    conn.execute("INSERT OR REPLACE INTO playlist_order VALUES (?, ?, ?, ?)",
+                 (playlist, source, _now(), payload))
+    conn.execute(
+        "DELETE FROM playlist_order WHERE playlist = ? AND source = ? AND captured_at NOT IN ("
+        "SELECT captured_at FROM playlist_order WHERE playlist = ? AND source = ? "
+        "ORDER BY captured_at DESC LIMIT ?)",
+        (playlist, source, playlist, source, ORDER_HISTORY_KEEP))
+    conn.commit()
+
+
+def get_order_history(conn, playlist, source):
+    """[(captured_at, [[track_id, name, artist], ...]), ...] newest first."""
+    rows = conn.execute(
+        "SELECT captured_at, tracks FROM playlist_order WHERE playlist = ? AND source = ? "
+        "ORDER BY captured_at DESC", (playlist, source))
+    return [(ts, json.loads(t)) for ts, t in rows.fetchall()]
 
 
 def get_playlist_state(conn, playlist, source):

--- a/omni_sync/engine/archive.py
+++ b/omni_sync/engine/archive.py
@@ -236,3 +236,11 @@ def set_playlist_state(conn, playlist, source, canonical_ids):
     conn.executemany("INSERT OR IGNORE INTO playlist_state VALUES (?, ?, ?)",
                      [(playlist, source, cid) for cid in canonical_ids])
     conn.commit()
+
+
+def clear_playlist_state(conn, playlist):
+    """Drop a playlist's stored N-way baselines (every source) — the next pass
+    re-bootstraps from what's actually on each provider, so out-of-band edits
+    (e.g. the duplicate cleanup) are never read back as user deletions."""
+    conn.execute("DELETE FROM playlist_state WHERE playlist = ?", (playlist,))
+    conn.commit()

--- a/omni_sync/engine/config.py
+++ b/omni_sync/engine/config.py
@@ -68,6 +68,7 @@ class Options:
     providers: str = DEFAULT_PROVIDERS
     sync_source: str = DEFAULT_SYNC_SOURCE
     spotify_cache_file: str = DEFAULT_SPOTIFY_CACHE_FILE
+    apply_large_removals: bool = False
 
 
 def parse_args(argv=None):
@@ -85,6 +86,9 @@ def parse_args(argv=None):
                    help=f"Per-playlist removal cap per pass; more than this skips removals (default: {DEFAULT_MAX_REMOVALS}).")
     p.add_argument("--max-adds", type=int, default=int(os.getenv("MAX_ADDS", DEFAULT_MAX_ADDS)),
                    help=f"Per-playlist additions cap per pass; the rest continue next pass (default: {DEFAULT_MAX_ADDS}).")
+    p.add_argument("--apply-large-removals", action="store_true", default=os.getenv("APPLY_LARGE_REMOVALS") == "1",
+                   help="Drain removals over --max-removals in batches across passes instead of holding "
+                        "them back (default: held back for safety).")
     p.add_argument("--download-dir", default=os.getenv("DOWNLOAD_DIR", ""),
                    help="Also mirror the paired playlists to local audio files under this folder (requires --execute).")
     p.add_argument("--refresh-local", action="store_true",
@@ -117,4 +121,5 @@ def parse_args(argv=None):
         storefront=a.storefront, cache_file=a.cache_file, song_cache_file=a.song_cache_file,
         refresh_local=a.refresh_local, sync_mode=a.sync_mode, providers=a.providers,
         sync_source=a.sync_source, spotify_cache_file=a.spotify_cache_file,
+        apply_large_removals=a.apply_large_removals,
     )

--- a/omni_sync/engine/dedupe.py
+++ b/omni_sync/engine/dedupe.py
@@ -1,0 +1,239 @@
+"""One-shot cleanup of duplicate playlist copies left by identity splits.
+
+Runs the reconciler's own identity pipeline (per-entry canonical ids, key2isrc
+seeding, alias unification) over each provider's current read, then flags every
+physical entry whose unified identity repeats an earlier entry's. Removing
+those copies never changes canonical membership — at least one copy of each
+identity stays on each provider it was on — so the cleanup is invisible to the
+N-way merge and can never cascade a removal to another provider.
+
+Separately, `variant_pairs` REPORTS (never removes) hard-id twins: two distinct
+recordings of what fuzzy-matching says is one song (live / instrumental /
+re-release vs the original — the residue a mis-resolved search add leaves).
+Removing one of those IS a membership change, so it stays a human decision.
+
+CLI (report by default; inside the container prefix with `docker exec`):
+    uv run python -m omni_sync.engine.dedupe [--playlists a,b] [--variants]
+    uv run python -m omni_sync.engine.dedupe --execute
+"""
+
+from . import archive
+from .matching import fuzzy_in, loose_name, romanized, spotify_track_keys, track_key
+from .targets.base import _entry_cids, _unify_aliases
+
+# Words that mark a DIFFERENT RECORDING of the same song. Alias unification is
+# deliberately version-blind (folding "Song (Live)" into "Song" keeps the sync
+# from re-propagating provider-local variants), but a DELETION across such a
+# boundary would destroy a real recording — e.g. a studio track flagged as a
+# "copy" of a live video that happened to fold into it.
+VERSION_MARKERS = frozenset((
+    "live", "instrumental", "acoustic", "unplugged", "remix", "mix", "karaoke",
+    "demo", "cover", "sped", "slowed", "nightcore", "reverb", "orchestral",
+    "stripped", "remaster", "remastered", "edit", "version", "ver", "mono", "8d",
+))
+
+
+def _markers(name):
+    return VERSION_MARKERS.intersection(loose_name(name).split())
+
+
+def _order_rows(peer, raw):
+    return [[peer.track_id(t), t.get("name", ""),
+             t.get("artist") or ", ".join(t.get("artists") or [])] for t in raw]
+
+
+def scan(peers, playlists, caches, songs, state_key):
+    """Read every peer once and unify identities across them.
+
+    Returns (entries, canon): entries = {source: [(unified_cid, raw, norm)]} in
+    playlist order; canon = {source: {unified_cid: norm}}. Also snapshots each
+    provider's current order into the archive (the pre-cleanup record)."""
+    key2isrc, per_entry, canon, raws = {}, {}, {}, {}
+    for p in peers:
+        raw = p.playlist_tracks(playlists[p.source])
+        raws[p.source] = raw
+        archive.record_order(songs, state_key, p.source, _order_rows(p, raw))
+        ec = _entry_cids(p, raw, songs, caches[p.source], key2isrc)
+        per_entry[p.source] = ec
+        fold = {}
+        for cid, norm in ec:
+            fold.setdefault(cid, norm)
+        canon[p.source] = fold
+        for cid, norm in ec:
+            if cid.startswith("i:"):
+                key2isrc.setdefault(track_key(norm["name"], norm["artist"]), cid[2:])
+    alias = _unify_aliases(canon)
+    entries = {}
+    for p in peers:
+        src = p.source
+        entries[src] = [(alias.get(cid, cid), cid, raw_t, norm)
+                        for (cid, norm), raw_t in zip(per_entry[src], raws[src])]
+        merged = {}
+        for cid, norm in canon[src].items():
+            merged.setdefault(alias.get(cid, cid), norm)
+        canon[src] = merged
+    return entries, canon
+
+
+def dup_plan(peers, entries):
+    """(plan, held): plan = {source: [(index, unified_cid, raw, norm)]} — every
+    physical copy after the first of its identity, in playlist order (first
+    copy = oldest add, so the original stays and the re-added copy goes).
+
+    A later copy is removable only when it is provably the SAME RECORDING as
+    the kept one: identical pre-unification identity, or matching version
+    markers (a copy that only fuzzy-folded into its keeper across a
+    live/remix/... boundary lands in `held` instead — report, never remove).
+    Entries with no usable track id, or with neither a name nor an artist
+    (unidentifiable reads that would collide on an empty key), are never
+    flagged."""
+    plan, held = {}, {}
+    for p in peers:
+        seen, dups, kept = {}, [], []
+        for idx, (cid, pre, raw, norm) in enumerate(entries[p.source]):
+            if not p.track_id(raw) or not (norm["name"] or norm["artist"]):
+                continue
+            if cid not in seen:
+                seen[cid] = (pre, norm)
+                continue
+            keeper_pre, keeper_norm = seen[cid]
+            if pre == keeper_pre or _markers(norm["name"]) == _markers(keeper_norm["name"]):
+                dups.append((idx, cid, raw, norm))
+            else:
+                kept.append((idx, cid, raw, norm))
+        plan[p.source], held[p.source] = dups, kept
+    return plan, held
+
+
+def apply(peers, playlists, caches, songs, state_key, plan):
+    """Execute a dup_plan: remove the flagged copies, clear the playlist's
+    stored N-way baseline (so the next pass re-bootstraps from the cleaned
+    reality instead of reading the removals as user deletions), then re-read
+    and snapshot each provider. Returns {source: (removed, count_after)}."""
+    out = {}
+    for p in peers:
+        dups = plan.get(p.source) or []
+        if dups:
+            p.remove_occurrences(playlists[p.source], [(i, raw) for i, _, raw, _ in dups])
+        out[p.source] = [len(dups), None]
+    if any(n for n, _ in out.values()):
+        archive.clear_playlist_state(songs, state_key)
+    for p in peers:
+        raw = p.playlist_tracks(playlists[p.source])
+        archive.record_order(songs, state_key, p.source, _order_rows(p, raw))
+        out[p.source][1] = len(raw)
+    return {src: tuple(v) for src, v in out.items()}
+
+
+def variant_pairs(canon):
+    """[(cid_a, cid_b, srcs_a, srcs_b)] — pairs of DISTINCT hard identities that
+    fuzzy-match as the same song, where at least one side is missing from some
+    provider (twins fully mirrored everywhere are a long-standing choice, not
+    debris). Report-only: which recording belongs is a human call.
+
+    Candidates are bucketed by the title's first token before the quadratic
+    fuzzy comparison — variants share their title head, and full pairwise over
+    a 1000+-track playlist would take minutes."""
+    keysets, srcs, buckets = {}, {}, {}
+    for src, by_cid in canon.items():
+        for cid, norm in by_cid.items():
+            if cid.startswith("k:"):
+                continue
+            if cid not in keysets:
+                keysets[cid] = {k.replace("|", " ") for k in spotify_track_keys(norm)}
+                keysets[cid] |= {romanized(k) for k in keysets[cid]}
+                name_toks = track_key(norm["name"], "").split("|")[0].split()
+                buckets.setdefault(name_toks[0] if name_toks else "", []).append(cid)
+            srcs.setdefault(cid, set()).add(src)
+    n_sources = len(canon)
+    pairs = []
+    for cids in buckets.values():
+        cids.sort()
+        for i, a in enumerate(cids):
+            for b in cids[i + 1:]:
+                if len(srcs[a]) == n_sources and len(srcs[b]) == n_sources:
+                    continue
+                if any(fuzzy_in(q, keysets[b]) for q in keysets[a]):
+                    pairs.append((a, b, sorted(srcs[a]), sorted(srcs[b])))
+    return pairs
+
+
+def _main(argv=None):
+    import argparse
+    import os
+
+    from dotenv import load_dotenv
+
+    from . import spotify
+    from .config import (DEFAULT_CACHE_FILE, DEFAULT_PROVIDERS, DEFAULT_SONG_CACHE_FILE,
+                         DEFAULT_SPOTIFY_CACHE_FILE, DEFAULT_STOREFRONT)
+    from .runner import load_cache
+    from .targets import build_peers
+
+    ap = argparse.ArgumentParser(
+        prog="python -m omni_sync.engine.dedupe",
+        description="Find (and with --execute remove) duplicate playlist copies left by identity splits.")
+    ap.add_argument("--execute", action="store_true",
+                    help="Remove the duplicate copies (default: report only).")
+    ap.add_argument("--playlists", default="",
+                    help="Comma-separated names (default: every N-way-managed playlist).")
+    ap.add_argument("--variants", action="store_true",
+                    help="Also report variant twins — distinct recordings that fuzzy-match as one song.")
+    args = ap.parse_args(argv)
+
+    load_dotenv(os.getenv("OMNI_ENV_FILE") or ".env", override=True)
+
+    class _Opts:  # just the fields the peer builders read
+        providers = os.getenv("PROVIDERS", DEFAULT_PROVIDERS)
+        storefront = os.getenv("APPLE_STOREFRONT") or DEFAULT_STOREFRONT
+        cache_file = os.getenv("APPLE_CACHE_FILE", DEFAULT_CACHE_FILE)
+        spotify_cache_file = os.getenv("SPOTIFY_CACHE_FILE", DEFAULT_SPOTIFY_CACHE_FILE)
+
+    sp = spotify.client(writable=args.execute)
+    peers = build_peers(_Opts(), sp)
+    songs = archive.connect(os.getenv("SONG_CACHE_FILE", DEFAULT_SONG_CACHE_FILE))
+    caches = {p.source: load_cache(p.cache_file) for p in peers}
+    dirs = {p.source: p.list_playlists() for p in peers}
+
+    managed = {r[0] for r in songs.execute("SELECT DISTINCT playlist FROM playlist_state")}
+    wanted = {n.strip().casefold() for n in args.playlists.split(",") if n.strip()} or managed
+
+    total = 0
+    for key in sorted(wanted):
+        playlists = {src: d[key] for src, d in dirs.items() if d.get(key)}
+        active = [p for p in peers if p.source in playlists]
+        if not active:
+            continue
+        entries, canon = scan(active, playlists, caches, songs, key)
+        plan, held = dup_plan(active, entries)
+        n = sum(len(v) for v in plan.values())
+        total += n
+        print(f"\n== {key} ==" + ("" if n else "  (no duplicate copies)"))
+        for p in active:
+            for idx, cid, raw, norm in plan[p.source]:
+                print(f"  {p.source:8} #{idx + 1:<4} {norm['name']} - {norm['artist']}   [{cid}]")
+            for idx, cid, raw, norm in held[p.source]:
+                print(f"  {p.source:8} #{idx + 1:<4} KEPT (version differs from its twin): "
+                      f"{norm['name']} - {norm['artist']}   [{cid}]")
+        if n and args.execute:
+            result = apply(active, playlists, caches, songs, key, plan)
+            for src, (removed, after) in sorted(result.items()):
+                print(f"  -> {src}: removed {removed}, {after} tracks now")
+        if args.variants:
+            lookup = {}
+            for by_cid in canon.values():
+                for cid, norm in by_cid.items():
+                    lookup.setdefault(cid, norm)
+            vps = variant_pairs(canon)
+            if vps:
+                print(f"  -- {len(vps)} variant twin(s), report only --")
+                for a, b, sa, sb in vps:
+                    la, lb = lookup[a], lookup[b]
+                    print(f"     {la['name']} - {la['artist']}   [{','.join(sa)}]")
+                    print(f"       ~ {lb['name']} - {lb['artist']}   [{','.join(sb)}]")
+    print(f"\n{'removed' if args.execute else 'would remove'} {total} duplicate cop"
+          f"{'y' if total == 1 else 'ies'} across {len(wanted)} playlist(s)")
+
+
+if __name__ == "__main__":
+    _main()

--- a/omni_sync/engine/downloads.py
+++ b/omni_sync/engine/downloads.py
@@ -649,7 +649,7 @@ def refresh(sp, spotify_playlists, download_dir):
         log_warn(f"refresh failed: {e!r}", tag="local")
 
 
-def run(sp, spotify_playlists, download_dir):
+def run(sp, spotify_playlists, download_dir, should_continue=None):
     """Never raises out; logs one skip line if spotdl/ffmpeg aren't set up.
 
     Per-playlist download state (Spotify snapshot_id, track ids, and the set of
@@ -676,6 +676,8 @@ def run(sp, spotify_playlists, download_dir):
         dirty = False
         used = set()
         for playlist in spotify_playlists:
+            if should_continue and should_continue() != "run":
+                break  # Stop/Pause requested — halt before the next download
             name = playlist.get("name") or playlist.get("id", "playlist")
             pid = playlist.get("id", "")
             folder = _folder_for(base, playlist, used)

--- a/omni_sync/engine/runner.py
+++ b/omni_sync/engine/runner.py
@@ -47,7 +47,7 @@ def save_cache(cache_file, cache):
         json.dump({"isrc": cache["isrc"], "search": cache["search"]}, f, indent=1)
 
 
-_SUMMARY_KEYS = ("added", "removed", "missing", "held", "deferred", "created", "skipped")
+_SUMMARY_KEYS = ("added", "removed", "missing", "held", "deferred", "removals_skipped", "created", "skipped")
 
 
 def _summary_entry(name, agg):
@@ -88,7 +88,7 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
     path (empty `links` => byte-for-byte unchanged when the source is Spotify)."""
     src_key = source.source
     agg = {"name": target.name, "pairs": 0, "added": 0, "removed": 0,
-           "missing": 0, "held": 0, "skipped": 0, "created": 0}
+           "missing": 0, "held": 0, "removals_skipped": 0, "skipped": 0, "created": 0}
     cache = load_cache(target.cache_file)
     try:
         tgt_by_name = target.list_playlists()
@@ -136,10 +136,11 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                 res = mirror_pair(
                     target, get_source_tracks(sp_playlist), sp_playlist, tgt, cache, songs,
                     execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
+                    drain_removals=opts.apply_large_removals,
                     source_key=src_key, source_name=source.name, name=name,
                 )
                 agg["pairs"] += 1
-                for k in ("added", "removed", "missing", "held"):
+                for k in ("added", "removed", "missing", "held", "removals_skipped"):
                     agg[k] += res[k]
                 if res["clean"] and snapshot:
                     archive.set_state(songs, state_key, target.source, snapshot, res["target_count"])
@@ -339,7 +340,7 @@ def _run_nway(opts, sp, selected, songs):
 
     dirs = {p.source: p.list_playlists() for p in peers}
     caches = {p.source: load_cache(p.cache_file) for p in peers}
-    total = {"added": 0, "removed": 0, "missing": 0, "held": 0, "deferred": 0}
+    total = {"added": 0, "removed": 0, "missing": 0, "held": 0, "deferred": 0, "removals_skipped": 0}
     try:
         for sp_playlist in selected:
             name = sp_playlist["name"]
@@ -370,7 +371,8 @@ def _run_nway(opts, sp, selected, songs):
                 continue
             try:
                 stats = reconcile(active, name, playlists, caches, songs,
-                                  execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds)
+                                  execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
+                                  drain_removals=opts.apply_large_removals)
                 for k in total:
                     total[k] += stats.get(k, 0)
             except TargetAuthError:

--- a/omni_sync/engine/runner.py
+++ b/omni_sync/engine/runner.py
@@ -139,7 +139,7 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                 res = mirror_pair(
                     target, get_source_tracks(sp_playlist), sp_playlist, tgt, cache, songs,
                     execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
-                    drain_removals=opts.apply_large_removals,
+                    drain_removals=opts.apply_large_removals, should_continue=should_continue,
                     source_key=src_key, source_name=source.name, name=name,
                 )
                 agg["pairs"] += 1
@@ -386,7 +386,7 @@ def _run_nway(opts, sp, selected, songs, should_continue=None):
             try:
                 stats = reconcile(active, name, playlists, caches, songs,
                                   execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
-                                  drain_removals=opts.apply_large_removals)
+                                  drain_removals=opts.apply_large_removals, should_continue=should_continue)
                 for k in total:
                     total[k] += stats.get(k, 0)
             except TargetAuthError:

--- a/omni_sync/engine/runner.py
+++ b/omni_sync/engine/runner.py
@@ -57,7 +57,7 @@ def _summary_entry(name, agg):
     return entry
 
 
-def _summary(opts, per_target, started, *, ok=True, error=None):
+def _summary(opts, per_target, started, *, ok=True, error=None, interrupted=None):
     """The value the web layer renders after a pass. The CLI ignores it."""
     return {
         "mode": opts.sync_mode,
@@ -65,6 +65,7 @@ def _summary(opts, per_target, started, *, ok=True, error=None):
         "duration_s": round(time.monotonic() - started, 1),
         "ok": ok,
         "error": error,
+        "interrupted": interrupted,  # "pause" | "stop" when a Stop/Pause cut the pass short
         "per_target": per_target,
     }
 
@@ -77,7 +78,7 @@ def _load_links():
     return [link for link in LinkStore().list() if link.enabled]
 
 
-def run_target(target, selected, get_source_tracks, songs, opts, links=None, source=None):
+def run_target(target, selected, get_source_tracks, songs, opts, links=None, source=None, should_continue=None):
     """Mirror every selected source playlist to one target. Returns an aggregate
     dict. Raises TargetAuthError to abort the whole target (fail closed).
 
@@ -96,6 +97,8 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
         link_by_src = {link.members[src_key]: link for link in (links or [])
                        if link.members.get(src_key) and target.source in link.members}
         for sp_playlist in selected:
+            if should_continue and should_continue() != "run":
+                break  # Stop/Pause requested — leave the rest for a re-run
             name = source.playlist_name(sp_playlist)
             link = link_by_src.get(source.playlist_id(sp_playlist))
             state_key = link.id if link else name.strip().casefold()
@@ -153,8 +156,12 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
     return agg
 
 
-def run_pass(opts):
+def run_pass(opts, should_continue=None):
     pass_started = time.monotonic()
+    # Pause/Stop hook: should_continue() returns "run" | "pause" | "stop"; the pass
+    # checks it between playlists and halts, keeping what's already applied. Absent
+    # (CLI / direct calls) ctrl() is always "run", so behaviour is unchanged.
+    ctrl = should_continue or (lambda: "run")
     # The web app points OMNI_ENV_FILE at SettingsStore's managed file so wizard
     # saves win; the headless CLI falls back to a plain .env. Either way this
     # picks up re-captured tokens without a restart.
@@ -204,11 +211,13 @@ def run_pass(opts):
     if opts.sync_mode == "nway":
         songs = archive.connect(opts.song_cache_file)
         try:
-            per_target = _run_nway(opts, sp, selected, songs)
+            per_target = _run_nway(opts, sp, selected, songs, ctrl)
         finally:
             songs.close()
-        _post_sync(opts, sp, selected)
-        return _summary(opts, per_target, pass_started)
+        c = ctrl()
+        if c == "run":
+            _post_sync(opts, sp, selected, should_continue=ctrl)
+        return _summary(opts, per_target, pass_started, interrupted=(None if c == "run" else c))
 
     targets = build_targets(opts, sp)
     if not targets:
@@ -262,7 +271,7 @@ def run_pass(opts):
 
     def worker(target):
         try:
-            results[target.tag] = run_target(target, selected, get_source_tracks, songs, opts, links, source)
+            results[target.tag] = run_target(target, selected, get_source_tracks, songs, opts, links, source, ctrl)
         except BaseException as e:  # surface after siblings finish
             errors.append((target, e))
 
@@ -299,11 +308,14 @@ def run_pass(opts):
         if isinstance(err, TargetAuthError):
             raise err  # fatal; main() decides exit vs. loop-continue
 
-    _post_sync(opts, sp, selected, source_is_spotify=src_is_spotify)
-    return _summary(opts, [_summary_entry(a["name"], a) for a in results.values()], pass_started)
+    c = ctrl()
+    if c == "run":
+        _post_sync(opts, sp, selected, source_is_spotify=src_is_spotify, should_continue=ctrl)
+    return _summary(opts, [_summary_entry(a["name"], a) for a in results.values()], pass_started,
+                    interrupted=(None if c == "run" else c))
 
 
-def _post_sync(opts, sp, selected, source_is_spotify=True):
+def _post_sync(opts, sp, selected, source_is_spotify=True, should_continue=None):
     """Local download mirror + Jellyfin covers — shared by one-way and N-way.
     Both read Spotify playlist data (spotDL by Spotify track; covers from Spotify
     art), so they run only when Spotify is the source; a note flags the skip."""
@@ -316,7 +328,7 @@ def _post_sync(opts, sp, selected, source_is_spotify=True):
         try:
             from . import downloads
 
-            downloads.run(sp, selected, opts.download_dir)
+            downloads.run(sp, selected, opts.download_dir, should_continue=should_continue)
         except Exception as e:
             log_warn(f"local download mirror failed (playlist sync unaffected): {e!r}", tag="local")
 
@@ -327,7 +339,7 @@ def _post_sync(opts, sp, selected, source_is_spotify=True):
         jellyfin.push_covers(selected)
 
 
-def _run_nway(opts, sp, selected, songs):
+def _run_nway(opts, sp, selected, songs, should_continue=None):
     """Bidirectional reconcile: each selected playlist across all peer providers,
     sequentially (each reconcile reads then writes every peer). A change on any
     provider propagates to the others via the stored canonical snapshot."""
@@ -343,6 +355,8 @@ def _run_nway(opts, sp, selected, songs):
     total = {"added": 0, "removed": 0, "missing": 0, "held": 0, "deferred": 0, "removals_skipped": 0}
     try:
         for sp_playlist in selected:
+            if should_continue and should_continue() != "run":
+                break  # Stop/Pause requested — leave the rest for a re-run
             name = sp_playlist["name"]
             key = name.strip().casefold()
             playlists = {}

--- a/omni_sync/engine/spotify.py
+++ b/omni_sync/engine/spotify.py
@@ -107,6 +107,26 @@ def playlists_by_name(sp):
     return {name: playlist for name, (rank, playlist) in best.items()}
 
 
+def all_playlists(sp):
+    """Every library playlist (owned AND followed), un-deduped, each annotated with
+    `_owned` (its owner is the current user). playlists_by_name collapses by name
+    for the sync engine's name-matching; browsing and transfers need the full,
+    id-addressable list so a followed playlist that shares a name with an owned one
+    stays reachable and can be labelled as followed."""
+    me = _retry(lambda: sp.current_user(), "current_user")["id"]
+    out = []
+    results = _retry(lambda: sp.current_user_playlists(limit=50), "playlists")
+    while results:
+        for playlist in results.get("items", []):
+            if not playlist:
+                continue
+            playlist["_owned"] = (playlist.get("owner") or {}).get("id") == me
+            out.append(playlist)
+        page = results
+        results = _retry(lambda: sp.next(page), "playlists page") if results.get("next") else None
+    return out
+
+
 def playlist_item_track(item):
     """The track object of a playlist item, handling both the legacy shape
     ({"track": {...}}) and the current Web API shape ({"item": {...}}). Returns

--- a/omni_sync/engine/targets/apple.py
+++ b/omni_sync/engine/targets/apple.py
@@ -273,3 +273,32 @@ class AppleMusicTarget(MirrorTarget):
         self._request("DELETE", f"{AMP}/me/library/playlists/{playlist['id']}/tracks",
                      params={"ids[library-songs]": track["relationship_id"], "mode": "all"})
         polite_sleep(0.4)
+
+    def remove_occurrences(self, playlist, positioned):
+        """Apple's tracks-DELETE addresses the library SONG, not one entry —
+        duplicate copies share one library id, so deleting a flagged copy would
+        take its keeper with it. Delete each flagged song once, then re-append
+        one copy per surviving (unflagged) entry of that song. The re-appended
+        keeper lands at the playlist's end (Apple has no positional insert); if
+        its catalog id is no longer addable (delisted release), the next sync
+        pass restores the song via search."""
+        totals = {}
+        for t in self.playlist_tracks(playlist):
+            rid = t.get("relationship_id")
+            totals[rid] = totals.get(rid, 0) + 1
+        flagged, catalog = {}, {}
+        for _, raw in positioned:
+            rid = raw.get("relationship_id")
+            if not rid:
+                continue
+            flagged[rid] = flagged.get(rid, 0) + 1
+            catalog.setdefault(rid, raw.get("catalog_id"))
+        for rid, n in flagged.items():
+            self.remove(playlist, {"relationship_id": rid})
+            keep = totals.get(rid, n) - n
+            if keep > 0 and catalog.get(rid):
+                try:
+                    self.add(playlist, [catalog[rid]] * keep)
+                except Exception as e:
+                    log_warn(f"couldn't re-append the kept copy of {catalog[rid]} ({e!r}); "
+                             "the next sync pass restores it via search", tag=self.tag)

--- a/omni_sync/engine/targets/base.py
+++ b/omni_sync/engine/targets/base.py
@@ -65,6 +65,23 @@ class MirrorTarget:
         """Stable id of a library playlist, for explicit pairing lookups."""
         return playlist.get("id")
 
+    def find_playlist(self, playlist_id):
+        """A library playlist by its stable id, or None. Default scans the
+        name-keyed list_playlists(); a provider whose list_playlists() dedupes by
+        name (Spotify) overrides this to scan its full, un-deduped set so a followed
+        playlist stays reachable by id."""
+        return next((pl for pl in self.browse_playlists()
+                     if self.playlist_id(pl) == playlist_id), None)
+
+    def browse_playlists(self):
+        """All library playlists for the browse / transfer pickers, as a flat list
+        (NOT name-deduped like list_playlists). Each dict may carry `_owned`
+        (treated as True when absent). Override for a provider that also exposes
+        followed / non-owned playlists — see SpotifyTarget. The browse layer reads
+        name/id/count/image off these via the target's own accessors, so a new
+        provider needs no change to services.playlists.browse."""
+        return list(self.list_playlists().values())
+
     def playlist_name(self, playlist):
         """Display name of a library playlist (for transfers / labels)."""
         return playlist.get("name", "")
@@ -99,7 +116,7 @@ class MirrorTarget:
 
 
 def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, execute, max_removals,
-                max_adds, source_key="spotify", source_name="Spotify", name=None):
+                max_adds, drain_removals=False, source_key="spotify", source_name="Spotify", name=None):
     """Reconcile one source→target playlist pair. Returns a stats dict; `clean`
     is True when everything applied with no guard tripped.
 
@@ -164,12 +181,18 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         additions, guard = additions[:max_adds], True
 
     removals, held = protect_removals(to_remove, not_found)
+    removals_skipped = 0
     if not sp_tracks and tgt_tracks:
-        log_warn(f"Spotify returned 0 tracks but {target.name} has {len(tgt_tracks)}; skipping all removals this pass", tag=tag)
+        log_warn(f"{source_name} returned 0 tracks but {target.name} has {len(tgt_tracks)}; skipping all removals this pass", tag=tag)
         removals, guard = [], True
     elif len(removals) > max_removals:
-        log_warn(f"{len(removals)} removals exceed --max-removals={max_removals}; skipping removals this pass", tag=tag)
-        removals, guard = [], True
+        if drain_removals:
+            log_warn(f"draining removals — applying {max_removals} now, {len(removals) - max_removals} next pass", tag=tag)
+            removals, guard = removals[:max_removals], True
+        else:
+            log_warn(f"{len(removals)} removals exceed --max-removals={max_removals}; held back "
+                     "(enable 'apply large removals' on this sync to drain them)", tag=tag)
+            removals_skipped, removals, guard = len(removals), [], True
 
     for _, label, method in additions:
         log_add(f"{label}  {paint('(' + method + ')', 'grey')}", dry=not execute, tag=tag)
@@ -196,6 +219,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     return {
         "clean": execute and not guard, "added": len(additions), "removed": len(removals),
         "missing": len(not_found), "held": len(held), "deferred": deferred,
+        "removals_skipped": removals_skipped,
         "target_count": len(tgt_tracks) + len(additions) - len(removals),
     }
 
@@ -277,7 +301,8 @@ def _merge(prev, cur, collapsed):
     return desired, plan
 
 
-def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, max_adds, link_key=None):
+def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, max_adds,
+              drain_removals=False, link_key=None):
     """Reconcile one logical playlist across N provider peers, bidirectionally.
 
     playlists: {source: playlist dict}; caches: {source: resolution cache}.
@@ -322,9 +347,11 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     desired, plan = _merge(prev, cur, collapsed)
     log_section(name, " / ".join(f"{p.name} {len(cur[p.source])}" for p in peers), tag="sync")
 
-    stats = {"clean": execute and not collapsed, "added": 0, "removed": 0, "missing": 0, "held": 0, "deferred": 0}
+    stats = {"clean": execute and not collapsed, "added": 0, "removed": 0, "missing": 0,
+             "held": 0, "deferred": 0, "removals_skipped": 0}
+    removals_capped = False   # any provider's removals hit the cap -> freeze the baseline
     new_links = {p.source: {} for p in peers}
-    new_state = {}   # source -> canonical membership to persist (only on a clean pass)
+    new_state = {}   # source -> canonical membership to persist (only when the baseline is safe)
     for p in peers:
         if p.source in collapsed:
             continue  # untrusted read: don't write to it this pass (guards adds too, not just removes)
@@ -370,12 +397,21 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         # REMOVE: canonical ids that left the set, guarded by protect_removals + cap.
         remove_pairs = [(cid, canon[p.source][cid]) for cid in remove_ids]
         safe, held = protect_removals([n for _, n in remove_pairs], not_found)
+        if len(safe) > max_removals:
+            # Cap hit: freezing the baseline (removals_capped) is what keeps a
+            # held-back / mid-drain removal from being resurrected via union_prev.
+            removals_capped, stats["clean"] = True, False
+            if drain_removals:
+                log_warn(f"{p.name}/{name}: draining removals — applying {max_removals} now, "
+                         f"{len(safe) - max_removals} next pass", tag=p.tag)
+                safe = safe[:max_removals]
+            else:
+                log_warn(f"{p.name}/{name}: {len(safe)} removals exceed --max-removals={max_removals}; "
+                         "held back (enable 'apply large removals' on this sync to drain them)", tag=p.tag)
+                stats["removals_skipped"] += len(safe)
+                safe = []
         safe_ids = {id(n) for n in safe}
         removed_cids = {cid for cid, n in remove_pairs if id(n) in safe_ids}
-        if len(safe) > max_removals:
-            log_warn(f"{p.name}/{name}: {len(safe)} removals exceed --max-removals={max_removals}; "
-                     "skipping removals this pass", tag=p.tag)
-            safe, removed_cids, stats["clean"] = [], set(), False
 
         for tid, method, norm in additions:
             log_add(f"{p.name}: {norm['name']} - {norm['artist']}  {paint('(' + method + ')', 'grey')}",
@@ -408,7 +444,11 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     if execute:
         for p in peers:
             archive.set_links(songs, p.source, new_links[p.source])
-        if stats["clean"]:
+        # Advance the removal baseline whenever reads were trusted and no removal was
+        # capped — deferred ADDS don't block it (they stay in `desired` via union_prev
+        # and re-add next pass), which is what lets removals activate on the pass after
+        # an add-heavy bootstrap instead of only after the whole backlog drains.
+        if not collapsed and not removals_capped:
             for src, ids in new_state.items():
                 archive.set_playlist_state(songs, key, src, ids)
 

--- a/omni_sync/engine/targets/base.py
+++ b/omni_sync/engine/targets/base.py
@@ -16,7 +16,7 @@ from ..logs import (
     fmt_counts, fmt_secs, log_add, log_hold, log_miss, log_note, log_remove,
     log_section, log_summary, log_warn, paint,
 )
-from ..matching import compute_diff, protect_removals, spotify_track_keys, track_key
+from ..matching import compute_diff, fuzzy_in, protect_removals, romanized, spotify_track_keys, track_key
 
 # A provider reading fewer than this fraction of the known baseline is treated
 # as a broken read: its removals are ignored so one bad fetch can't cascade a
@@ -133,6 +133,8 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
 
     archive.upsert_many(songs, source_key, sp_tracks)
     archive.upsert_many(songs, target.source, tgt_tracks)
+    archive.record_order(songs, name.strip().casefold(), target.source,
+                         [[target.track_id(t), t.get("name", ""), t.get("artist", "")] for t in tgt_tracks])
 
     links = (archive.get_links(songs, target.source, [t.get("id") for t in sp_tracks])
              if source_key == "spotify" else {})
@@ -281,6 +283,57 @@ def _canonicalize(target, tracks, songs, cache, key2isrc):
     return out
 
 
+def _unify_aliases(canon):
+    """{alias_cid: winner_cid} — fold fuzzy-key (k:) canonicals into the hard
+    (i:/s:) — or first k: — identity of the same song across providers.
+
+    The same song canonicalizes differently per provider whenever hard ids are
+    missing and the metadata is provider-flavored: decorated titles ("(Official
+    Audio)"), partial or embellished artist credits ("Woodkid" vs "Woodkid,
+    Arcane, League of Legends Music"). Left split, every alias is its own
+    `desired` member that other providers appear to lack — re-added via search
+    as a duplicate each pass — and a flip between aliases reads as a user
+    deletion. Matching: any exact spotify_track_keys overlap, else the same
+    composite-key fuzzy tolerance the one-way removal guard trusts. Hard ids
+    never merge with each other — two ISRCs are two recordings."""
+    keysets = {}
+    for by_cid in canon.values():
+        for cid, norm in by_cid.items():
+            keysets.setdefault(cid, set()).update(spotify_track_keys(norm))
+    soft = sorted(cid for cid in keysets if cid.startswith("k:"))
+    if not soft:
+        return {}
+    hard = sorted((cid for cid in keysets if not cid.startswith("k:")),
+                  key=lambda c: (not c.startswith("i:"), c))  # prefer an ISRC winner
+    by_key = {}
+    for cid in hard:
+        for k in keysets[cid]:
+            by_key.setdefault(k, cid)
+    # For the fuzzy comparison, the "name|artist" separator must become a space
+    # (left in, it fuses different neighbor tokens on each side — "legends|woodkid"
+    # vs "legends|arcane" — and blocks matches on mere credit reordering), and a
+    # romanized variant joins each side so cross-script copies of one song match.
+    def _variants(k):
+        k = k.replace("|", " ")
+        return {k, romanized(k)}
+
+    flat = {cid: set().union(*(_variants(k) for k in ks)) for cid, ks in keysets.items()}
+    alias, anchors = {}, []  # anchors: surviving k: ids (matched pairwise, never chained)
+    for cid in soft:
+        qs = _variants(cid[2:])
+        winner = next((by_key[k] for k in sorted(keysets[cid]) if k in by_key), None)
+        if not winner:
+            winner = next((h for h in hard if any(fuzzy_in(q, flat[h]) for q in qs)), None)
+        if not winner:
+            winner = next((a for a in anchors
+                           if keysets[cid] & keysets[a] or any(fuzzy_in(q, flat[a]) for q in qs)), None)
+        if winner:
+            alias[cid] = winner
+        else:
+            anchors.append(cid)
+    return alias
+
+
 def _merge(prev, cur, collapsed):
     """Pure delta merge over PER-PROVIDER state. prev, cur: {source:
     set(canonical_id)} — each provider's membership after the last clean pass
@@ -321,18 +374,33 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
 
     canon = {}         # source -> {canonical_id: normalized track}
     present = {}       # source -> set of ALL current target ids (not canonical-deduped)
-    present_keys = {}  # source -> set of track_keys already on the provider (dupe guard)
     key2isrc = {}      # track_key -> ISRC, seeded by any ISRC-bearing provider (peers are ISRC-rich first)
     for p in peers:
         raw = p.playlist_tracks(playlists[p.source])
         archive.upsert_many(songs, p.source, raw)
+        archive.record_order(songs, key, p.source,
+                             [[p.track_id(t), t.get("name", ""),
+                               t.get("artist") or ", ".join(t.get("artists") or [])] for t in raw])
         present[p.source] = {p.track_id(t) for t in raw if p.track_id(t)}
         canon[p.source] = _canonicalize(p, raw, songs, caches[p.source], key2isrc)
-        present_keys[p.source] = set().union(*(spotify_track_keys(n) for n in canon[p.source].values())) \
-            if canon[p.source] else set()
         for cid, norm in canon[p.source].items():
             if cid.startswith("i:"):  # any provider that resolved an ISRC anchors the rest
                 key2isrc.setdefault(track_key(norm["name"], norm["artist"]), cid[2:])
+
+    # One identity per song: fold provider-flavored aliases together BEFORE any
+    # membership math, and map the stored baseline through the same table so a
+    # retired alias is never mistaken for a deletion.
+    alias = _unify_aliases(canon)
+    if alias:
+        for src, by_cid in canon.items():
+            merged = {}
+            for cid, norm in by_cid.items():
+                merged.setdefault(alias.get(cid, cid), norm)
+            canon[src] = merged
+        prev = {src: {alias.get(cid, cid) for cid in ids} for src, ids in prev.items()}
+    present_keys = {  # source -> track_keys already on the provider (dupe guard)
+        src: set().union(*(spotify_track_keys(n) for n in by_cid.values())) if by_cid else set()
+        for src, by_cid in canon.items()}
     cur = {src: set(m) for src, m in canon.items()}
 
     repr_ = {}  # canonical_id -> representative track (peers are ordered spotify-first for ISRC-rich reprs)

--- a/omni_sync/engine/targets/base.py
+++ b/omni_sync/engine/targets/base.py
@@ -116,7 +116,7 @@ class MirrorTarget:
 
 
 def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, execute, max_removals,
-                max_adds, drain_removals=False, source_key="spotify", source_name="Spotify", name=None):
+                max_adds, drain_removals=False, should_continue=None, source_key="spotify", source_name="Spotify", name=None):
     """Reconcile one source→target playlist pair. Returns a stats dict; `clean`
     is True when everything applied with no guard tripped.
 
@@ -146,7 +146,11 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     # Resolve additions to target ids, preserving the oldest-first order.
     present = {target.track_id(t) for t in tgt_tracks if target.track_id(t)}
     additions, not_found, new_links, methods = [], [], {}, {}
+    stopped_early = False
     for i, track in enumerate(to_add, 1):
+        if should_continue and should_continue() != "run":
+            stopped_early = True  # Pause/Stop — defer the rest; keep the pass "not clean" below
+            break
         label = f"{track['name']} - {', '.join(track['artists'])}"
         tid = links.get(track.get("id"))
         method = "link" if tid else None
@@ -173,7 +177,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     if source_key == "spotify":
         archive.set_links(songs, target.source, new_links)  # keep the shared table Spotify-anchored
 
-    guard = False
+    guard = stopped_early  # a pause mid-resolve must not advance the snapshot (a re-run finishes it)
     deferred = 0
     if len(additions) > max_adds:
         deferred = len(additions) - max_adds
@@ -302,7 +306,7 @@ def _merge(prev, cur, collapsed):
 
 
 def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, max_adds,
-              drain_removals=False, link_key=None):
+              drain_removals=False, should_continue=None, link_key=None):
     """Reconcile one logical playlist across N provider peers, bidirectionally.
 
     playlists: {source: playlist dict}; caches: {source: resolution cache}.
@@ -350,9 +354,13 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     stats = {"clean": execute and not collapsed, "added": 0, "removed": 0, "missing": 0,
              "held": 0, "deferred": 0, "removals_skipped": 0}
     removals_capped = False   # any provider's removals hit the cap -> freeze the baseline
+    interrupted = False       # a Pause/Stop mid-pass -> freeze the baseline too (partial advance is unsafe)
     new_links = {p.source: {} for p in peers}
     new_state = {}   # source -> canonical membership to persist (only when the baseline is safe)
     for p in peers:
+        if should_continue and should_continue() != "run":
+            interrupted = True  # Pause/Stop — skip the remaining providers this pass
+            break
         if p.source in collapsed:
             continue  # untrusted read: don't write to it this pass (guards adds too, not just removes)
         add_ids, remove_ids = plan[p.source]
@@ -367,6 +375,9 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             log_warn(f"{p.name} prefetch failed: {e!r}", tag=p.tag)
         additions, not_found = [], []
         for norm in sorted(add_norms, key=lambda n: n["added_at"]):
+            if should_continue and should_continue() != "run":
+                interrupted = True  # Pause/Stop — defer this provider's remaining adds
+                break
             if spotify_track_keys(norm) & present_keys[p.source]:
                 continue  # song already on the provider under a different id — no dupe, and no wasted search
             try:
@@ -448,7 +459,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         # capped — deferred ADDS don't block it (they stay in `desired` via union_prev
         # and re-add next pass), which is what lets removals activate on the pass after
         # an add-heavy bootstrap instead of only after the whole backlog drains.
-        if not collapsed and not removals_capped:
+        if not collapsed and not removals_capped and not interrupted:
             for src, ids in new_state.items():
                 archive.set_playlist_state(songs, key, src, ids)
 

--- a/omni_sync/engine/targets/base.py
+++ b/omni_sync/engine/targets/base.py
@@ -114,6 +114,17 @@ class MirrorTarget:
         """Remove one existing target track."""
         raise NotImplementedError
 
+    def remove_occurrences(self, playlist, positioned):
+        """Remove specific physical entries, positioned = [(index, raw_track)] in
+        playlist order — the duplicate-cleanup path, where only ONE copy of a
+        song present multiple times may go. Default: per-entry remove(), which
+        is entry-scoped on YT (playlist-item id / setVideoId). Spotify overrides
+        with a position-addressed call (its remove() drops every occurrence of a
+        uri); Apple overrides with delete-then-re-append (its DELETE addresses
+        the library song, taking every copy with it)."""
+        for _, raw in positioned:
+            self.remove(playlist, raw)
+
 
 def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, execute, max_removals,
                 max_adds, drain_removals=False, should_continue=None, source_key="spotify", source_name="Spotify", name=None):
@@ -251,8 +262,9 @@ def _normalize(track, source):
     }
 
 
-def _canonicalize(target, tracks, songs, cache, key2isrc):
-    """{canonical_id: normalized track} for one provider's current tracks.
+def _entry_cids(target, tracks, songs, cache, key2isrc):
+    """[(canonical_id, normalized track), ...] — one per PHYSICAL entry, in
+    playlist order (so a duplicate copy yields a repeated canonical id).
 
     Canonical precedence: ISRC (direct / provider-native map / same-playlist
     Spotify track_key) -> ISRC via the reverse link to Spotify -> the Spotify id
@@ -266,7 +278,7 @@ def _canonicalize(target, tracks, songs, cache, key2isrc):
            else archive.get_reverse_links(songs, target.source, [target.track_id(t) for t in tracks]))
     sp_isrc = archive.get_isrcs(songs, "spotify", list(rev.values())) if rev else {}
     id2isrc = target.native_isrc_map(cache)  # provider-supplied track_id -> ISRC (Apple, future providers)
-    out = {}
+    out = []
     for t in tracks:
         norm = _normalize(t, target.source)
         isrc = (norm["isrc"] or id2isrc.get(target.track_id(t))
@@ -279,7 +291,16 @@ def _canonicalize(target, tracks, songs, cache, key2isrc):
                 cid = f"i:{sp_isrc[sp_id]}" if sp_id in sp_isrc else f"s:{sp_id}"
             else:
                 cid = f"k:{track_key(norm['name'], norm['artist'])}"
-        out.setdefault(cid, norm)  # first occurrence wins (dedupe within a provider)
+        out.append((cid, norm))
+    return out
+
+
+def _canonicalize(target, tracks, songs, cache, key2isrc):
+    """{canonical_id: normalized track} for one provider's current tracks —
+    first occurrence wins, so duplicate copies collapse to one membership."""
+    out = {}
+    for cid, norm in _entry_cids(target, tracks, songs, cache, key2isrc):
+        out.setdefault(cid, norm)
     return out
 
 

--- a/omni_sync/engine/targets/spotify_target.py
+++ b/omni_sync/engine/targets/spotify_target.py
@@ -50,6 +50,12 @@ class SpotifyTarget(MirrorTarget):
     def list_playlists(self):
         return spotify.playlists_by_name(self._sp)
 
+    def browse_playlists(self):
+        # Un-deduped, with `_owned` — so browse lists (and the inherited find_playlist
+        # scans) every playlist, including a followed one that shares a name with an
+        # owned one. list_playlists() name-dedupes for the sync engine and would hide it.
+        return spotify.all_playlists(self._sp)
+
     def is_editable(self, playlist):
         owner = (playlist.get("owner") or {}).get("id")
         return owner is None or owner == self._user()

--- a/omni_sync/engine/targets/spotify_target.py
+++ b/omni_sync/engine/targets/spotify_target.py
@@ -135,3 +135,15 @@ class SpotifyTarget(MirrorTarget):
             return
         self._write(lambda: self._sp.playlist_remove_all_occurrences_of_items(playlist["id"], [_uri(tid)]), "remove")
         polite_sleep(0.3)
+
+    def remove_occurrences(self, playlist, positioned):
+        # Position-addressed removal against the read-time snapshot: with the
+        # same uri present twice, remove() would drop BOTH copies. All positions
+        # are evaluated against the one snapshot, so batches never shift indexes.
+        items = [{"uri": _uri(self.track_id(raw)), "positions": [pos]}
+                 for pos, raw in positioned if self.track_id(raw)]
+        snapshot = playlist.get("snapshot_id")
+        for i in range(0, len(items), 100):
+            self._write(lambda chunk=items[i:i + 100]: self._sp.playlist_remove_specific_occurrences_of_items(
+                playlist["id"], chunk, snapshot_id=snapshot), "remove occurrences")
+            polite_sleep(0.3)

--- a/omni_sync/engine/targets/ytmusic.py
+++ b/omni_sync/engine/targets/ytmusic.py
@@ -190,7 +190,8 @@ class YTMusicTarget(MirrorTarget):
             key = title.casefold()
             if key and key not in out:
                 out[key] = {"playlistId": pl["id"], "title": title,
-                            "count": pl.get("contentDetails", {}).get("itemCount")}
+                            "count": pl.get("contentDetails", {}).get("itemCount"),
+                            "thumbnails": pl.get("snippet", {}).get("thumbnails")}  # cover art for browse
         return out
 
     def is_editable(self, playlist):
@@ -310,7 +311,8 @@ class YTMusicBrowserTarget(YTMusicTarget):
             title = (pl.get("title") or "").strip()
             key = title.casefold()
             if key and key not in out:
-                out[key] = {"playlistId": pl.get("playlistId"), "title": title, "count": pl.get("count")}
+                out[key] = {"playlistId": pl.get("playlistId"), "title": title, "count": pl.get("count"),
+                            "thumbnails": pl.get("thumbnails")}  # cover art for browse
         return out
 
     def create(self, sp_playlist):

--- a/omni_sync/services/accounts/jellyfin.py
+++ b/omni_sync/services/accounts/jellyfin.py
@@ -10,7 +10,7 @@ class JellyfinConnector(Connector):
     name = "Jellyfin"
     auth_kind = "api_key"
     config_fields = [
-        Field("JELLYFIN_URL", "Server URL", help="e.g. http://localhost:8096"),
+        Field("JELLYFIN_URL", "Server URL", help="e.g. http://localhost:8096 (in Docker: http://host.docker.internal:8096)"),
         Field("JELLYFIN_API_KEY", "API key", secret=True, help="Jellyfin Dashboard → API Keys → New"),
         Field("JELLYFIN_USER_ID", "User ID", required=False, help="Optional; only if listing playlists needs it"),
     ]

--- a/omni_sync/services/playlists.py
+++ b/omni_sync/services/playlists.py
@@ -50,32 +50,31 @@ class PlaylistService:
         self._settings = settings
 
     def browse(self, provider_id):
-        """[{id, name, count}] for one connected provider (empty if unconfigured)."""
+        """[{id, name, count, image, owned}] for one connected provider (empty if
+        unconfigured). Provider-agnostic: every service is listed through its
+        MirrorTarget.browse_playlists() + accessors, so adding a provider needs no
+        change here. `owned` is False only for a followed (non-owned) playlist — a
+        provider surfaces those by overriding browse_playlists (Spotify does today).
+        Jellyfin is browse-only and lists via its own API."""
         self._settings.apply_to_env()
         if provider_id == "jellyfin":
-            # Jellyfin is browse-only (cover-push destination, not a sync target),
-            # so it lists via its own API rather than the targets registry.
             from ..engine import jellyfin
-            return sorted(jellyfin.list_playlists(), key=lambda r: (r["name"] or "").casefold())
+            rows = [{**r, "owned": True} for r in jellyfin.list_playlists()]
+            return sorted(rows, key=lambda r: (r["name"] or "").casefold())
         opts = parse_args([])
-        sp = None
-        if provider_id == "spotify":
-            try:
-                sp = spotify.client()
-            except Exception:
-                return []
-        target = build_one(provider_id, opts, sp)
+        try:
+            sp = spotify.client() if provider_id == "spotify" else None  # only the Spotify target needs a client
+            target = build_one(provider_id, opts, sp)
+        except Exception:
+            return []  # e.g. Spotify not authorized yet -> nothing to browse
         if target is None:
             return []
         try:
-            by_name = target.list_playlists()
+            playlists = target.browse_playlists()
         except Exception:
             return []
-        rows = [
-            {"id": _pl_id(pl), "name": _pl_name(pl), "count": target.playlist_count(pl),
-             "image": _pl_image(pl)}
-            for pl in by_name.values()
-        ]
+        rows = [{"id": _pl_id(pl), "name": _pl_name(pl), "count": target.playlist_count(pl),
+                 "image": _pl_image(pl), "owned": bool(pl.get("_owned", True))} for pl in playlists]
         return sorted(rows, key=lambda r: (r["name"] or "").casefold())
 
 

--- a/omni_sync/services/sync_service.py
+++ b/omni_sync/services/sync_service.py
@@ -210,6 +210,9 @@ class SyncService:
             "queued": job.id in self._active and self._running_job != job.id,
             # Its last pass was cut short by Pause and can be resumed (re-run).
             "paused": self._interrupted.get(job.id) == "paused",
+            # A pause/stop requested on the running job but not yet in effect (it
+            # halts at the next checkpoint) — drives the "Pausing…" indicator.
+            "pending": self._control if (self._running_job == job.id and self._control != "run") else None,
             "next_run_at": self._next_run.get(job.id),
             "last": self._last.get(job.id),
         }

--- a/omni_sync/services/sync_service.py
+++ b/omni_sync/services/sync_service.py
@@ -54,6 +54,7 @@ class SyncService:
         opts.playlists = job.playlists
         opts.max_adds = job.max_adds
         opts.max_removals = job.max_removals
+        opts.apply_large_removals = job.apply_large_removals
         # OMNI_DOWNLOAD_DIR (a container-internal bind-mount path set by
         # docker-compose) wins over the UI-saved DOWNLOAD_DIR: inside the
         # container that UI value can be a host path (e.g. a Windows F:\ path)

--- a/omni_sync/services/sync_service.py
+++ b/omni_sync/services/sync_service.py
@@ -22,9 +22,9 @@ from ..engine.runner import run_pass
 from .syncs import SyncStore
 
 
-async def _run_pass_async(opts):
+async def _run_pass_async(opts, should_continue=None):
     """Run one blocking pass off the event loop (patched in tests)."""
-    return await asyncio.to_thread(run_pass, opts)
+    return await asyncio.to_thread(run_pass, opts, should_continue)
 
 
 class SyncService:
@@ -41,6 +41,8 @@ class SyncService:
         self._next_run = {}            # job_id -> epoch seconds of its next scheduled pass
         self._schedulers = {}          # job_id -> asyncio.Task
         self._lock = asyncio.Lock()    # one engine writer at a time (jobs + transfers)
+        self._control = "run"          # "run" | "pause" | "stop" for the in-flight pass
+        self._interrupted = {}         # job_id -> "paused" | "stopped" (last pass was cut short)
 
     # -- running ---------------------------------------------------------------
     def _opts_for(self, job, execute):
@@ -78,12 +80,19 @@ class SyncService:
         try:
             async with self._lock:
                 self._running_job, self._running_mode = job_id, ("execute" if execute else "preview")
+                self._control = "run"
+                self._interrupted.pop(job_id, None)
                 try:
                     self._emit("section", f"{job.name}: pass started ({'execute' if execute else 'dry run'})", "sync")
-                    summary = await _run_pass_async(self._opts_for(job, execute))
+                    summary = await _run_pass_async(self._opts_for(job, execute),
+                                                    should_continue=lambda: self._control)
                     summary.update(job_id=job_id, job_name=job.name)
                     self._last[job_id] = self._last_any = summary
-                    self._emit("summary", f"{job.name}: pass finished", "sync", summary)
+                    if summary.get("interrupted"):
+                        self._interrupted[job_id] = "paused" if summary["interrupted"] == "pause" else "stopped"
+                        self._emit("note", f"{job.name}: pass {self._interrupted[job_id]}", "sync")
+                    else:
+                        self._emit("summary", f"{job.name}: pass finished", "sync", summary)
                 except asyncio.CancelledError:
                     raise
                 except BaseException as e:  # a bad pass must never kill the scheduler
@@ -107,6 +116,30 @@ class SyncService:
         async with self._lock:
             return await asyncio.to_thread(fn)
 
+    def pause(self, job_id):
+        """Ask the running pass to halt at the next playlist boundary and hold as
+        resumable. False if that job isn't the one currently running."""
+        if self._running_job != job_id:
+            return False
+        self._control = "pause"
+        return True
+
+    def stop(self, job_id):
+        """Abort the running pass at the next playlist boundary — applied changes
+        stay. False if that job isn't currently running."""
+        if self._running_job != job_id:
+            return False
+        self._control = "stop"
+        return True
+
+    def resume(self, job_id):
+        """Re-run a paused job. reconcile is idempotent, so already-applied changes
+        are skipped and the pass picks up the remaining work. False if not paused."""
+        if self._interrupted.get(job_id) != "paused":
+            return False
+        asyncio.create_task(self.run_job(job_id, execute=True))
+        return True
+
     # -- scheduling ------------------------------------------------------------
     def _master_on(self):
         return self._settings.get("AUTO_SYNC", "on") != "off"
@@ -127,7 +160,9 @@ class SyncService:
             if jid not in self._schedulers:
                 self._schedulers[jid] = asyncio.create_task(self._job_scheduler(jid))
 
-    async def stop(self):
+    async def shutdown(self):
+        """Cancel every per-job scheduler — app teardown. (Not to be confused with
+        stop(job_id), which aborts a single in-flight pass.)"""
         self._stopping = True
         for jid in list(self._schedulers):
             self._schedulers.pop(jid).cancel()
@@ -173,6 +208,8 @@ class SyncService:
             # finish — passes are serialized (shared caches/archive/rate limits),
             # so a second "Sync now" queues rather than overlaps.
             "queued": job.id in self._active and self._running_job != job.id,
+            # Its last pass was cut short by Pause and can be resumed (re-run).
+            "paused": self._interrupted.get(job.id) == "paused",
             "next_run_at": self._next_run.get(job.id),
             "last": self._last.get(job.id),
         }

--- a/omni_sync/services/syncs.py
+++ b/omni_sync/services/syncs.py
@@ -33,6 +33,7 @@ class SyncJob:
     interval: str = DEFAULT_INTERVAL          # this job's own auto-sync cadence
     max_adds: int = DEFAULT_MAX_ADDS
     max_removals: int = DEFAULT_MAX_REMOVALS
+    apply_large_removals: bool = False        # drain removals over max_removals across passes (default: hold back)
     download: bool = False                    # opt into the global download mirror
     id: str = ""
 

--- a/omni_sync/services/transfers.py
+++ b/omni_sync/services/transfers.py
@@ -39,6 +39,10 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
     total = len(src)
     if on_progress:
         on_progress(0, total, 0)  # publish the total once source is read, before matching begins
+    # Same-provider copy (e.g. a followed Spotify list into a new owned one): the
+    # track's own id is already valid on the destination, so use it directly instead
+    # of re-searching for it (which resolve() does for the cross-provider case).
+    same_provider = source.source == dest.source
     additions, not_found = [], []
     completed = True
     for i, norm in enumerate(sorted(src, key=lambda n: n["added_at"]), 1):
@@ -47,12 +51,15 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
             break
         keys = spotify_track_keys(norm)
         if not keys & seen:  # skip tracks already on the destination
-            try:
-                tid, _ = dest.resolve(norm, cache)
-            except TargetAuthError:
-                raise
-            except Exception:
-                tid = None
+            if same_provider:
+                tid = source.track_id(norm["_raw"])
+            else:
+                try:
+                    tid, _ = dest.resolve(norm, cache)
+                except TargetAuthError:
+                    raise
+                except Exception:
+                    tid = None
             if tid:
                 additions.append(tid)
                 seen |= keys
@@ -246,10 +253,10 @@ class TransferService:
         return build_one(provider_id, opts, sp)
 
     def _find(self, provider, playlist_id):
-        for pl in provider.list_playlists().values():
-            if provider.playlist_id(pl) == playlist_id:
-                return pl
-        return None
+        # find_playlist scans the provider's full set — for Spotify that's the
+        # un-deduped list, so a followed playlist is reachable by id even when a
+        # same-named owned one exists (list_playlists() would have hidden it).
+        return provider.find_playlist(playlist_id)
 
     def _dest_playlist(self, dst, src, src_pl, spec):
         if spec.get("dest_playlist_id"):

--- a/omni_sync/web/__init__.py
+++ b/omni_sync/web/__init__.py
@@ -53,7 +53,7 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
         try:
             yield
         finally:
-            await sync_service.stop()
+            await sync_service.shutdown()
 
     app = FastAPI(title="Omni Playlist Sync", lifespan=lifespan)
     app.state.settings = settings

--- a/omni_sync/web/routers/syncs.py
+++ b/omni_sync/web/routers/syncs.py
@@ -15,7 +15,7 @@ from ...services.syncs import SyncJob
 router = APIRouter()
 
 _FIELDS = {"name", "enabled", "mode", "source", "providers", "playlists",
-           "interval", "max_adds", "max_removals", "download", "id"}
+           "interval", "max_adds", "max_removals", "apply_large_removals", "download", "id"}
 
 
 def _job_from(values):
@@ -24,7 +24,7 @@ def _job_from(values):
     for k in ("max_adds", "max_removals"):
         if k in data:
             data[k] = int(data[k])
-    for k in ("enabled", "download"):
+    for k in ("enabled", "download", "apply_large_removals"):
         if k in data:
             data[k] = bool(data[k])
     return SyncJob(**data)

--- a/omni_sync/web/routers/syncs.py
+++ b/omni_sync/web/routers/syncs.py
@@ -64,3 +64,15 @@ async def run_sync(job_id: str, request: Request, execute: bool = False):
     # Fire-and-forget onto SyncService's single queue; returns immediately.
     asyncio.create_task(request.app.state.sync.run_job(job_id, execute=execute))
     return JSONResponse({"queued": True}, status_code=202)
+
+
+@router.post("/api/syncs/{job_id}/{action}")
+async def control_sync(job_id: str, action: str, request: Request):
+    """Pause / stop the running pass, or resume a paused one. Returns {ok} — False
+    when the action doesn't apply (e.g. that job isn't the one currently running).
+    Declared after /run so the literal 'run' route isn't shadowed."""
+    svc = request.app.state.sync
+    fn = {"pause": svc.pause, "stop": svc.stop, "resume": svc.resume}.get(action)
+    if fn is None:
+        return JSONResponse({"detail": "unknown action"}, status_code=404)
+    return {"ok": fn(job_id)}

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,141 @@
+"""The duplicate-copy cleanup: flag only extra copies of one identity, keep
+membership intact, clear the baseline on apply so nothing propagates."""
+
+from omni_sync.engine import archive, dedupe
+from omni_sync.engine.targets.base import MirrorTarget, _normalize
+
+
+class _Peer(MirrorTarget):
+    """Fake peer inheriting the default per-entry remove_occurrences."""
+
+    def __init__(self, source, tracks):
+        self.source = self.tag = self.name = source
+        self._tracks = list(tracks)
+        self.removed = []
+
+    def playlist_tracks(self, pl):
+        return list(self._tracks)
+
+    def track_id(self, t):
+        return t.get("id")
+
+    def remove(self, pl, raw):
+        self.removed.append(raw["id"])
+        self._tracks = [t for t in self._tracks if t is not raw]  # entry-scoped, like Apple/YT
+
+
+def _t(id_, name, artist, isrc=None):
+    return {"id": id_, "name": name, "artist": artist, "artists": [artist],
+            "isrc": isrc, "duration_ms": 1000, "added_at": "2020"}
+
+
+def _caches(*sources):
+    return {s: {"isrc": {}, "search": {}, "dirty": False} for s in sources}
+
+
+def test_dup_plan_flags_only_extra_copies(tmp_path):
+    conn = archive.connect(str(tmp_path / "s.db"))
+    sp = _Peer("spotify", [
+        _t("sp1", "Song A", "Artist", isrc="A"),
+        _t("sp2", "Song B", "Artist", isrc="B"),
+        _t("sp3", "Song A", "Artist", isrc="A"),   # re-added under a second catalog id
+        _t("sp1", "Song A", "Artist", isrc="A"),   # same-id second copy
+    ])
+    ap = _Peer("apple", [_t("ap1", "Song A (Official Audio)", "Artist")])  # junk-alias, single copy
+    playlists = {"spotify": {"id": "s"}, "apple": {"id": "a"}}
+    entries, _ = dedupe.scan([sp, ap], playlists, _caches("spotify", "apple"), conn, "mix")
+    plan, held = dedupe.dup_plan([sp, ap], entries)
+    assert [(i, raw["id"]) for i, _, raw, _ in plan["spotify"]] == [(2, "sp3"), (3, "sp1")]
+    assert plan["apple"] == []  # its one copy unified with Song A, but membership is never touched
+    assert held == {"spotify": [], "apple": []}
+    conn.close()
+
+
+def test_apply_removes_clears_state_and_snapshots(tmp_path):
+    conn = archive.connect(str(tmp_path / "s.db"))
+    archive.set_playlist_state(conn, "mix", "spotify", {"i:A", "i:B"})
+    sp = _Peer("spotify", [_t("sp1", "Song A", "Artist", "A"), _t("sp2", "Song B", "Artist", "B"),
+                           _t("sp3", "Song A", "Artist", "A")])
+    playlists = {"spotify": {"id": "s"}}
+    entries, _ = dedupe.scan([sp], playlists, _caches("spotify"), conn, "mix")
+    plan, _ = dedupe.dup_plan([sp], entries)
+    result = dedupe.apply([sp], playlists, _caches("spotify"), conn, "mix", plan)
+    assert sp.removed == ["sp3"]
+    assert result["spotify"] == (1, 2)
+    assert archive.get_playlist_state(conn, "mix", "spotify") == set()  # baseline cleared, no propagation
+    newest = archive.get_order_history(conn, "mix", "spotify")[0][1]
+    assert [row[0] for row in newest] == ["sp1", "sp2"]                 # post-clean snapshot on top
+    conn.close()
+
+
+def test_unidentifiable_entries_never_flagged(tmp_path):
+    # Empty metadata would collide on an empty key; a missing track id can't be
+    # removed. Neither may ever be flagged as a "duplicate".
+    conn = archive.connect(str(tmp_path / "s.db"))
+    sp = _Peer("spotify", [_t("x1", "", ""), _t("x2", "", ""),
+                           _t(None, "Song", "A"), _t(None, "Song", "A")])
+    entries, _ = dedupe.scan([sp], {"spotify": {"id": "s"}}, _caches("spotify"), conn, "mix")
+    plan, held = dedupe.dup_plan([sp], entries)
+    assert plan["spotify"] == [] and held["spotify"] == []
+    conn.close()
+
+
+def test_version_boundary_folds_are_held_not_removed(tmp_path):
+    # A live video (fuzzy key, no ISRC) folds into the studio identity so the
+    # sync stays quiet — but the studio copy must NEVER be deleted as its
+    # "duplicate": the version markers differ, so it lands in `held`.
+    conn = archive.connect(str(tmp_path / "s.db"))
+    yt = _Peer("ytmusic", [_t("v-live", "American Pie (Live)", "Don McLean"),
+                           _t("v-studio", "American Pie", "Don McLean", isrc="S1")])
+    entries, _ = dedupe.scan([yt], {"ytmusic": {"id": "y"}}, _caches("ytmusic"), conn, "mix")
+    plan, held = dedupe.dup_plan([yt], entries)
+    assert plan["ytmusic"] == []
+    assert [raw["id"] for _, _, raw, _ in held["ytmusic"]] == ["v-studio"]
+    # …while a same-recording decoration ("Official Audio") still dedupes:
+    yt2 = _Peer("ytmusic", [_t("v1", "stevie (Official Audio)", "Kasabian"),
+                            _t("v2", "stevie", "Kasabian", isrc="K1")])
+    entries, _ = dedupe.scan([yt2], {"ytmusic": {"id": "y"}}, _caches("ytmusic"), conn, "mix2")
+    plan, held = dedupe.dup_plan([yt2], entries)
+    assert [raw["id"] for _, _, raw, _ in plan["ytmusic"]] == ["v2"]
+    assert held["ytmusic"] == []
+    conn.close()
+
+
+def test_apple_remove_occurrences_reappends_shared_id_keeper(monkeypatch):
+    # Apple's tracks-DELETE takes every copy of a library song with it. When
+    # the keeper shares the flagged copy's id it must be re-appended; a group
+    # whose copies are all flagged must not be.
+    from omni_sync.engine.targets.apple import AppleMusicTarget
+
+    ap = AppleMusicTarget.__new__(AppleMusicTarget)  # no tokens needed for this path
+    tracks = [
+        {"relationship_id": "L1", "catalog_id": "c1", "name": "Song A", "artist": "X"},  # keeper
+        {"relationship_id": "L1", "catalog_id": "c1", "name": "Song A", "artist": "X"},  # dup (same lib id)
+        {"relationship_id": "L2", "catalog_id": "c2", "name": "Song B", "artist": "X"},  # dup of a distinct-id keeper
+    ]
+    removed, added = [], []
+    monkeypatch.setattr(ap, "playlist_tracks", lambda pl: list(tracks))
+    monkeypatch.setattr(ap, "remove", lambda pl, t: removed.append(t["relationship_id"]))
+    monkeypatch.setattr(ap, "add", lambda pl, ids: added.extend(ids))
+    ap.remove_occurrences({"id": "p"}, [(1, tracks[1]), (2, tracks[2])])
+    assert removed == ["L1", "L2"]
+    assert added == ["c1"]  # L1's keeper re-appended; L2 had no unflagged copy in the group
+
+
+def test_variant_pairs_reports_hard_twins_not_mirrored_ones():
+    studio = _normalize({"name": "American Pie", "artist": "Don McLean", "isrc": "S1"}, "spotify")
+    live = _normalize({"name": "American Pie - Live", "artist": "Don McLean", "isrc": "L1"}, "spotify")
+    canon = {"spotify": {"i:S1": studio, "i:L1": live}, "apple": {"i:S1": studio}}
+    assert [(a, b) for a, b, _, _ in dedupe.variant_pairs(canon)] == [("i:L1", "i:S1")]
+    canon["apple"]["i:L1"] = live  # now fully mirrored on every provider -> not debris
+    assert dedupe.variant_pairs(canon) == []
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    import tempfile
+    from pathlib import Path
+    for t in tests:
+        t(Path(tempfile.mkdtemp())) if t.__code__.co_argcount else t()
+        print(f"ok  {t.__name__}")
+    print("\nOK: all checks passed")

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -59,32 +59,32 @@ def test_browse_normalizes_rows(monkeypatch, tmp_path):
         def list_playlists(self):
             return {"chill": {"id": "1", "name": "Chill", "tracks": {"total": 5}}}
 
+        def browse_playlists(self):
+            return list(self.list_playlists().values())
+
         def playlist_count(self, pl):
             return (pl.get("tracks") or {}).get("total")
 
     monkeypatch.setattr("omni_sync.services.playlists.build_one", lambda pid, opts, sp=None: FakeTarget())
     rows = PlaylistService(SettingsStore(dir=tmp_path)).browse("apple")
-    assert rows == [{"id": "1", "name": "Chill", "count": 5, "image": ""}]
+    assert rows == [{"id": "1", "name": "Chill", "count": 5, "image": "", "owned": True}]
 
 
 def test_browse_lists_followed_spotify_playlists(monkeypatch, tmp_path):
-    # Spotify browse lists followed (non-owned) playlists alongside owned ones —
-    # they're transferable via the web-player fallback, so none are filtered out.
+    # Spotify browse lists followed (non-owned) playlists alongside owned ones, via
+    # the un-deduped all_playlists(), and labels each with `owned` so the UI can
+    # divide Created from Followed.
     from omni_sync.services.playlists import PlaylistService
     from omni_sync.services.settings import SettingsStore
 
-    class FakeSpotify:
-        def list_playlists(self):
-            return {"mine": {"id": "1", "name": "Mine", "owner": {"id": "me"}},
-                    "theirs": {"id": "2", "name": "Theirs", "owner": {"id": "other"}}}
-
-        def playlist_count(self, pl):
-            return None
-
     monkeypatch.setattr("omni_sync.services.playlists.spotify.client", lambda *a, **k: object())
-    monkeypatch.setattr("omni_sync.services.playlists.build_one", lambda pid, opts, sp=None: FakeSpotify())
+    monkeypatch.setattr(
+        "omni_sync.services.playlists.spotify.all_playlists",
+        lambda sp: [{"id": "1", "name": "Mine", "owner": {"id": "me"}, "_owned": True},
+                    {"id": "2", "name": "Theirs", "owner": {"id": "other"}, "_owned": False}],
+    )
     rows = PlaylistService(SettingsStore(dir=tmp_path)).browse("spotify")
-    assert {r["name"] for r in rows} == {"Mine", "Theirs"}
+    assert {r["name"]: r["owned"] for r in rows} == {"Mine": True, "Theirs": False}
 
 
 def test_track_total_reads_both_shapes():

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -236,6 +236,20 @@ def test_large_removals_held_back_by_default_then_drain_when_opted_in(tmp_path):
     conn.close()
 
 
+def test_reconcile_interrupt_freezes_baseline(tmp_path):
+    # A Pause/Stop mid-reconcile must NOT advance the per-provider baseline — a
+    # partial advance could resurrect a track via union_prev on the next pass.
+    conn = archive.connect(str(tmp_path / "s.db"))
+    sp, ap = _P("spotify", ["A", "B", "C"]), _P("apple", ["A"])
+    control = iter(["run"])  # allow the first check, then "stop" (default) interrupts the pass
+    reconcile([sp, ap], "Mix", {"spotify": {"id": "s"}, "apple": {"id": "a"}},
+              _caches("spotify", "apple"), conn, execute=True, max_removals=25, max_adds=200,
+              should_continue=lambda: next(control, "stop"))
+    assert archive.get_playlist_state(conn, "mix", "spotify") == set()  # frozen, not advanced
+    assert archive.get_playlist_state(conn, "mix", "apple") == set()
+    conn.close()
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for t in tests:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -149,6 +149,93 @@ def test_reconcile_uses_link_key_for_state():
     conn.close()
 
 
+class _P:
+    """Reconcile peer with a controllable ISRC set that reflects adds/removes —
+    for exercising the persist gate + removal draining across passes."""
+
+    def __init__(self, source, isrcs):
+        self.source = self.tag = self.name = source
+        self._isrcs = list(isrcs)
+        self.removed = []
+
+    def playlist_tracks(self, pl):
+        return [{"id": f"{self.source}-{i}", "name": f"Song {i}", "artists": ["A"], "artist": "A",
+                 "duration_ms": 1000, "isrc": i, "added_at": "2020"} for i in self._isrcs]
+
+    def track_id(self, t):
+        return t.get("id")
+
+    def prefetch(self, norms, cache):
+        pass
+
+    def native_isrc_map(self, cache):
+        return {}
+
+    def resolve(self, norm, cache):
+        return f"{self.source}-{norm['isrc']}", "search"
+
+    def add(self, pl, ids):
+        for tid in ids:
+            isrc = tid.split("-", 1)[1]
+            if isrc not in self._isrcs:
+                self._isrcs.append(isrc)
+
+    def remove(self, pl, raw):
+        self.removed.append(raw["isrc"])
+        if raw["isrc"] in self._isrcs:
+            self._isrcs.remove(raw["isrc"])
+
+
+def _caches(*sources):
+    return {s: {"isrc": {}, "search": {}, "dirty": False} for s in sources}
+
+
+def test_reconcile_saves_baseline_when_only_adds_deferred(tmp_path):
+    # The bootstrap fix: a pass that merely DEFERS adds (max_adds hit) is not
+    # "clean", yet its per-provider removal baseline must still be recorded — else
+    # removals can never activate until the whole add backlog drains.
+    conn = archive.connect(str(tmp_path / "s.db"))
+    sp, ap = _P("spotify", ["A", "B", "C"]), _P("apple", ["A"])  # apple missing B, C
+    stats = reconcile([sp, ap], "Mix", {"spotify": {"id": "s"}, "apple": {"id": "a"}},
+                      _caches("spotify", "apple"), conn, execute=True, max_removals=25, max_adds=1)
+    assert stats["deferred"] >= 1 and stats["clean"] is False   # add backlog deferred
+    assert archive.get_playlist_state(conn, "mix", "spotify") == {"i:A", "i:B", "i:C"}  # baseline still saved
+    conn.close()
+
+
+def test_large_removals_held_back_by_default_then_drain_when_opted_in(tmp_path):
+    isrcs = list("ABCDEFGHIJ")
+
+    def fresh():
+        conn = archive.connect(str(tmp_path.joinpath(f"s{len(isrcs)}.db")))
+        for src in ("spotify", "apple"):
+            archive.set_playlist_state(conn, "mix", src, {f"i:{i}" for i in isrcs})
+        sp = _P("spotify", ["A", "B", "C", "H", "I", "J"])  # user dropped D,E,F,G (keeps 6/10 -> no collapse)
+        ap = _P("apple", list(isrcs))
+        return conn, sp, ap
+
+    playlists = {"spotify": {"id": "s"}, "apple": {"id": "a"}}
+
+    # Default: 4 removals > max_removals=2 -> held back entirely, surfaced, baseline frozen.
+    conn, sp, ap = fresh()
+    stats = reconcile([sp, ap], "Mix", playlists, _caches("spotify", "apple"), conn,
+                      execute=True, max_removals=2, max_adds=200, drain_removals=False)
+    assert stats["removals_skipped"] == 4 and ap.removed == []
+    assert archive.get_playlist_state(conn, "mix", "apple") == {f"i:{i}" for i in isrcs}  # not advanced
+    conn.close()
+
+    # Opt-in: drains 2/pass across two passes, advancing the baseline only once cleared.
+    conn, sp, ap = fresh()
+    reconcile([sp, ap], "Mix", playlists, _caches("spotify", "apple"), conn,
+              execute=True, max_removals=2, max_adds=200, drain_removals=True)
+    assert len(ap.removed) == 2 and archive.get_playlist_state(conn, "mix", "apple") == {f"i:{i}" for i in isrcs}
+    reconcile([sp, ap], "Mix", playlists, _caches("spotify", "apple"), conn,
+              execute=True, max_removals=2, max_adds=200, drain_removals=True)
+    assert len(ap.removed) == 4  # fully drained
+    assert archive.get_playlist_state(conn, "mix", "apple") == {f"i:{i}" for i in ("A", "B", "C", "H", "I", "J")}
+    conn.close()
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for t in tests:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -236,6 +236,163 @@ def test_large_removals_held_back_by_default_then_drain_when_opted_in(tmp_path):
     conn.close()
 
 
+class _VariantPeer:
+    """Peer holding ONE copy of a song under provider-flavored metadata
+    (decorated title, partial or embellished artist credits). resolve() returns
+    a catalog id different from the library id already in the playlist — the
+    real-world shape that let re-adds slip past the seen-id guard."""
+
+    def __init__(self, source, track, resolve_id):
+        self.source = self.tag = self.name = source
+        self._track = track
+        self._resolve_id = resolve_id
+        self.added, self.removed = [], []
+
+    def playlist_tracks(self, pl):
+        return [dict(self._track)]
+
+    def track_id(self, t):
+        return t.get("id")
+
+    def prefetch(self, norms, cache):
+        pass
+
+    def native_isrc_map(self, cache):
+        return {}
+
+    def resolve(self, norm, cache):
+        return self._resolve_id, "search"
+
+    def add(self, pl, ids):
+        self.added.extend(ids)
+
+    def remove(self, pl, raw):
+        self.removed.append(raw)
+
+
+def _arcane_peers():
+    """One song, three provider-flavored copies: Spotify lists every artist plus
+    the ISRC; Apple joins the artists into one embellished string; YT credits
+    only the primary. Without alias unification each shape becomes its own
+    canonical id."""
+    name = "To Ashes and Blood (from the series Arcane League of Legends)"
+    sp = _VariantPeer("spotify", {"id": "sp-lib", "name": name,
+                                  "artists": ["Woodkid", "Arcane", "League of Legends"],
+                                  "artist": "Woodkid, Arcane, League of Legends",
+                                  "duration_ms": 246000, "isrc": "X1", "added_at": "2020"}, "sp-cat")
+    ap = _VariantPeer("apple", {"id": "ap-lib", "name": name,
+                                "artist": "Woodkid, Arcane, League of Legends Music",
+                                "duration_ms": 246000, "isrc": None, "added_at": "2020"}, "ap-cat")
+    yt = _VariantPeer("ytmusic", {"id": "yt-lib", "name": name, "artists": ["Woodkid"],
+                                  "artist": "Woodkid", "duration_ms": 246000, "isrc": None,
+                                  "added_at": "2020"}, "yt-cat")
+    return sp, ap, yt
+
+
+def test_alias_variants_do_not_duplicate_across_providers(tmp_path):
+    # Every provider already HAS the song; a pass must be a no-op. Before alias
+    # unification, the k: identities from Apple/YT metadata sat in `desired`
+    # and were re-added elsewhere via search — duplicating the song on services
+    # that already had it, every pass.
+    conn = archive.connect(str(tmp_path / "s.db"))
+    sp, ap, yt = _arcane_peers()
+    stats = reconcile([sp, ap, yt], "Mix", {p.source: {"id": p.source} for p in (sp, ap, yt)},
+                      _caches("spotify", "apple", "ytmusic"), conn,
+                      execute=True, max_removals=25, max_adds=200)
+    assert stats["added"] == 0 and stats["removed"] == 0
+    assert sp.added == [] and ap.added == [] and yt.added == []
+    for src in ("spotify", "apple", "ytmusic"):  # baseline stores ONE unified identity, not three
+        assert archive.get_playlist_state(conn, "mix", src) == {"i:X1"}
+    conn.close()
+
+
+def test_alias_flip_never_removes_the_real_track(tmp_path):
+    # A provider's canonical for a song can FLIP between passes (an ISRC or link
+    # appears where only a fuzzy key existed). The retired alias then reads as a
+    # user deletion and the very-much-present song gets removed from the other
+    # providers. Unification maps the stored alias forward instead.
+    conn = archive.connect(str(tmp_path / "s.db"))
+    name = "Ma Meilleure Ennemie"
+    stale = "k:ma meilleure ennemie|stromae pomme arcane"
+    archive.set_playlist_state(conn, "mix", "spotify", {"i:Z9"})
+    archive.set_playlist_state(conn, "mix", "apple", {stale})
+    archive.set_playlist_state(conn, "mix", "ytmusic", {stale})
+    sp = _VariantPeer("spotify", {"id": "sp-lib", "name": name, "artists": ["Stromae", "Pomme"],
+                                  "artist": "Stromae, Pomme", "duration_ms": 178000,
+                                  "isrc": "Z9", "added_at": "2020"}, "sp-cat")
+    ap = _VariantPeer("apple", {"id": "ap-lib", "name": name,
+                                "artist": "Stromae, Pomme, Arcane", "duration_ms": 178000,
+                                "isrc": None, "added_at": "2020"}, "ap-cat")
+    yt = _VariantPeer("ytmusic", {"id": "yt-lib", "name": name, "artists": ["Stromae", "Pomme"],
+                                  "artist": "Stromae, Pomme", "duration_ms": 178000,
+                                  "isrc": "Z9",  # the flip: yt now reads an ISRC it didn't have
+                                  "added_at": "2020"}, "yt-cat")
+    stats = reconcile([sp, ap, yt], "Mix", {p.source: {"id": p.source} for p in (sp, ap, yt)},
+                      _caches("spotify", "apple", "ytmusic"), conn,
+                      execute=True, max_removals=25, max_adds=200)
+    assert stats["removed"] == 0 and ap.removed == [] and yt.removed == []
+    assert stats["added"] == 0
+    conn.close()
+
+
+def test_unify_never_merges_different_songs():
+    # Same title, different artists (a cover on a label channel) must stay two
+    # canonical identities — unification is for provider-flavored metadata of
+    # ONE song, never for genuinely different recordings by different artists.
+    from omni_sync.engine.targets.base import _normalize, _unify_aliases
+
+    orig = _normalize({"name": "Another Day in Paradise", "artists": ["Phil Collins"], "isrc": "P1"}, "spotify")
+    cover = _normalize({"name": "Another Day in Paradise",
+                        "artists": ["Thriller Records", "Kailee Morgue"]}, "ytmusic")
+    alias = _unify_aliases({
+        "spotify": {"i:P1": orig},
+        "ytmusic": {"k:another day in paradise|thriller records kailee morgue": cover},
+    })
+    assert alias == {}
+
+
+def test_unify_folds_reordered_and_embellished_artist_credits():
+    # Live-data shape: Spotify credits "Arcane, Woodkid" while Apple credits
+    # "Woodkid, Arcane, League of Legends Music" — same song, reordered AND
+    # embellished. The composite key's | separator must not block the match by
+    # fusing different neighbor tokens together.
+    from omni_sync.engine.matching import track_key
+    from omni_sync.engine.targets.base import _normalize, _unify_aliases
+
+    name = "To Ashes and Blood (from the series Arcane League of Legends)"
+    sp = _normalize({"name": name, "artist": "Arcane, Woodkid", "isrc": "X1"}, "spotify")
+    ap = _normalize({"name": name, "artist": "Woodkid, Arcane, League of Legends Music"}, "apple")
+    kid = f"k:{track_key(name, 'Woodkid, Arcane, League of Legends Music')}"
+    alias = _unify_aliases({"spotify": {"i:X1": sp}, "apple": {kid: ap}})
+    assert alias == {kid: "i:X1"}
+
+
+def test_order_history_records_dedupes_and_prunes(tmp_path, monkeypatch):
+    conn = archive.connect(str(tmp_path / "s.db"))
+    stamps = iter(f"2026-01-01T00:00:{i:02d}+00:00" for i in range(60))
+    monkeypatch.setattr(archive, "_now", lambda: next(stamps))
+    archive.record_order(conn, "mix", "spotify", [["t1", "One", "A"]])
+    archive.record_order(conn, "mix", "spotify", [["t1", "One", "A"]])  # unchanged -> no new row
+    assert len(archive.get_order_history(conn, "mix", "spotify")) == 1
+    for i in range(2, 20):
+        archive.record_order(conn, "mix", "spotify", [["t1", "One", "A"]] * i)
+    hist = archive.get_order_history(conn, "mix", "spotify")
+    assert len(hist) == archive.ORDER_HISTORY_KEEP        # pruned to the retention cap
+    assert len(hist[0][1]) == 19                          # newest first, latest snapshot intact
+    assert archive.get_order_history(conn, "mix", "apple") == []  # scoped per source
+    conn.close()
+
+
+def test_reconcile_records_order_history(tmp_path):
+    conn = archive.connect(str(tmp_path / "s.db"))
+    peers = [_FakePeer("spotify"), _FakePeer("apple")]
+    reconcile(peers, "Mix", {"spotify": {"id": "s1"}, "apple": {"id": "a1"}},
+              _caches("spotify", "apple"), conn, execute=True, max_removals=25, max_adds=200)
+    hist = archive.get_order_history(conn, "mix", "spotify")
+    assert hist and hist[0][1] == [["spotify1", "Song", "A"]]  # ordered [id, name, artist] rows
+    conn.close()
+
+
 def test_reconcile_interrupt_freezes_baseline(tmp_path):
     # A Pause/Stop mid-reconcile must NOT advance the per-provider baseline — a
     # partial advance could resurrect a track via union_prev on the next pass.

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -86,10 +86,11 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
     captured = {}
 
     def fake_mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs_, *,
-                         execute, max_removals, max_adds, source_key="spotify", source_name="Spotify", name=None):
+                         execute, max_removals, max_adds, drain_removals=False,
+                         source_key="spotify", source_name="Spotify", name=None):
         captured["tgt_id"] = tgt_playlist["id"]
         return {"clean": True, "added": 1, "removed": 0, "missing": 0, "held": 0,
-                "deferred": 0, "target_count": 1}
+                "deferred": 0, "removals_skipped": 0, "target_count": 1}
 
     monkeypatch.setattr(runner, "mirror_pair", fake_mirror_pair)
 

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -86,7 +86,7 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
     captured = {}
 
     def fake_mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs_, *,
-                         execute, max_removals, max_adds, drain_removals=False,
+                         execute, max_removals, max_adds, drain_removals=False, should_continue=None,
                          source_key="spotify", source_name="Spotify", name=None):
         captured["tgt_id"] = tgt_playlist["id"]
         return {"clean": True, "added": 1, "removed": 0, "missing": 0, "held": 0,

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -47,7 +47,7 @@ def test_nway_wraps_accumulated_summary(monkeypatch):
     monkeypatch.setattr(runner, "_post_sync", lambda *a, **k: None)
     monkeypatch.setattr(
         runner, "_run_nway",
-        lambda opts, sp, selected, songs: [runner._summary_entry("N-way", {"added": 3, "removed": 1})],
+        lambda opts, sp, selected, songs, should_continue=None: [runner._summary_entry("N-way", {"added": 3, "removed": 1})],
     )
     s = runner.run_pass(_opts(sync_mode="nway"))
     assert s["mode"] == "nway"
@@ -103,6 +103,43 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
     assert agg["added"] == 1
     assert archive.get_state(songs, "LINK1", "apple") is not None  # state keyed by the link id
     songs.close()
+
+
+def test_run_target_stops_between_playlists_on_control(tmp_path):
+    # The Stop/Pause hook: run_target checks should_continue at each playlist
+    # boundary and halts, leaving the rest for a re-run.
+    from omni_sync.engine import archive
+    from omni_sync.engine.runner import run_target
+
+    songs = archive.connect(str(tmp_path / "s.db"))
+    names = []
+
+    class Source:
+        source, name = "spotify", "Spotify"
+
+        def playlist_name(self, pl):
+            names.append(pl["name"])  # counts playlists whose iteration actually starts
+            return pl["name"]
+
+        def playlist_id(self, pl):
+            return pl.get("id")
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+        cache_file = str(tmp_path / "c.json")
+
+        def list_playlists(self):
+            return {}  # nothing exists -> dry-run "would create" path, no writes
+
+        def playlist_id(self, pl):
+            return pl.get("id")
+
+    control = iter(["run", "stop"])  # process the 1st playlist, stop before the 2nd
+    selected = [{"id": "p1", "name": "One"}, {"id": "p2", "name": "Two"}]
+    run_target(Target(), selected, lambda pl: [], songs, _opts(),
+               source=Source(), should_continue=lambda: next(control, "stop"))
+    songs.close()
+    assert names == ["One"]  # halted at the playlist boundary, never reached "Two"
 
 
 def test_mirror_pair_non_spotify_source_never_writes_links(tmp_path):

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -21,7 +21,7 @@ def test_run_job_coalesces(monkeypatch, tmp_path):
     async def scenario():
         import omni_sync.services.sync_service as m
 
-        async def fake_pass(opts):
+        async def fake_pass(opts, should_continue=None):
             calls.append("start")
             await asyncio.sleep(0.05)
             calls.append("end")
@@ -39,11 +39,68 @@ def test_run_job_coalesces(monkeypatch, tmp_path):
     assert calls == ["start", "end"]  # the overlapping duplicate trigger was coalesced
 
 
+def test_pause_marks_job_resumable(monkeypatch, tmp_path):
+    # Pause only affects the running job; the interrupted pass is recorded as
+    # "paused" so the card can offer Resume.
+    async def scenario():
+        import omni_sync.services.sync_service as m
+
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def held_pass(opts, should_continue=None):
+            started.set()
+            await release.wait()
+            return {"ok": True, "per_target": [], "interrupted": should_continue()}
+
+        monkeypatch.setattr(m, "_run_pass_async", held_pass)
+        bus = EventBus()
+        bus.bind_loop(asyncio.get_running_loop())
+        svc, jid = _svc(tmp_path, bus)
+        task = asyncio.create_task(svc.run_job(jid, True))
+        await started.wait()                       # pass is now running
+        assert svc.stop("other") is False          # only the running job responds
+        assert svc.pause(jid) is True and svc._control == "pause"
+        release.set()
+        await task
+        st = svc.status()
+        assert st["last"]["interrupted"] == "pause"
+        assert st["jobs"][0]["paused"] is True
+
+    asyncio.run(scenario())
+
+
+def test_resume_reruns_a_paused_job(monkeypatch, tmp_path):
+    runs = []
+
+    async def scenario():
+        import omni_sync.services.sync_service as m
+
+        async def fake_pass(opts, should_continue=None):
+            runs.append(1)
+            return {"ok": True, "per_target": [], "interrupted": None}
+
+        monkeypatch.setattr(m, "_run_pass_async", fake_pass)
+        bus = EventBus()
+        bus.bind_loop(asyncio.get_running_loop())
+        svc, jid = _svc(tmp_path, bus)
+        assert svc.resume(jid) is False            # not paused -> no-op
+        svc._interrupted[jid] = "paused"           # simulate a paused job
+        assert svc.resume(jid) is True
+        for _ in range(50):
+            if runs:
+                break
+            await asyncio.sleep(0.01)
+        assert runs == [1]                         # resume triggered exactly one re-run
+        assert svc.status()["jobs"][0]["paused"] is False  # cleared once it re-ran
+
+    asyncio.run(scenario())
+
+
 def test_run_job_records_failure(monkeypatch, tmp_path):
     async def scenario():
         import omni_sync.services.sync_service as m
 
-        async def boom(opts):
+        async def boom(opts, should_continue=None):
             raise RuntimeError("nope")
 
         monkeypatch.setattr(m, "_run_pass_async", boom)

--- a/tests/test_targets_accessors.py
+++ b/tests/test_targets_accessors.py
@@ -17,6 +17,27 @@ def test_playlist_id_per_provider_shape():
     assert YTMusicTarget.playlist_id(None, {"playlistId": "y1"}) == "y1"  # youtube
 
 
+def test_find_playlist_default_and_spotify_override(monkeypatch):
+    # Default scans the name-keyed list_playlists()...
+    class T(MirrorTarget):
+        def list_playlists(self):
+            return {"a": {"id": "1", "name": "A"}, "b": {"id": "2", "name": "B"}}
+
+    t = T()
+    assert t.find_playlist("2") == {"id": "2", "name": "B"}
+    assert t.find_playlist("9") is None
+
+    # ...but Spotify scans the un-deduped all_playlists, so a followed playlist
+    # sharing a name with an owned one is still reachable by id.
+    from omni_sync.engine.targets.spotify_target import SpotifyTarget
+
+    monkeypatch.setattr("omni_sync.engine.spotify.all_playlists",
+                        lambda sp: [{"id": "own", "name": "Dup", "_owned": True},
+                                    {"id": "flw", "name": "Dup", "_owned": False}])
+    target = SpotifyTarget(object(), "cache.json")
+    assert target.find_playlist("flw")["id"] == "flw"
+
+
 def test_apple_description_handles_missing():
     assert AppleMusicTarget.playlist_description(None, {"attributes": {}}) == ""
     assert AppleMusicTarget.playlist_description(

--- a/tests/test_targets_accessors.py
+++ b/tests/test_targets_accessors.py
@@ -64,7 +64,8 @@ def test_ytmusic_browser_backend_maps_shapes_and_is_selected(monkeypatch, tmp_pa
             ]}
 
         def get_library_playlists(self, limit=None):
-            return [{"playlistId": "p1", "title": "Mix", "count": "12 songs"}]
+            return [{"playlistId": "p1", "title": "Mix", "count": "12 songs",
+                     "thumbnails": [{"url": "http://yt/cover.jpg"}]}]
 
     monkeypatch.setattr("ytmusicapi.YTMusic", FakeYTM)
     auth = tmp_path / "browser.json"
@@ -79,7 +80,9 @@ def test_ytmusic_browser_backend_maps_shapes_and_is_selected(monkeypatch, tmp_pa
     assert len(tracks) == 1
     t = tracks[0]
     assert (t["videoId"], t["setVideoId"], t["artist"], t["duration_ms"]) == ("v1", "s1", "A, B", 200000)
-    assert target.list_playlists() == {"mix": {"playlistId": "p1", "title": "Mix", "count": "12 songs"}}
+    assert target.list_playlists() == {
+        "mix": {"playlistId": "p1", "title": "Mix", "count": "12 songs",
+                "thumbnails": [{"url": "http://yt/cover.jpg"}]}}
 
 
 def test_apple_playlist_count_uses_meta_total_and_caches():

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -45,6 +45,42 @@ def test_transfer_copies_matches_skips_dupes_reports_conflicts():
     # "Dup" already exists on the destination (same track_key) -> skipped, not re-added
 
 
+def test_transfer_same_provider_copies_by_id_without_resolving():
+    # Spotify -> Spotify (e.g. a followed list into a new owned one): the track's own
+    # id is already valid on the destination, so transfer() copies it directly and
+    # never invokes the fuzzy resolver.
+    added, resolved = [], []
+
+    class _SpotifySrc:
+        source = "spotify"
+
+        def playlist_tracks(self, pl):
+            return [{"id": "t1", "name": "One", "artists": ["A"], "duration_ms": 1, "added_at": "1"},
+                    {"id": "t2", "name": "Two", "artists": ["B"], "duration_ms": 1, "added_at": "2"}]
+
+        def track_id(self, raw):
+            return raw["id"]
+
+    class _SpotifyDst:
+        source = "spotify"
+
+        def playlist_tracks(self, pl):
+            return []
+
+        def resolve(self, norm, cache):
+            resolved.append(norm["name"])  # must never be called for same-provider
+            return (None, None)
+
+        def add(self, pl, ids):
+            added.extend(ids)
+
+    res = transfer(_SpotifySrc(), _SpotifyDst(), {"id": "s"}, {"id": "d"},
+                   {"search": {}, "isrc": {}, "dirty": False}, execute=True, max_adds=100)
+    assert res["added"] == 2
+    assert added == ["t1", "t2"]   # copied by their own ids, oldest-first
+    assert resolved == []          # resolver never invoked
+
+
 def test_transfer_dry_run_adds_nothing():
     added = []
     res = transfer(_Src(), _dst_factory(added), {"id": "s"}, {"id": "d"},
@@ -138,8 +174,8 @@ def test_run_exclusive_queues_behind_sync(monkeypatch, tmp_path):
 
 
 class _Prov:
-    def __init__(self, cache_file, tracks):
-        self.name, self.source, self.cache_file = "Prov", "apple", cache_file
+    def __init__(self, cache_file, tracks, source="apple"):
+        self.name, self.source, self.cache_file = "Prov", source, cache_file
         self._tracks = tracks
 
     def list_playlists(self):
@@ -147,6 +183,9 @@ class _Prov:
 
     def playlist_id(self, pl):
         return pl.get("id")
+
+    def find_playlist(self, playlist_id):
+        return next((pl for pl in self.list_playlists().values() if self.playlist_id(pl) == playlist_id), None)
 
     def playlist_name(self, pl):
         return pl.get("name", "")
@@ -179,7 +218,7 @@ def _service(monkeypatch, tmp_path):
     src = _Prov(str(tmp_path / "s.json"),
                 [{"id": "t", "name": "Song", "artists": ["A"], "artist": "A",
                   "duration_ms": 1, "isrc": "I", "added_at": "1"}])
-    dst = _Prov(str(tmp_path / "d.json"), [])  # empty destination
+    dst = _Prov(str(tmp_path / "d.json"), [], source="ytmusic")  # empty destination, other provider
     monkeypatch.setattr(TransferService, "_build",
                         lambda self, pid, opts, s=src, d=dst: s if pid == "apple" else d)
     return src, dst

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -153,7 +153,7 @@ def test_run_exclusive_queues_behind_sync(monkeypatch, tmp_path):
     async def scenario():
         import omni_sync.services.sync_service as m
 
-        async def fake_pass(opts):
+        async def fake_pass(opts, should_continue=None):
             order.append("sync-start")
             await asyncio.sleep(0.05)
             order.append("sync-end")


### PR DESCRIPTION
## Summary
- **Same-provider transfers** — copy a followed Spotify playlist into a new owned playlist with a custom name; same-provider tracks copy by their own id (no lossy re-search). The destination picker is restricted to playlists you own; the source still lists all.
- **Followed-playlist visibility** — browse returns `owned`; the picker shows a Created/Followed divider; Spotify lists un-deduped so a same-named followed playlist is no longer hidden. Ownership lives in `MirrorTarget.browse_playlists`, keeping browse/find provider-agnostic.
- **Removal reconciliation** — the per-provider baseline records even when a pass only *defers adds*, so removals activate on the next pass instead of only after the whole add backlog drains (fixes the `+200 −0 … deferred` trap). New opt-in per-sync **Apply large removals** toggle drains removals over the cap in batches; the safe default is surfaced on the dashboard.
- **Pause/Stop running syncs** — a running sync pass can now be interrupted like a transfer: **Stop** aborts it, **Pause** holds it, **Resume** re-runs (reconcile is idempotent, so it resumes the remainder). Takes effect at the next playlist boundary; applied changes persist. New `POST /api/syncs/{id}/{pause,stop,resume}` + Stop/Pause/Resume on the sync card.
- **Sync UX** — preset interval dropdown in the wizard (was free-text); Jellyfin connect points Docker users at `host.docker.internal`.
- **Docs** — `docs/adding-a-provider.md`: a five-touchpoint guide for adding Tidal/Qobuz/Deezer.

## Test plan
- [x] `pytest` — 101 passed (new self-checks: same-provider copy, browse ownership, `find_playlist`, removal baseline vs deferred adds, large-removal skip-vs-drain, pause marks resumable, resume re-runs, run_target halts at the playlist boundary)
- [x] `pnpm -C frontend build` (typecheck) + `lint` clean
- [x] `pnpm -C frontend test:e2e` — 110 checks, 0 overflow
- [x] Live smoke test against a real Spotify account (browse 32 playlists → 14 owned / 18 followed; writable client + drain plumbing loaded)