### PR TITLE
fix(web): reset the sync wizard before paint

### DIFF
--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useLayoutEffect, useState } from 'react'
 import { LuArrowLeft, LuArrowRight, LuCheck, LuInfo } from 'react-icons/lu'
 
 import { api, errorMessage } from '@/api'
@@ -251,8 +251,10 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   const [error, setError] = useState<string | null>(null)
 
   // Fresh state every time the wizard (re)opens, so a previous attempt (or a
-  // different job) never leaks into a new session.
-  useEffect(() => {
+  // different job) never leaks into a new session. Layout effect: it must
+  // apply BEFORE paint, or editing an N-way job flashes one frame of the
+  // one-way defaults (Source-of-truth picker included).
+  useLayoutEffect(() => {
     if (!open) return
     setForm(formFromJob(job))
     setStep(0)


### PR DESCRIPTION
## Summary
- Editing an N-way job flashed one frame of the one-way defaults (Source-of-truth picker visible) because the form reset ran in a post-paint `useEffect`; the mocked-CI screenshot check caught the frame intermittently (main run 29411229697).
- `useLayoutEffect` applies the same reset before paint, eliminating the flash and the flake at its source.

## Test plan
- [x] `pnpm build` + `pnpm lint` clean
- [x] e2e: 110 checks, 0 overflow — including "Source of truth picker is hidden while N-way"