### PR TITLE
feat(accounts): support remote Spotify OAuth callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 # Provider credentials (configure only the services you use; at least two for syncing)
+# Browser-visible base URL for redirect-based OAuth when SongMirror runs behind
+# Docker or a reverse proxy. Keep this unset for the default request-derived URL.
+# Spotify requires HTTPS here unless the host is a literal loopback address.
+# Example callback: https://music.example.com/oauth/spotify/callback
+#SONGMIRROR_PUBLIC_URL=https://music.example.com
+
 APPLE_BEARER_TOKEN=
 APPLE_USER_TOKEN=
 
@@ -7,6 +13,7 @@ APPLE_USER_TOKEN=
 SPOTIFY_SP_DC=
 SPOTIFY_WRITE_BACKEND=cookie
 # Optional legacy developer-app OAuth fallback:
+#SPOTIFY_AUTH_MODE=oauth       # changes the Accounts wizard from cookie paste to OAuth
 #SPOTIFY_CLIENT_ID=
 #SPOTIFY_CLIENT_SECRET=
 
@@ -51,8 +58,9 @@ AMAZON_MUSIC_CACHE_FILE=amazon_music_resolve_cache.json
 #AMAZON_MUSIC_CLIENT_SECRET=
 #AMAZON_MUSIC_TOKEN_FILE=data/amazon_music_oauth.json
 
-# Optional (legacy Spotify OAuth only)
-#SPOTIFY_REDIRECT_URI=http://127.0.0.1:8888/callback
+# Optional legacy Spotipy/CLI callback. The web app instead derives its exact
+# /oauth/spotify/callback URI from SONGMIRROR_PUBLIC_URL above.
+#SPOTIFY_REDIRECT_URI=http://127.0.0.1:8888/oauth/spotify/callback
 PLAYLISTS=                # comma-separated names; empty = every same-named pair
 SYNC_INTERVAL=15m         # loop sleep (e.g. 900, 15m, 1h)
 MAX_REMOVALS=0            # per-playlist removal cap per pass. 0 (default) = removals never

--- a/README.md
+++ b/README.md
@@ -168,6 +168,17 @@ docker compose logs -f           # watch it work
 
 **No `.env` is needed to start** — everything is configured in the browser and saved under `./data`. OAuth, partner-token, and API-key setup all live on the Accounts page; each wizard explains the service-specific prerequisites and exact callback URI. Then build your syncs on the Sync page.
 
+Opening SongMirror from another computer works at `http://<server>:8888`. The default Spotify connection uses a pasted `sp_dc` web session, so it needs no developer app or callback URL. If you intentionally use the legacy developer-app OAuth fallback behind Docker or a reverse proxy, set the browser-visible base URL in `.env`:
+
+```dotenv
+SPOTIFY_AUTH_MODE=oauth
+SPOTIFY_CLIENT_ID=your-client-id
+SPOTIFY_CLIENT_SECRET=your-client-secret
+SONGMIRROR_PUBLIC_URL=https://music.example.com
+```
+
+SongMirror will then advertise `https://music.example.com/oauth/spotify/callback`; register that exact URI in the Spotify app dashboard and recreate the container with `docker compose up -d --force-recreate`. A reverse-proxy base path is supported too (for example, `https://example.com/songmirror`). [Spotify requires HTTPS](https://developer.spotify.com/documentation/web-api/concepts/redirect_uri) for every non-loopback redirect; plain HTTP is accepted only with literal loopback addresses such as `127.0.0.1`, not a LAN IP or `localhost`.
+
 | | |
 | --- | --- |
 | **Port** | The UI is published on host **8888** (the `8888:8080` mapping in `docker-compose.yml`; change the host side if it clashes). **LAN-only** — don't port-forward it to the internet; the UI has no login yet. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     # under ./data. Keep a .env only to preset things like DOWNLOAD_DIR or
     # credentials. (`required: false` needs Docker Compose v2.24+; on older
     # versions either create an empty `.env` or drop the `path:`/`required:` keys.)
+    # For redirect-based OAuth on a remote host, set SONGMIRROR_PUBLIC_URL in
+    # that file to the browser-visible HTTPS base URL.
     env_file:
       - path: .env
         required: false

--- a/songmirror/services/accounts/spotify.py
+++ b/songmirror/services/accounts/spotify.py
@@ -10,10 +10,31 @@ class SpotifyConnector(Connector):
     id = "spotify"
     name = "Spotify"
     auth_kind = "token_paste"
-    config_fields = [
+    _cookie_fields = [
         Field("SPOTIFY_SP_DC", "sp_dc cookie", secret=True,
               help="From open.spotify.com → browser dev tools → Application/Storage → Cookies"),
     ]
+    _oauth_fields = [
+        Field("SPOTIFY_CLIENT_ID", "Client ID"),
+        Field("SPOTIFY_CLIENT_SECRET", "Client secret", secret=True),
+    ]
+    # The class-level union lets settings.py discover every Spotify secret.
+    # Each connector instance narrows this to the fields for its selected flow.
+    config_fields = _cookie_fields + _oauth_fields
+
+    def __init__(self, store):
+        super().__init__(store)
+        self._select_auth_flow()
+
+    def _select_auth_flow(self):
+        selected = str(self._value("SPOTIFY_AUTH_MODE") or "").strip().lower()
+        oauth = selected == "oauth"
+        self.auth_kind = "oauth_redirect" if oauth else "token_paste"
+        self.config_fields = list(self._oauth_fields if oauth else self._cookie_fields)
+
+    def _value(self, key):
+        value = self._store.get(key)
+        return value if value not in (None, "") else os.getenv(key)
 
     def _token_cache(self):
         # os.getenv first so Docker's SPOTIFY_TOKEN_CACHE=/data/... (the persistent
@@ -34,8 +55,8 @@ class SpotifyConnector(Connector):
         # and — because engine and connector request the identical scope — spotipy's
         # per-refresh scope rewrite can never narrow the cached token.
         return SpotifyOAuth(
-            client_id=self._store.get("SPOTIFY_CLIENT_ID"),
-            client_secret=self._store.get("SPOTIFY_CLIENT_SECRET"),
+            client_id=self._value("SPOTIFY_CLIENT_ID"),
+            client_secret=self._value("SPOTIFY_CLIENT_SECRET"),
             redirect_uri=redirect_uri,
             scope=SPOTIFY_SCOPE,
             cache_path=cache,
@@ -43,20 +64,28 @@ class SpotifyConnector(Connector):
         )
 
     def _cookie_on(self):
-        backend = self._store.get("SPOTIFY_WRITE_BACKEND") or os.getenv("SPOTIFY_WRITE_BACKEND") or "oauth"
+        backend = self._value("SPOTIFY_WRITE_BACKEND") or "oauth"
         return str(backend).strip().lower() == "cookie"
 
     def _isrc_app_on(self):
-        return bool(self._store.get("SPOTIFY_ISRC_CLIENTS") or os.getenv("SPOTIFY_ISRC_CLIENTS"))
+        return bool(self._value("SPOTIFY_ISRC_CLIENTS"))
 
     def status(self) -> ConnStatus:
         from ...engine import spotify, spotify_cookie
 
-        if self._cookie_on() and spotify_cookie.configured():
-            return ConnStatus("connected", "signed-in web session · no developer API")
+        # Settings can be saved through this connector instance immediately
+        # before status() is called (for example when switching backends).
+        self._select_auth_flow()
+        if self.auth_kind == "token_paste":
+            if self._cookie_on() and spotify_cookie.configured():
+                return ConnStatus("connected", "signed-in web session · no developer API")
+            # Preserve the status of pre-existing wizard-managed OAuth grants,
+            # while keeping env-only credentials opt-in via SPOTIFY_AUTH_MODE.
+            if not all(self._store.get(k) for k in ("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET")):
+                return ConnStatus("unconfigured")
 
-        if not self._configured("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET"):
-            return ConnStatus("unconfigured")
+        elif not all(self._value(k) for k in ("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET")):
+            return ConnStatus("unconfigured", "legacy OAuth needs a client ID and secret")
         note = ((" · cookie writes" if self._cookie_on() else "")
                 + (" · ISRC app" if self._isrc_app_on() else ""))
         if not os.path.exists(self._token_cache()):
@@ -162,7 +191,10 @@ class SpotifyConnector(Connector):
                 pass
 
     def begin_redirect(self, redirect_uri: str) -> str:
-        self._store.save({"SPOTIFY_REDIRECT_URI": redirect_uri})
+        self._store.save({
+            "SPOTIFY_WRITE_BACKEND": "oauth",
+            "SPOTIFY_REDIRECT_URI": redirect_uri,
+        })
         return self._oauth(redirect_uri).get_authorize_url()
 
     def complete_redirect(self, params: dict) -> ConnStatus:

--- a/songmirror/web/routers/accounts.py
+++ b/songmirror/web/routers/accounts.py
@@ -1,10 +1,12 @@
 """Account wizard endpoints — connect/inspect each service uniformly."""
 
 import html
+import os
 import re
 from dataclasses import asdict
+from urllib.parse import urlsplit, urlunsplit
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from ...engine.targets import is_peer
@@ -19,10 +21,46 @@ def _conn(request: Request, cid: str):
 
 
 def _redirect_uri(request: Request, cid: str) -> str:
-    base = str(request.base_url).rstrip("/")
+    configured = (
+        request.app.state.settings.get("SONGMIRROR_PUBLIC_URL")
+        or os.getenv("SONGMIRROR_PUBLIC_URL")
+        or ""
+    )
+    base = str(configured).strip() or str(request.base_url)
+
+    if configured:
+        parts = urlsplit(base)
+        try:
+            parts.port  # validate malformed/non-numeric ports too
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"invalid SONGMIRROR_PUBLIC_URL ({exc})",
+            ) from exc
+        if (
+            parts.scheme.lower() not in {"http", "https"}
+            or not parts.hostname
+            or parts.username is not None
+            or parts.password is not None
+            or parts.query
+            or parts.fragment
+        ):
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "SONGMIRROR_PUBLIC_URL must be an absolute http(s) URL "
+                    "without credentials, a query, or a fragment"
+                ),
+            )
+        # Preserve an optional reverse-proxy base path while canonicalizing the
+        # scheme and removing the trailing slash before appending our route.
+        base = urlunsplit((parts.scheme.lower(), parts.netloc, parts.path.rstrip("/"), "", ""))
+
+    base = base.rstrip("/")
     # Spotify (and increasingly others) reject `localhost` for http loopback
     # OAuth redirects — the explicit 127.0.0.1 loopback IP is required over http.
-    # Force it here so the redirect works no matter how the app is opened.
+    # Force it for the request-derived fallback. A configured public URL is still
+    # normalized too, which catches an accidentally configured localhost alias.
     base = re.sub(r"://localhost(?=[:/]|$)", "://127.0.0.1", base, count=1)
     return base + f"/oauth/{cid}/callback"
 
@@ -37,7 +75,9 @@ def list_accounts(request: Request):
         fields = []
         for f in c.config_fields:
             d = asdict(f)
-            cur = store.get(f.key) or ""
+            cur = store.get(f.key)
+            if cur in (None, ""):
+                cur = os.getenv(f.key) or ""
             # Pre-fill on reconnect, but NEVER echo a secret back to the browser —
             # send its value only when it's non-secret; a `configured` flag lets the
             # wizard show "saved — leave blank to keep" for a stored secret instead.

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -45,6 +45,30 @@ def test_spotify_begin_redirect_returns_url(tmp_path, monkeypatch):
     assert c._store.get("SPOTIFY_REDIRECT_URI") == "http://host/oauth/spotify/callback"
 
 
+def test_spotify_oauth_mode_uses_docker_env_credentials(tmp_path, monkeypatch):
+    from songmirror.services.accounts.spotify import SpotifyConnector
+
+    captured = {}
+
+    class FakeOAuth:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env-client")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "env-secret")
+    monkeypatch.setattr("spotipy.oauth2.SpotifyOAuth", FakeOAuth)
+
+    c = SpotifyConnector(SettingsStore(dir=tmp_path))
+    c._oauth("https://music.example.test/oauth/spotify/callback")
+
+    assert c.auth_kind == "oauth_redirect"
+    assert [field.key for field in c.config_fields] == ["SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET"]
+    assert captured["client_id"] == "env-client"
+    assert captured["client_secret"] == "env-secret"
+    assert captured["redirect_uri"] == "https://music.example.test/oauth/spotify/callback"
+
+
 def test_spotify_cookie_only_account_is_connected_without_developer_credentials(tmp_path, monkeypatch):
     from songmirror.engine import spotify_cookie
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -135,6 +135,76 @@ def test_oauth_callback_handles_provider_error(tmp_path):
         assert "server_error" in r.text and "Spotify" in r.text
 
 
+def test_oauth_redirect_uses_configured_public_url(tmp_path, monkeypatch):
+    """A remotely hosted Docker app must advertise its browser-reachable URL,
+    not the container/request URL that happened to reach FastAPI."""
+    from songmirror.services.accounts.spotify import SpotifyConnector
+
+    seen = []
+    monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
+    monkeypatch.setattr(
+        SpotifyConnector,
+        "begin_redirect",
+        lambda _self, uri: (seen.append(uri), "https://accounts.spotify.test/authorize")[1],
+    )
+    monkeypatch.setenv("SONGMIRROR_PUBLIC_URL", "https://music.example.test/songmirror/")
+
+    with TestClient(_app(tmp_path)) as client:
+        result = client.post(
+            "/api/accounts/spotify/connect",
+            headers={"host": "127.0.0.1:8080"},
+        ).json()
+
+    expected = "https://music.example.test/songmirror/oauth/spotify/callback"
+    assert seen == [expected]
+    assert result["redirect_uri"] == expected
+
+
+def test_spotify_oauth_mode_exposes_masked_env_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env-client")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "env-secret")
+
+    with TestClient(_app(tmp_path)) as client:
+        spotify = next(a for a in client.get("/api/accounts").json() if a["id"] == "spotify")
+
+    assert spotify["auth_kind"] == "oauth_redirect"
+    fields = {field["key"]: field for field in spotify["fields"]}
+    assert fields["SPOTIFY_CLIENT_ID"]["value"] == "env-client"
+    assert fields["SPOTIFY_CLIENT_ID"]["configured"] is True
+    assert fields["SPOTIFY_CLIENT_SECRET"]["value"] == ""
+    assert fields["SPOTIFY_CLIENT_SECRET"]["configured"] is True
+
+
+def test_oauth_redirect_rejects_invalid_public_url(tmp_path, monkeypatch):
+    from songmirror.services.accounts.spotify import SpotifyConnector
+
+    monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
+    monkeypatch.setenv("SONGMIRROR_PUBLIC_URL", "music.example.test?from=compose")
+
+    with TestClient(_app(tmp_path), raise_server_exceptions=False) as client:
+        result = client.post("/api/accounts/spotify/connect")
+
+    assert result.status_code == 500
+    assert "SONGMIRROR_PUBLIC_URL" in result.json()["detail"]
+
+
+def test_oauth_redirect_keeps_safe_loopback_fallback(tmp_path, monkeypatch):
+    from songmirror.services.accounts.spotify import SpotifyConnector
+
+    monkeypatch.delenv("SONGMIRROR_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
+    monkeypatch.setattr(SpotifyConnector, "begin_redirect", lambda _self, _uri: "https://example.test")
+
+    with TestClient(_app(tmp_path)) as client:
+        result = client.post(
+            "/api/accounts/spotify/connect",
+            headers={"host": "localhost:8888"},
+        ).json()
+
+    assert result["redirect_uri"] == "http://127.0.0.1:8888/oauth/spotify/callback"
+
+
 def test_sync_run_queues(tmp_path, monkeypatch):
     import songmirror.services.sync_service as m
 


### PR DESCRIPTION
## Summary

- add a validated `SONGMIRROR_PUBLIC_URL` for browser-visible OAuth callbacks behind Docker and reverse proxies
- keep keyless Spotify cookie authentication as the default while allowing `SPOTIFY_AUTH_MODE=oauth` to activate the legacy developer-app wizard
- load Docker-provided account fields without exposing secrets
- document the exact callback path and Spotify's HTTPS requirement for non-loopback hosts

## Why

Issue #10 reports that Spotify's callback URL was derived from the incoming request, which can be an internal container or desktop-local address rather than the URL a browser uses to reach a remote SongMirror server. The legacy OAuth implementation also existed behind a connector path that was no longer selectable after keyless Spotify authentication became the default.

This keeps the no-developer-key flow unchanged and makes the legacy fallback explicitly configurable for server-hosted deployments.

## Impact

A Docker user can set:

```dotenv
SPOTIFY_AUTH_MODE=oauth
SPOTIFY_CLIENT_ID=...
SPOTIFY_CLIENT_SECRET=...
SONGMIRROR_PUBLIC_URL=https://music.example.com
```

SongMirror then advertises `https://music.example.com/oauth/spotify/callback`. Invalid public URLs fail with a clear configuration error instead of producing a malformed redirect.

Closes #10.

## Validation

- `uv run pytest -q` — 237 passed, 1 skipped
- `docker compose config --quiet`
- `git diff --check`
