### PR TITLE
fix(sync): unify aliases against every copy's keys

### DIFF
--- a/omni_sync/engine/dedupe.py
+++ b/omni_sync/engine/dedupe.py
@@ -62,7 +62,7 @@ def scan(peers, playlists, caches, songs, state_key):
         for cid, norm in ec:
             if cid.startswith("i:"):
                 key2isrc.setdefault(track_key(norm["name"], norm["artist"]), cid[2:])
-    alias = _unify_aliases(canon)
+    alias = _unify_aliases(per_entry)  # every copy's keys, not just the first per identity
     entries = {}
     for p in peers:
         src = p.source

--- a/omni_sync/engine/matching.py
+++ b/omni_sync/engine/matching.py
@@ -37,8 +37,10 @@ def normalize_text(value):
 def loose_name(name):
     """Title with feat-clauses stripped — '(feat. X)' is the classic drift for
     the SAME song. Version qualifiers like (Live)/(Acoustic) are kept: those
-    are different recordings."""
+    are different recordings — but the abbreviation 'ver' expands to 'version'
+    so 'Twin Ver.' and 'Twin Version' agree token-for-token."""
     cleaned = TRAILING_FEAT_RE.sub("", normalize_text(PAREN_FEAT_RE.sub(" ", name or ""))).strip()
+    cleaned = re.sub(r"\bver\b", "version", cleaned)
     return cleaned or normalize_text(name)
 
 

--- a/omni_sync/engine/targets/base.py
+++ b/omni_sync/engine/targets/base.py
@@ -316,10 +316,16 @@ def _unify_aliases(canon):
     as a duplicate each pass — and a flip between aliases reads as a user
     deletion. Matching: any exact spotify_track_keys overlap, else the same
     composite-key fuzzy tolerance the one-way removal guard trusts. Hard ids
-    never merge with each other — two ISRCs are two recordings."""
+    never merge with each other — two ISRCs are two recordings.
+
+    `canon` values may be {cid: norm} dicts OR per-entry (cid, norm) sequences.
+    Per-entry is strictly better: one identity often spans several releases with
+    DIFFERENT titles ("Song" + "Song (From ...)"), and an alias may match only
+    the copy a dict fold would have dropped."""
     keysets = {}
     for by_cid in canon.values():
-        for cid, norm in by_cid.items():
+        pairs = by_cid.items() if hasattr(by_cid, "items") else by_cid
+        for cid, norm in pairs:
             keysets.setdefault(cid, set()).update(spotify_track_keys(norm))
     soft = sorted(cid for cid in keysets if cid.startswith("k:"))
     if not soft:
@@ -394,6 +400,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     prev = {p.source: archive.get_playlist_state(songs, key, p.source) for p in peers}
 
     canon = {}         # source -> {canonical_id: normalized track}
+    per_entry = {}     # source -> [(canonical_id, norm)] for EVERY physical entry
     present = {}       # source -> set of ALL current target ids (not canonical-deduped)
     key2isrc = {}      # track_key -> ISRC, seeded by any ISRC-bearing provider (peers are ISRC-rich first)
     for p in peers:
@@ -403,15 +410,21 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                              [[p.track_id(t), t.get("name", ""),
                                t.get("artist") or ", ".join(t.get("artists") or [])] for t in raw])
         present[p.source] = {p.track_id(t) for t in raw if p.track_id(t)}
-        canon[p.source] = _canonicalize(p, raw, songs, caches[p.source], key2isrc)
-        for cid, norm in canon[p.source].items():
+        per_entry[p.source] = _entry_cids(p, raw, songs, caches[p.source], key2isrc)
+        fold = {}
+        for cid, norm in per_entry[p.source]:
+            fold.setdefault(cid, norm)  # first occurrence wins (dedupe within a provider)
+        canon[p.source] = fold
+        for cid, norm in per_entry[p.source]:
             if cid.startswith("i:"):  # any provider that resolved an ISRC anchors the rest
                 key2isrc.setdefault(track_key(norm["name"], norm["artist"]), cid[2:])
 
     # One identity per song: fold provider-flavored aliases together BEFORE any
     # membership math, and map the stored baseline through the same table so a
-    # retired alias is never mistaken for a deletion.
-    alias = _unify_aliases(canon)
+    # retired alias is never mistaken for a deletion. Unification sees every
+    # PHYSICAL entry's keys — an identity spanning differently-titled releases
+    # must expose all of their names for aliases to land on.
+    alias = _unify_aliases(per_entry)
     if alias:
         for src, by_cid in canon.items():
             merged = {}

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -335,6 +335,38 @@ def test_alias_flip_never_removes_the_real_track(tmp_path):
     conn.close()
 
 
+def test_unify_uses_every_copys_keys_not_just_the_first():
+    # Live-data shape (chai & chill): one identity, two Spotify releases — the
+    # decorated title sits FIRST in playlist order. The junk YT copy matches
+    # only the plain second copy's keys; unification must consider every
+    # entry's keys, not just the first copy folded into canon.
+    from omni_sync.engine.matching import track_key
+    from omni_sync.engine.targets.base import _normalize, _unify_aliases
+
+    dec = _normalize({"name": 'Kuch To Hai (From "Do Lafzon Ki Kahani")',
+                      "artists": ["Armaan Malik"], "isrc": "I1"}, "spotify")
+    plain = _normalize({"name": "Kuch To Hai",
+                        "artists": ["Armaan Malik", "Amaal Mallik", "Manoj Muntashir"],
+                        "isrc": "I1"}, "spotify")
+    junk = _normalize({"name": "KUCH TO HAI", "artists": ["ARMAAN MALIK", "AMAAL MALLIK"]}, "ytmusic")
+    kid = f"k:{track_key('KUCH TO HAI', 'ARMAAN MALIK, AMAAL MALLIK')}"
+    alias = _unify_aliases({"spotify": [("i:I1", dec), ("i:I1", plain)], "ytmusic": [(kid, junk)]})
+    assert alias == {kid: "i:I1"}
+
+
+def test_unify_folds_ver_abbreviation_into_version():
+    # "Twin Ver." vs "Twin Version" — the same release string abbreviated;
+    # token-set matching can't bridge ver/version, so loose_name normalizes it.
+    from omni_sync.engine.matching import track_key
+    from omni_sync.engine.targets.base import _normalize, _unify_aliases
+
+    sp = _normalize({"name": "Cupid - Twin Ver.", "artists": ["FIFTY FIFTY"], "isrc": "K1"}, "spotify")
+    ap = _normalize({"name": "Cupid (Twin Version)", "artist": "FIFTY FIFTY"}, "apple")
+    kid = f"k:{track_key('Cupid (Twin Version)', 'FIFTY FIFTY')}"
+    alias = _unify_aliases({"spotify": {"i:K1": sp}, "apple": {kid: ap}})
+    assert alias == {kid: "i:K1"}
+
+
 def test_unify_never_merges_different_songs():
     # Same title, different artists (a cover on a label channel) must stay two
     # canonical identities — unification is for provider-flavored metadata of


### PR DESCRIPTION
## Summary
- `_unify_aliases` saw only the first copy's keys per identity; an identity spanning differently-titled releases ("Kuch To Hai" / "Kuch To Hai (From …)") never exposed the plain title, so junk provider copies failed to fold and re-added variant releases every pass (a loop with the duplicate cleanup).
- reconcile and the dedupe scan now pass every physical entry's (cid, norm) pairs into unification.
- `loose_name` expands standalone `ver` → `version` ("Twin Ver." ≡ "Twin Version").

## Test plan
- [x] 116 tests pass; two new regression tests mirror the live Chai & Chill and Cupid shapes
- [x] Live diagnostic on Chai & Chill: `k:kuch to hai|…` now folds to `i:INS181600701`; plan drops to +0/+0