### PR TITLE
feat(sync): never mirror removals by default, with per-sync opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,9 @@ SPOTIFY_CLIENT_SECRET=
 SPOTIFY_REDIRECT_URI=http://127.0.0.1:8888/callback
 PLAYLISTS=                # comma-separated names; empty = every same-named pair
 SYNC_INTERVAL=15m         # loop sleep (e.g. 900, 15m, 1h)
-MAX_REMOVALS=25           # per-playlist removal cap per pass (guards every write side)
+MAX_REMOVALS=0            # per-playlist removal cap per pass. 0 (default) = removals never
+                          # propagate: a track gone from one service (deleted, or pulled by
+                          # licensing) is kept everywhere else. Raise to mirror removals too.
 MAX_ADDS=200              # per-playlist additions cap per pass (rest continue next pass)
 
 # Sync direction. oneway (default) = Spotify -> Apple/YT, Spotify never modified.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Bidirectional sync is impossible statelessly, so each logical playlist's canonic
 - **Add-wins** on conflict — losing a song is worse than keeping an extra one.
 - **Read-collapse guard** — if a provider suddenly reads far fewer tracks than the baseline (a transient API hiccup), it's skipped that pass so one bad read can't cascade a mass-delete.
 - **Same rails as one-way** — per-pass `MAX_ADDS` / `MAX_REMOVALS` caps and net-loss protection hold on every write side.
+- **Removals are opt-in** — `MAX_REMOVALS` defaults to 0, so a track that disappears from one provider (deleted there, or silently pulled by licensing) is kept on the others and only logged. Set a cap (or the UI's "Mirror removals" toggle) to propagate deletions.
 
 > **Always dry-run first.** Run without `--execute` (or use **Preview** in the UI) and read the plan — it prints every proposed add/remove on every provider before anything is written.
 
@@ -323,7 +324,7 @@ Removals are destructive, so they're guarded:
 
 - **Dry run is the default** — nothing changes without `--execute` (or the UI's real-sync action).
 - If the source returns 0 tracks for a playlist the target shows as non-empty, removals are skipped that pass (a transient API failure can't empty a playlist).
-- More than `MAX_REMOVALS` pending removals in one pass → removals are skipped and logged.
+- **Removals are off by default** — `MAX_REMOVALS=0` holds every removal back (logged, never applied), so a licensing takedown on one platform can't cascade a deletion to the rest. Opt in per sync with the "Mirror removals" toggle (or set `MAX_REMOVALS`), and even then more pending removals than the cap in one pass → all skipped and logged.
 - More than `MAX_ADDS` pending additions → the rest continue next pass (giant one-burst backfills are what trip bot detection).
 - **Net-loss protection** — a target-side track resembling a source track that has no match on that service is held, not deleted.
 - Any Apple `401/403` aborts the pass immediately — no partial deletes on expired tokens.

--- a/frontend/src/components/dashboard/NeedsALook.tsx
+++ b/frontend/src/components/dashboard/NeedsALook.tsx
@@ -75,7 +75,7 @@ function buildItems(accounts: Account[] | null, status: SyncStatus | null): Need
       icon: LuTriangleAlert,
       title: `${removalsSkipped} removal${removalsSkipped === 1 ? '' : 's'} held back for safety`,
       description:
-        'They exceeded the per-pass removal cap. Turn on "Apply large removals" for the sync to delete them in batches over the next passes.',
+        'Tracks left a playlist on one service, and this sync isn\'t allowed to delete that many elsewhere. Turn on "Mirror removals" (and raise its cap) on the sync if you want them to follow.',
       action: { label: 'Open sync', to: '/sync' },
     })
   }

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -10,10 +10,11 @@ import { ServiceLogo } from '@/components/ui/ServiceLogo'
 import { SettingsGroup } from '@/components/ui/SettingsGroup'
 import { TextField } from '@/components/ui/TextField'
 import { Toggle } from '@/components/ui/Toggle'
+import { Tooltip } from '@/components/ui/Tooltip'
 import { useSettings } from '@/hooks/useSettings'
 import { cn } from '@/lib/cn'
 import { serviceLogoId, tagDot, tagText } from '@/lib/constants'
-import { isValidIntervalText, isValidNonNegativeInt, isValidPositiveInt } from '@/lib/format'
+import { isValidIntervalText, isValidPositiveInt } from '@/lib/format'
 import { buildSyncSummaryRows, enabledProvidersOf, lockedSourceOf, syncPeersOf } from '@/lib/syncSummary'
 import { PlaylistFilterField } from '../settings/PlaylistFilterField'
 import type { Account, SyncJob, SyncJobUpsertRequest, SyncMode } from '@/types'
@@ -30,6 +31,8 @@ interface JobFormState {
   playlists: string
   interval: string
   max_adds: string
+  /** UI-only switch; persisted as max_removals (0 = off, the safe default). */
+  mirror_removals: boolean
   max_removals: string
   apply_large_removals: boolean
   download: boolean
@@ -44,6 +47,7 @@ const NEW_JOB_DEFAULTS: JobFormState = {
   playlists: '',
   interval: '15m',
   max_adds: '200',
+  mirror_removals: false,
   max_removals: '25',
   apply_large_removals: false,
   download: false,
@@ -60,7 +64,9 @@ function formFromJob(job: SyncJob | null): JobFormState {
     playlists: job.playlists,
     interval: job.interval,
     max_adds: String(job.max_adds),
-    max_removals: String(job.max_removals),
+    mirror_removals: job.max_removals > 0,
+    // Keep a sane cap staged so switching mirroring on doesn't start from 0.
+    max_removals: job.max_removals > 0 ? String(job.max_removals) : '25',
     apply_large_removals: job.apply_large_removals,
     download: job.download,
   }
@@ -308,7 +314,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   const nameValid = form.name.trim().length > 0
   const intervalValid = isValidIntervalText(form.interval)
   const maxAddsValid = isValidPositiveInt(form.max_adds)
-  const maxRemovalsValid = isValidNonNegativeInt(form.max_removals)
+  const maxRemovalsValid = !form.mirror_removals || isValidPositiveInt(form.max_removals)
   const formValid = nameValid && intervalValid && maxAddsValid && maxRemovalsValid
 
   // Only Direction's name (always valid) aside, Schedule (interval) and
@@ -326,8 +332,8 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     playlists: form.playlists,
     interval: form.interval,
     max_adds: Number(form.max_adds) || 0,
-    max_removals: Number(form.max_removals) || 0,
-    apply_large_removals: form.apply_large_removals,
+    max_removals: form.mirror_removals ? Number(form.max_removals) || 0 : 0,
+    apply_large_removals: form.mirror_removals && form.apply_large_removals,
     download: form.download,
   }
   const summaryRows = buildSyncSummaryRows(previewJob, syncPeers, settings?.DOWNLOAD_DIR)
@@ -346,8 +352,8 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
         playlists: form.playlists,
         interval: form.interval,
         max_adds: Number(form.max_adds),
-        max_removals: Number(form.max_removals),
-        apply_large_removals: form.apply_large_removals,
+        max_removals: form.mirror_removals ? Number(form.max_removals) : 0,
+        apply_large_removals: form.mirror_removals && form.apply_large_removals,
         download: form.download,
       }
       if (job) await api.updateSync(job.id, values)
@@ -514,14 +520,16 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     onChange={(e) => setField('max_adds', e.target.value)}
                     error={!maxAddsValid ? 'Enter a whole number of 1 or more.' : undefined}
                   />
-                  <TextField
-                    label="Max removals / pass"
-                    type="number"
-                    min={0}
-                    value={form.max_removals}
-                    onChange={(e) => setField('max_removals', e.target.value)}
-                    error={!maxRemovalsValid ? 'Enter a whole number of 0 or more.' : undefined}
-                  />
+                  {form.mirror_removals && (
+                    <TextField
+                      label="Max removals / pass"
+                      type="number"
+                      min={1}
+                      value={form.max_removals}
+                      onChange={(e) => setField('max_removals', e.target.value)}
+                      error={!maxRemovalsValid ? 'Enter a whole number of 1 or more.' : undefined}
+                    />
+                  )}
                 </div>
                 <div className="flex gap-2.5 rounded-control bg-warning-soft px-3.5 py-2.5">
                   <span className="font-mono text-xs font-semibold text-warning" aria-hidden="true">
@@ -532,12 +540,40 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     instead of writing it. You'll see held rows in the feed and can review before anything is lost.
                   </p>
                 </div>
-                <Toggle
-                  checked={form.apply_large_removals}
-                  onChange={(v) => setField('apply_large_removals', v)}
-                  label="Apply large removals"
-                  description="Off (default): removals beyond the cap are held back for safety. On: they're deleted in capped batches over successive passes until cleared."
-                />
+                <div className="flex items-center gap-3">
+                  <Toggle
+                    className="flex-1"
+                    checked={form.mirror_removals}
+                    onChange={(v) => setField('mirror_removals', v)}
+                    label="Mirror removals"
+                    description="Off (default): a track removed on one service is kept on the others — so a song losing licensing on one platform never disappears everywhere. On: removals sync too, capped per pass."
+                  />
+                  <Tooltip
+                    content={
+                      <>
+                        A track removed on <span className="font-semibold text-text">any</span> service — including one
+                        quietly pulled by a licensing change — is deleted from all the others, and its downloaded copy
+                        goes too. Removals under the cap apply without review.
+                      </>
+                    }
+                  >
+                    <button
+                      type="button"
+                      aria-label="About mirroring removals"
+                      className="cursor-help rounded-full p-1 text-text-3 transition-colors duration-fast hover:text-warning focus-visible:text-warning"
+                    >
+                      <LuInfo size={15} />
+                    </button>
+                  </Tooltip>
+                </div>
+                {form.mirror_removals && (
+                  <Toggle
+                    checked={form.apply_large_removals}
+                    onChange={(v) => setField('apply_large_removals', v)}
+                    label="Apply large removals"
+                    description="Off (default): removals beyond the cap are held back for safety. On: they're deleted in capped batches over successive passes until cleared."
+                  />
+                )}
               </div>
 
               <div className="border-t border-border pt-3.5">

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/cn'
+
+/** CSS-only hover/focus tooltip. The bubble is `display: none` until shown
+ * (never `opacity`), so it contributes nothing to layout or overflow while
+ * hidden; it appears for mouse hover and keyboard focus alike. Anchored above
+ * the trigger and right-aligned, so a trigger near a row's right edge keeps
+ * the bubble inside the panel. */
+export function Tooltip({
+  content,
+  children,
+  className,
+}: {
+  content: ReactNode
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <span className={cn('group/tip relative inline-flex', className)}>
+      {children}
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute bottom-full right-0 z-50 mb-2 hidden w-64 rounded-control border border-border bg-surface px-3.5 py-2.5 text-[12px] leading-relaxed text-text-2 shadow-lg group-hover/tip:block group-focus-within/tip:block"
+      >
+        {content}
+      </span>
+    </span>
+  )
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -78,8 +78,3 @@ export function isValidIntervalText(value: string): boolean {
 export function isValidPositiveInt(value: string): boolean {
   return /^\d+$/.test(value.trim()) && Number(value) >= 1
 }
-
-/** Matches the backend's `--max-removals` validation (config.py: must be >= 0). */
-export function isValidNonNegativeInt(value: string): boolean {
-  return /^\d+$/.test(value.trim())
-}

--- a/frontend/src/lib/syncSummary.ts
+++ b/frontend/src/lib/syncSummary.ts
@@ -75,7 +75,13 @@ export function buildSyncSummaryRows(job: SyncJob, peers: Account[], downloadDir
   rows.push({ label: 'Playlists', value: playlistsValue })
 
   const removalNote = job.apply_large_removals ? ' (large removals drained in batches)' : ''
-  rows.push({ label: 'Limits', value: `≤${job.max_adds} adds, ≤${job.max_removals} removals / pass${removalNote}` })
+  rows.push({
+    label: 'Limits',
+    value:
+      job.max_removals > 0
+        ? `≤${job.max_adds} adds, ≤${job.max_removals} removals / pass${removalNote}`
+        : `≤${job.max_adds} adds / pass · removals not mirrored`,
+  })
 
   rows.push({
     label: 'Downloads',

--- a/songmirror/engine/config.py
+++ b/songmirror/engine/config.py
@@ -11,7 +11,7 @@ AMP = "https://amp-api.music.apple.com/v1"
 REQUEST_TIMEOUT = 30
 
 DEFAULT_INTERVAL = "15m"
-DEFAULT_MAX_REMOVALS = 25
+DEFAULT_MAX_REMOVALS = 0
 DEFAULT_MAX_ADDS = 200
 DEFAULT_CACHE_FILE = "apple_resolve_cache.json"
 DEFAULT_SONG_CACHE_FILE = "song_cache.db"
@@ -98,7 +98,8 @@ def parse_args(argv=None):
     p.add_argument("--playlists", default=os.getenv("PLAYLISTS", ""),
                    help="Comma-separated playlist names to sync (default: every same-named pair).")
     p.add_argument("--max-removals", type=int, default=int(os.getenv("MAX_REMOVALS", DEFAULT_MAX_REMOVALS)),
-                   help=f"Per-playlist removal cap per pass; more than this skips removals (default: {DEFAULT_MAX_REMOVALS}).")
+                   help="Per-playlist removal cap per pass; more than this skips removals. 0 never propagates "
+                        f"removals — a track gone from one service is kept everywhere else (default: {DEFAULT_MAX_REMOVALS}).")
     p.add_argument("--max-adds", type=int, default=int(os.getenv("MAX_ADDS", DEFAULT_MAX_ADDS)),
                    help=f"Per-playlist additions cap per pass; the rest continue next pass (default: {DEFAULT_MAX_ADDS}).")
     p.add_argument("--apply-large-removals", action="store_true", default=os.getenv("APPLY_LARGE_REMOVALS") == "1",

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -203,7 +203,11 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         log_warn(f"{source_name} returned 0 tracks but {target.name} has {len(tgt_tracks)}; skipping all removals this pass", tag=tag)
         removals, guard = [], True
     elif len(removals) > max_removals:
-        if drain_removals:
+        if max_removals == 0:
+            log_warn(f"{len(removals)} removals detected; removal mirroring is off "
+                     "(max removals = 0) — kept everywhere, raise the cap on this sync to apply", tag=tag)
+            removals_skipped, removals, guard = len(removals), [], True
+        elif drain_removals:
             log_warn(f"draining removals — applying {max_removals} now, {len(removals) - max_removals} next pass", tag=tag)
             removals, guard = removals[:max_removals], True
         else:
@@ -514,7 +518,12 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             # Cap hit: freezing the baseline (removals_capped) is what keeps a
             # held-back / mid-drain removal from being resurrected via union_prev.
             removals_capped, stats["clean"] = True, False
-            if drain_removals:
+            if max_removals == 0:
+                log_warn(f"{p.name}/{name}: {len(safe)} removals detected; removal mirroring is off "
+                         "(max removals = 0) — kept everywhere, raise the cap on this sync to apply", tag=p.tag)
+                stats["removals_skipped"] += len(safe)
+                safe = []
+            elif drain_removals:
                 log_warn(f"{p.name}/{name}: draining removals — applying {max_removals} now, "
                          f"{len(safe) - max_removals} next pass", tag=p.tag)
                 safe = safe[:max_removals]

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -236,6 +236,22 @@ def test_large_removals_held_back_by_default_then_drain_when_opted_in(tmp_path):
     conn.close()
 
 
+def test_removals_never_propagate_at_cap_zero(tmp_path):
+    # max_removals=0 is the "removals off" switch (the default): a track gone
+    # from one provider (user delete or a licensing pull) is kept everywhere
+    # else, surfaced as skipped, and the baseline stays frozen so the held
+    # removal can't resurrect or silently apply later.
+    conn = archive.connect(str(tmp_path / "z.db"))
+    for src in ("spotify", "apple"):
+        archive.set_playlist_state(conn, "mix", src, {f"i:{i}" for i in "ABCD"})
+    sp, ap = _P("spotify", ["A", "B", "C"]), _P("apple", ["A", "B", "C", "D"])  # D dropped on spotify
+    stats = reconcile([sp, ap], "Mix", {"spotify": {"id": "s"}, "apple": {"id": "a"}},
+                      _caches("spotify", "apple"), conn, execute=True, max_removals=0, max_adds=200)
+    assert stats["removals_skipped"] == 1 and ap.removed == []
+    assert archive.get_playlist_state(conn, "mix", "apple") == {f"i:{i}" for i in "ABCD"}  # frozen
+    conn.close()
+
+
 class _VariantPeer:
     """Peer holding ONE copy of a song under provider-flavored metadata
     (decorated title, partial or embellished artist credits). resolve() returns


### PR DESCRIPTION
## Summary
- `MAX_REMOVALS` now defaults to 0: a track that disappears from one provider (user delete or a silent licensing pull) is kept on every other service and only surfaced as held back — deletion mirroring is a per-sync opt-in.
- Wizard gains a "Mirror removals" toggle (off by default) that gates the removals cap and "Apply large removals", plus a hover/focus warning tooltip (new CSS-only `Tooltip` primitive) spelling out that deletions cascade to every service and the download mirror.
- Copy across the review summary, dashboard held-removals card, README, and `.env.example` reflects the new default; both engine removal gates log a dedicated cap-zero message.

## Test plan
- [x] `uv run pytest tests/` — 126 passed, incl. new `test_removals_never_propagate_at_cap_zero` (cap 0 holds all removals, baseline frozen)
- [x] `npm run build` + `npm run lint` — clean
- [x] `npm run test:e2e` — 110 checks, 0 failures, 0 overflow
- [x] Docker image rebuilt; live sync verified via `/api/syncs` with `max_removals: 0`