### PR TITLE
feat(sync): add authoritative groups and harden playlist mirroring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,9 +69,12 @@ MAX_REMOVALS=0            # per-playlist removal cap per pass. 0 (default) = rem
 MAX_ADDS=200              # per-playlist additions cap per pass (rest continue next pass)
 
 # Sync direction. oneway (default) = one selected source -> the other selected peers.
-# nway = bidirectional: a track added/removed on ANY provider propagates to the
-# others. Every participating provider needs write permission. Dry-run it first.
-SYNC_MODE=oneway          # oneway | nway
+# group = two or more authorities contribute membership; every other selected
+# provider is a destination-only mirror. nway = every selected provider contributes.
+# Every participating provider needs write permission in group/nway. Dry-run first.
+SYNC_MODE=oneway          # oneway | group | nway
+SYNC_SOURCE=spotify       # one-way source, or group order/name authority
+SYNC_AUTHORITIES=         # group only, e.g. spotify,apple (at least two; includes source)
 PROVIDERS=spotify,tidal,qobuz,deezer,amazon,apple,ytmusic   # participating peers
 DOWNLOAD_DIR=             # set to a folder to also keep local audio copies
 #LOCAL_MIRROR_FORMAT=mp3  # flac/ogg/opus/m4a/wav; opus keeps YouTube's native ~160k without re-encoding

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Playlist Synchronization
+
+SongMirror keeps one logical playlist aligned across music services while making authority and conflict boundaries explicit.
+
+## Language
+
+**Authoritative group**:
+Two or more selected music services whose confirmed membership changes define the logical playlist together.
+_Avoid_: Two-way mode, partial N-way
+
+**Order authority**:
+The member of an authoritative group whose playlist names and track sequence define the canonical ordering.
+_Avoid_: Primary provider, master
+
+**Mirror**:
+A selected music service that receives the authoritative membership and order but never contributes changes back to them.
+_Avoid_: Peer, secondary authority
+
+**Authority baseline**:
+The last trusted membership snapshot for each member of an authoritative group, used to distinguish additions and removals from pre-existing differences.
+_Avoid_: Initial union, sync history

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Self-hosted, always-on **playlist sync for Spotify, TIDAL, Qobuz, Deezer, Amazon Music, Apple Music, and YouTube Music** — plus a local, Jellyfin-ready audio mirror.<br/>
 A free, open-source, **self-hosted alternative to Soundiiz, TuneMyMusic, and FreeYourMusic** that _you_ own and run.
 
-**One-way mirror or full bidirectional (N-way) sync · one-off playlist transfers · ISRC-accurate matching · all from your browser**
+**One-way, authoritative-group, or full bidirectional (N-way) sync · one-off playlist transfers · ISRC-accurate matching · all from your browser**
 
 [Quick Start](#-quick-start) · [Features](#-features) · [Screenshots](#-screenshots) · [Docker](#-always-running-docker) · [How it works](#-how-it-works) · [Report Bug][github-issues-link] · [Request Feature][github-issues-link]
 
@@ -53,6 +53,7 @@ A free, open-source, **self-hosted alternative to Soundiiz, TuneMyMusic, and Fre
 - [🐳 Always running: Docker](#-always-running-docker)
 - [⚙️ How it works](#-how-it-works)
   - [Matching](#matching)
+  - [Authoritative groups](#authoritative-groups)
   - [Bidirectional (N-way) sync](#bidirectional-n-way-sync)
 - [💿 Local download mirror (Jellyfin)](#-local-download-mirror-jellyfin)
 - [🔌 Connecting each service](#-connecting-each-service)
@@ -82,6 +83,7 @@ A free, open-source, **self-hosted alternative to Soundiiz, TuneMyMusic, and Fre
 SongMirror keeps your playlists identical everywhere without manual re-adding, one-by-one copying, or a paid cloud service holding your library. It is **cross-platform, self-hosted, and open source**.
 
 - 🔁 **True mirroring, not append-only** — adds _and_ removals. Choose a source of truth (Spotify by default) and the others follow it.
+- ⇆ **Authoritative groups** — trust two or more services (for example Spotify + Apple Music) while every other selected service remains a destination-only mirror.
 - ⇄ **Bidirectional N-way sync** — an add or removal on _any_ connected service propagates to all the others, echo-free, behind removal guards.
 - 🎯 **ISRC-accurate matching** — exact recording identity where available, with Unicode-aware fuzzy title/artist/duration fallbacks (feat-credit drift, "- 2015 Remaster" suffixes, non-Latin scripts, video-only uploads — all handled).
 - 🎛️ **Multiple named syncs** — set up as many independent syncs as you like, each with its own services, playlists, schedule, and safety caps.
@@ -109,7 +111,7 @@ SongMirror keeps your playlists identical everywhere without manual re-adding, o
 
 <img src="./.github/assets/dashboard.png" alt="SongMirror dashboard showing sync status, configured jobs, live activity, and health for Spotify, TIDAL, Qobuz, Deezer, Amazon Music, Apple Music, YouTube Music, and Jellyfin" width="82%">
 
-**Set up any number of syncs — one-way or bidirectional — in a short wizard**
+**Set up any number of syncs — one-way, authoritative-group, or bidirectional — in a short wizard**
 
 <img src="./.github/assets/sync-wizard.png" alt="The SongMirror setup wizard selecting services for a bidirectional sync across Spotify, TIDAL, Qobuz, Deezer, Amazon Music, Apple Music, and YouTube Music" width="82%">
 
@@ -216,6 +218,19 @@ Same hierarchy the cross-service tools use ([TuneLink](https://tommcfarlin.com/c
    - **Video-only tracks** — YouTube search falls back to the `videos` filter for indie/OST tracks that live on YT only as uploads.
 
 The **duration anchor** unlocks the looser title match, so a different version (`Runaway - Piano Version`) or a wrong-artist cover isn't accepted when its length disagrees. Tracks with no confident match are reported and skipped.
+
+### Authoritative groups
+
+Use an **authoritative group** when you actively curate the same logical playlist on two or more services, but want every other selected service to follow them. A typical setup is **Spotify + Apple Music as authorities**, with TIDAL, Qobuz, Deezer, Amazon Music, and YouTube Music as mirrors.
+
+- **Membership comes only from authorities** — a track added on Spotify or Apple Music propagates to the other authority and every mirror. A track added only on a mirror is drift; it is never imported back into the authorities.
+- **One order authority** — choose which authority supplies playlist names and the ordering of additions. The other authorities still contribute membership changes.
+- **Confirmed removals propagate from either authority** — an absence must appear in two consecutive complete reads before it can delete anything. A simultaneous authority-side addition wins over a removal.
+- **Mirrors never get a vote** — deleting a track from a mirror repairs that mirror; it does not delete the track from Spotify or Apple Music.
+- **Safe first pass** — every authority set has its own baseline. Its first successful pass may add missing tracks, but holds all removals until a later pass proves the baseline is stable.
+- **Fail closed** — if any authority is disconnected, unreadable, or its playlist cannot be opened/created, that logical playlist is skipped instead of silently falling back to fewer authorities.
+
+Removal writes remain opt-in and capped. Enable **Mirror removals** for the job (or set `MAX_REMOVALS` in headless mode) if mirrors should be pruned to match the authoritative set.
 
 ### Bidirectional (N-way) sync
 
@@ -369,9 +384,11 @@ Useful flags:
 uv run main.py --execute --playlists "Aurora,Chill"   # only these pairs
 uv run main.py --execute --loop --interval 15m        # run forever
 uv run main.py --execute --max-removals 100           # one-off larger cleanup
+uv run main.py --execute --sync-mode group --sync-source spotify \
+  --authorities spotify,apple --providers spotify,apple,tidal,ytmusic
 ```
 
-Key env vars (see `.env.example`): the credentials for whichever providers you use, `PLAYLISTS`, `SYNC_INTERVAL`, `MAX_ADDS` / `MAX_REMOVALS`, `DOWNLOAD_DIR`, `SYNC_MODE=nway`, and `PROVIDERS`.
+Key env vars (see `.env.example`): the credentials for whichever providers you use, `PLAYLISTS`, `SYNC_INTERVAL`, `MAX_ADDS` / `MAX_REMOVALS`, `DOWNLOAD_DIR`, `SYNC_MODE`, `SYNC_SOURCE`, `SYNC_AUTHORITIES`, and `PROVIDERS`.
 
 <div align="right">
 

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -255,6 +255,34 @@ const PLAYLISTS = {
   ],
 }
 
+const PLAYLIST_DETAIL = {
+  provider: 'spotify',
+  id: 'pl_spotify_1',
+  name: 'Road Trip 2025',
+  description: 'A clean provider description with another mix.',
+  count: 118,
+  image: svgCover('#3b6fd6'),
+  owned: true,
+  editable: true,
+  external_url: 'https://open.spotify.com/playlist/pl_spotify_1',
+  tracks: Array.from({ length: 118 }, (_, index) => ({
+    position: index,
+    id: `track_${index + 1}`,
+    occurrence_id: `entry_${index + 1}`,
+    name: `Track ${index + 1}`,
+    artist: `Artist ${index + 1}`,
+    album: `Album ${Math.floor(index / 10) + 1}`,
+    duration_ms: 180000 + index * 1000,
+    image: svgCover(index % 2 ? '#7b4bc4' : '#3aa76d'),
+    // Most providers omit per-entry dates, so undated rows use reverse append
+    // order. Qobuz returns Unix seconds; one deliberately non-terminal entry
+    // proves that timestamp outranks the fallback instead of being parsed as
+    // an invalid date.
+    added_at: index === 116 ? '1786850562' : '',
+    external_url: `https://open.spotify.com/track/track_${index + 1}`,
+  })),
+}
+
 // Polished, deterministic data used only for committed README/promo captures.
 // Every provider is connected and every playlist has cover art so the media
 // demonstrates the finished experience without setup errors or empty states.
@@ -416,6 +444,12 @@ async function installMocks(page, opts = {}) {
       return json({ ok: true })
     }
 
+    if (p === '/api/playlists/spotify/pl_spotify_1' && method === 'GET') {
+      return json(PLAYLIST_DETAIL)
+    }
+    if (p === '/api/playlists/spotify/pl_spotify_1/tracks' && method === 'DELETE') {
+      return json({ ok: true })
+    }
     if (p === '/api/playlists' && method === 'GET') {
       const provider = url.searchParams.get('provider')
       await delay('playlists')
@@ -661,6 +695,56 @@ async function main() {
         if (width !== 320) await shot(page, `settings-${width}-${theme}`)
       }
 
+      await context.close()
+    }
+
+    // The in-app playlist ledger renders only one 50-track page at a time,
+    // defaults to most-recently-added, keeps the provider-order option, and
+    // paints track artwork rather than a text-only thousand-row list.
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'dark'))
+      const page = await context.newPage()
+      await installMocks(page)
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/playlists', { waitUntil: 'networkidle' })
+      await page.getByRole('button', { name: 'Open Road Trip 2025 inside SongMirror' }).first().click()
+      const dialog = page.getByRole('dialog')
+      await dialog.getByText('Showing 1–50 of 118 tracks · 50 per page').waitFor()
+
+      const firstLatest = await dialog.locator('ol > li').first().textContent()
+      const secondLatest = await dialog.locator('ol > li').nth(1).textContent()
+      const firstPageRows = await dialog.locator('ol > li').count()
+      const firstPageCovers = await dialog.locator('ol > li img').count()
+      const latestOk = firstLatest?.includes('Track 117')
+        && secondLatest?.includes('Track 118')
+        && firstPageRows === 50
+        && firstPageCovers === 50
+      console.log(`${latestOk ? 'ok        ' : 'FAIL      '} playlist ledger understands Unix date-added values and falls back to reverse append order with 50 covered rows (first=${JSON.stringify(firstLatest?.slice(0, 40))}, rows=${firstPageRows}, covers=${firstPageCovers})`)
+      if (!latestOk) results.push({ label: 'playlist ledger latest/page/covers', overflow: true })
+
+      await dialog.getByRole('button', { name: 'Next' }).click()
+      await dialog.getByText('Showing 51–100 of 118 tracks · 50 per page').waitFor()
+      const secondPageOk = (await dialog.locator('ol > li').first().textContent())?.includes('Track 68')
+      console.log(`${secondPageOk ? 'ok        ' : 'FAIL      '} playlist ledger advances to the next 50-track page`)
+      if (!secondPageOk) results.push({ label: 'playlist ledger next page', overflow: true })
+
+      await dialog.getByRole('button', { name: 'Sort playlist tracks' }).click()
+      await page.getByRole('option', { name: 'Playlist order' }).click()
+      const providerOrderOk = (await dialog.locator('ol > li').first().textContent())?.includes('Track 1')
+      console.log(`${providerOrderOk ? 'ok        ' : 'FAIL      '} playlist ledger can return to canonical playlist order`)
+      if (!providerOrderOk) results.push({ label: 'playlist ledger provider order', overflow: true })
+
+      await dialog.getByRole('button', { name: 'Select Track 1', exact: true }).click()
+      await dialog.getByRole('button', { name: 'Select Track 4', exact: true }).click({ modifiers: ['Shift'] })
+      const rangeSelected = await dialog.getByText('4 tracks selected').isVisible()
+      await dialog.getByRole('button', { name: 'Remove selected' }).click()
+      const bulkConfirmation = await dialog.getByRole('button', { name: 'Remove 4 tracks' }).isVisible()
+      await dialog.getByRole('button', { name: 'Keep selected' }).click()
+      const bulkSelectOk = rangeSelected && bulkConfirmation
+      console.log(`${bulkSelectOk ? 'ok        ' : 'FAIL      '} playlist ledger supports click/shift-click range selection and guarded bulk removal`)
+      if (!bulkSelectOk) results.push({ label: 'playlist ledger bulk selection', overflow: true })
+      await checkOverflow(page, 'Playlist track ledger @ 1280', results)
       await context.close()
     }
 
@@ -3280,14 +3364,14 @@ async function main() {
           const save = (key, data) => {
             window.localStorage.setItem(
               key,
-              JSON.stringify({ version: 1, savedAt: Date.now(), data }),
+              JSON.stringify({ version: 2, savedAt: Date.now(), data }),
             )
           }
           window.localStorage.setItem('songmirror-theme', 'light')
-          save('songmirror-cache-v1:accounts', accounts)
-          save('songmirror-cache-v1:syncs', syncs)
-          save('songmirror-cache-v1:settings', settings)
-          save('songmirror-cache-v1:playlists:spotify', playlists)
+          save('songmirror-cache-v2:accounts', accounts)
+          save('songmirror-cache-v2:syncs', syncs)
+          save('songmirror-cache-v2:settings', settings)
+          save('songmirror-cache-v2:playlists:spotify', playlists)
         },
         {
           accounts: cachedAccounts,
@@ -3393,7 +3477,7 @@ async function main() {
 
       const settingsCacheRefreshed = await page.evaluate(() => {
         try {
-          const raw = window.localStorage.getItem('songmirror-cache-v1:settings')
+          const raw = window.localStorage.getItem('songmirror-cache-v2:settings')
           if (!raw) return false
           return JSON.parse(raw).data?.DISPLAY_NAME === 'Maya'
         } catch {

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -253,6 +253,9 @@ const PLAYLISTS = {
     { id: 'pl_apple_1', name: 'Road Trip 2025', count: null, image: '' },
     { id: 'pl_apple_4', name: 'Rainy Day', count: null, image: '' },
   ],
+  ytmusic: [
+    { id: 'pl_yt_latest', name: 'YouTube ordering fixture', count: 3, image: svgCover('#d64545') },
+  ],
 }
 
 const PLAYLIST_DETAIL = {
@@ -281,6 +284,31 @@ const PLAYLIST_DETAIL = {
     added_at: index === 116 ? '1786850562' : '',
     external_url: `https://open.spotify.com/track/track_${index + 1}`,
   })),
+}
+
+const YTMUSIC_PLAYLIST_DETAIL = {
+  provider: 'ytmusic',
+  id: 'pl_yt_latest',
+  name: 'YouTube ordering fixture',
+  description: 'YouTube returns this physical list newest-first.',
+  count: 3,
+  image: svgCover('#d64545'),
+  owned: true,
+  editable: true,
+  external_url: 'https://music.youtube.com/playlist?list=pl_yt_latest',
+  tracks: ['Newest YouTube addition', 'Middle YouTube addition', 'Oldest YouTube addition']
+    .map((name, position) => ({
+      position,
+      id: `yt_track_${position + 1}`,
+      occurrence_id: `yt_entry_${position + 1}`,
+      name,
+      artist: 'YouTube Artist',
+      album: 'YouTube Album',
+      duration_ms: 180000,
+      image: svgCover('#d64545'),
+      added_at: '',
+      external_url: `https://music.youtube.com/watch?v=yt_track_${position + 1}`,
+    })),
 }
 
 // Polished, deterministic data used only for committed README/promo captures.
@@ -446,6 +474,9 @@ async function installMocks(page, opts = {}) {
 
     if (p === '/api/playlists/spotify/pl_spotify_1' && method === 'GET') {
       return json(PLAYLIST_DETAIL)
+    }
+    if (p === '/api/playlists/ytmusic/pl_yt_latest' && method === 'GET') {
+      return json(YTMUSIC_PLAYLIST_DETAIL)
     }
     if (p === '/api/playlists/spotify/pl_spotify_1/tracks' && method === 'DELETE') {
       return json({ ok: true })
@@ -706,6 +737,15 @@ async function main() {
       await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'dark'))
       const page = await context.newPage()
       await installMocks(page)
+      await page.route('**/api/accounts', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ACCOUNTS.map((account) => (
+            account.id === 'ytmusic' ? { ...account, state: 'connected', detail: null } : account
+          ))),
+        })
+      })
       await page.setViewportSize({ width: 1280, height: 900 })
       await page.goto(BASE_URL + '/playlists', { waitUntil: 'networkidle' })
       await page.getByRole('button', { name: 'Open Road Trip 2025 inside SongMirror' }).first().click()
@@ -744,6 +784,15 @@ async function main() {
       const bulkSelectOk = rangeSelected && bulkConfirmation
       console.log(`${bulkSelectOk ? 'ok        ' : 'FAIL      '} playlist ledger supports click/shift-click range selection and guarded bulk removal`)
       if (!bulkSelectOk) results.push({ label: 'playlist ledger bulk selection', overflow: true })
+
+      await page.keyboard.press('Escape')
+      await page.getByRole('button', { name: 'Open YouTube ordering fixture inside SongMirror' }).click()
+      const youtubeDialog = page.getByRole('dialog')
+      await youtubeDialog.getByText('Newest YouTube addition').waitFor()
+      const firstYoutube = await youtubeDialog.locator('ol > li').first().textContent()
+      const youtubeLatestOk = firstYoutube?.includes('Newest YouTube addition')
+      console.log(`${youtubeLatestOk ? 'ok        ' : 'FAIL      '} YouTube Music's undated newest-first response is not reversed (first=${JSON.stringify(firstYoutube?.slice(0, 50))})`)
+      if (!youtubeLatestOk) results.push({ label: 'playlist ledger YouTube newest-first order', overflow: true })
       await checkOverflow(page, 'Playlist track ledger @ 1280', results)
       await context.close()
     }

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -144,6 +144,7 @@ function initialSyncs() {
       enabled: true,
       mode: 'nway',
       source: 'apple',
+      authorities: '',
       providers: 'spotify',
       playlists: 'Road Trip 2025, Some Old Mix',
       interval: '15m',
@@ -157,6 +158,7 @@ function initialSyncs() {
       enabled: false,
       mode: 'oneway',
       source: 'spotify',
+      authorities: '',
       providers: 'spotify,apple',
       playlists: '',
       interval: '1h',
@@ -446,6 +448,7 @@ async function installMocks(page, opts = {}) {
         enabled: true,
         mode: 'oneway',
         source: 'spotify',
+        authorities: '',
         providers: 'spotify,apple,ytmusic',
         playlists: '',
         interval: '15m',
@@ -1935,6 +1938,93 @@ async function main() {
     }
 
     // -----------------------------------------------------------------
+    // Wizard Direction: authoritative groups distinguish one order
+    // authority, two-or-more membership authorities, and destination-only
+    // mirrors. The roles must survive the PUT round trip and remain legible
+    // in the list-card summary.
+    // -----------------------------------------------------------------
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'light'))
+      const page = await context.newPage()
+      await installMocks(page)
+      await page.route('**/api/accounts', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback()
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ACCOUNTS.map((a) => (a.id === 'tidal' ? { ...a, state: 'connected' } : a))),
+        })
+      })
+      let savedGroup = null
+      await page.route('**/api/syncs/job1', async (route) => {
+        if (route.request().method() === 'PUT') savedGroup = route.request().postDataJSON()
+        await route.fallback()
+      })
+
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/sync', { waitUntil: 'networkidle' })
+      await page.waitForSelector('h1:has-text("Sync")')
+      const defaultCard = page.locator('h3', { hasText: 'Default' }).locator('xpath=ancestor::div[contains(@class,"rounded-card")][1]')
+      await defaultCard.getByRole('button', { name: 'Edit', exact: true }).click()
+      const dialog = page.getByRole('dialog')
+      await dialog.waitFor()
+
+      await dialog.getByText('Authority group ⇆', { exact: true }).click()
+      await dialog.getByText('Membership authorities', { exact: true }).waitFor()
+
+      const appleOrder = dialog.getByRole('button', { name: /Apple Music order/, exact: false })
+      const spotifyAuthority = dialog.getByRole('button', { name: /Spotify authority/, exact: false })
+      const autoSelectedTwo =
+        (await appleOrder.getAttribute('aria-pressed')) === 'true' &&
+        (await spotifyAuthority.getAttribute('aria-pressed')) === 'true'
+      console.log(`${autoSelectedTwo ? 'ok        ' : 'FAIL      '} Authority group starts with the saved order authority plus a second connected authority`)
+      if (!autoSelectedTwo) results.push({ label: 'wizard authority group defaults', overflow: true })
+      await checkOverflow(page, 'Wizard authoritative group direction @ 1280', results)
+      await shot(page, 'wizard-authoritative-group-direction')
+
+      await dialog.getByRole('radio', { name: 'Services', exact: true }).click()
+      const appleLocked = await dialog.getByRole('button', { name: /Apple Music order/, exact: false }).isDisabled()
+      const spotifyLocked = await dialog.getByRole('button', { name: /Spotify authority/, exact: false }).isDisabled()
+      const authorityLocksOk = appleLocked && spotifyLocked
+      console.log(`${authorityLocksOk ? 'ok        ' : 'FAIL      '} Services locks both authorities so neither can be dropped accidentally`)
+      if (!authorityLocksOk) results.push({ label: 'wizard authority group locks', overflow: true })
+
+      await dialog.getByRole('button', { name: 'TIDAL', exact: true }).click()
+      const tidalMirror = dialog.getByRole('button', { name: /TIDAL mirror/, exact: false })
+      const mirrorRoleOk = (await tidalMirror.getAttribute('aria-pressed')) === 'true'
+      console.log(`${mirrorRoleOk ? 'ok        ' : 'FAIL      '} A selected non-authority is explicitly badged as a mirror`)
+      if (!mirrorRoleOk) results.push({ label: 'wizard authority mirror role', overflow: true })
+
+      await dialog.getByRole('radio', { name: 'Limits & downloads', exact: true }).click()
+      const review = await dialog.getByText('REVIEW', { exact: true }).locator('xpath=..').innerText()
+      const groupReviewOk =
+        review.includes('Authoritative group') &&
+        review.includes('Apple Music + Spotify → TIDAL')
+      console.log(`${groupReviewOk ? 'ok        ' : 'FAIL      '} Review distinguishes authorities from mirrors (got "${review.replace(/\n/g, ' ')}")`)
+      if (!groupReviewOk) results.push({ label: 'wizard authority group summary', overflow: true })
+      await checkOverflow(page, 'Wizard authoritative group review @ 1280', results)
+      await shot(page, 'wizard-authoritative-group')
+
+      await dialog.getByRole('button', { name: 'Save changes', exact: true }).click()
+      await dialog.waitFor({ state: 'hidden' })
+      await page.waitForSelector('text=Authoritative group')
+      const payloadOk =
+        savedGroup?.mode === 'group' &&
+        savedGroup?.source === 'apple' &&
+        savedGroup?.authorities === 'spotify,apple' &&
+        savedGroup?.providers === 'spotify,tidal,apple'
+      console.log(`${payloadOk ? 'ok        ' : 'FAIL      '} Group PUT persists mode, order authority, authorities, and mirrors separately (got ${JSON.stringify(savedGroup)})`)
+      if (!payloadOk) results.push({ label: 'wizard authority group payload', overflow: true })
+      const cardText = await defaultCard.innerText()
+      const cardSummaryOk = cardText.includes('Authoritative group') && cardText.includes('Apple Music + Spotify → TIDAL')
+      console.log(`${cardSummaryOk ? 'ok        ' : 'FAIL      '} Sync card keeps the authoritative-group roles visible after save`)
+      if (!cardSummaryOk) results.push({ label: 'sync card authority group summary', overflow: true })
+
+      await context.close()
+    }
+
+    // -----------------------------------------------------------------
     // Sync list: card-level quick actions — toggle enabled (immediate PUT),
     // delete (confirm + removal), run now (confirm + POST), and creating a
     // brand-new sync end to end.
@@ -2032,6 +2122,7 @@ async function main() {
         enabled: true,
         mode: 'nway',
         source: 'apple',
+        authorities: '',
         providers: 'spotify',
         playlists: '',
         interval: '15m',

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,9 @@ import type {
   PlaylistLink,
   PollResponse,
   ProviderPlaylist,
+  ProviderPlaylistDetail,
+  RemovePlaylistTrackRequest,
+  RemovePlaylistTracksRequest,
   ResolveConflictRequest,
   RunResponse,
   ScheduleRequest,
@@ -114,6 +117,31 @@ export const api = {
   // Playlists (browse)
   getPlaylists: (provider: string) =>
     request<ProviderPlaylist[]>(`/api/playlists?provider=${encodeURIComponent(provider)}`),
+  getPlaylistDetail: (
+    provider: string,
+    playlistId: string,
+    options: { refresh?: boolean; expectedCount?: number | null } = {},
+  ) => {
+    const params = new URLSearchParams()
+    if (options.refresh) params.set('refresh', 'true')
+    if (options.expectedCount !== null && options.expectedCount !== undefined) {
+      params.set('expected_count', String(options.expectedCount))
+    }
+    const query = params.size > 0 ? `?${params}` : ''
+    return request<ProviderPlaylistDetail>(
+      `/api/playlists/${encodeURIComponent(provider)}/${encodeURIComponent(playlistId)}${query}`,
+    )
+  },
+  removePlaylistTrack: (provider: string, playlistId: string, body: RemovePlaylistTrackRequest) =>
+    request<OkResponse>(
+      `/api/playlists/${encodeURIComponent(provider)}/${encodeURIComponent(playlistId)}/tracks`,
+      { method: 'DELETE', body: JSON.stringify(body) },
+    ),
+  removePlaylistTracks: (provider: string, playlistId: string, body: RemovePlaylistTracksRequest) =>
+    request<OkResponse>(
+      `/api/playlists/${encodeURIComponent(provider)}/${encodeURIComponent(playlistId)}/tracks`,
+      { method: 'DELETE', body: JSON.stringify(body) },
+    ),
 
   // Links (cross-service pairings)
   getLinks: () => request<PlaylistLink[]>('/api/links'),

--- a/frontend/src/components/dashboard/LiveFeed.tsx
+++ b/frontend/src/components/dashboard/LiveFeed.tsx
@@ -65,6 +65,7 @@ const COUNTER_META: Array<{
 ]
 
 const HOLD_REASON_LABELS: Record<string, string> = {
+  authority_baseline: 'Waiting for the authority baseline',
   unconfirmed_absence: 'Awaiting a second trusted read',
   confirmed_removal_disabled: 'Confirmed; removal mirroring is off',
   removal_cap: 'Confirmed; over the removal cap',

--- a/frontend/src/components/dashboard/NeedsALook.tsx
+++ b/frontend/src/components/dashboard/NeedsALook.tsx
@@ -118,6 +118,32 @@ function buildItems(accounts: Account[] | null, status: SyncStatus | null): Need
   const targets = status?.last?.per_target ?? []
   const diagnostics = targets.flatMap((target) => target.change_diagnostics ?? [])
 
+  const authorityBaselineRows = diagnosticsByCategory(diagnostics, 'authority_baseline')
+  if (authorityBaselineRows.length > 0) {
+    items.push({
+      key: 'authority-baseline',
+      icon: LuTriangleAlert,
+      title: 'An authoritative baseline is being established',
+      description:
+        'This authority set has not completed a trusted pass before. Additions may proceed, but SongMirror held ' +
+        'every removal until the next complete pass can compare against this baseline.',
+      details: diagnosticDetails(authorityBaselineRows),
+    })
+  }
+
+  const recreatedRows = diagnosticsByCategory(diagnostics, 'playlist_recreated')
+  if (recreatedRows.length > 0) {
+    items.push({
+      key: 'playlist-recreated',
+      icon: LuTriangleAlert,
+      title: `${recreatedRows.length} provider playlist${recreatedRows.length === 1 ? '' : 's'} recreated`,
+      description:
+        'The playlist kept its name but received a new provider ID. SongMirror discarded that side’s stale ' +
+        'baseline and rebuilt it from the replacement instead of treating the smaller read as a deletion.',
+      details: diagnosticDetails(recreatedRows),
+    })
+  }
+
   const isrcFallback = targets.reduce((sum, t) => sum + (t.isrc_fallback ?? 0), 0)
   if (isrcFallback > 0) {
     items.push({

--- a/frontend/src/components/playlists/PlaylistDetailModal.tsx
+++ b/frontend/src/components/playlists/PlaylistDetailModal.tsx
@@ -125,13 +125,15 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
       }
       if (leftAdded !== null) return -1
       if (rightAdded !== null) return 1
-      // Mirrors append additions in source order. Providers such as Amazon,
-      // Apple, Deezer, Qobuz, and YouTube omit per-entry timestamps, so the
-      // last physical entry is the best available (and sync-correct) newest
-      // item. "Playlist order" remains available for the canonical sequence.
-      return right.position - left.position
+      // Most mirrors append additions and expose oldest-first physical order,
+      // making the last entry the newest available evidence. YouTube Music's
+      // authenticated playlist read is already newest-first, so reversing it
+      // would put the oldest track at the top under a misleading label.
+      return provider === 'ytmusic'
+        ? left.position - right.position
+        : right.position - left.position
     })
-  }, [detail, deferredQuery, order])
+  }, [detail, deferredQuery, order, provider])
 
   const pageCount = Math.max(1, Math.ceil(orderedTracks.length / PAGE_SIZE))
   const safePage = Math.min(page, pageCount)

--- a/frontend/src/components/playlists/PlaylistDetailModal.tsx
+++ b/frontend/src/components/playlists/PlaylistDetailModal.tsx
@@ -1,0 +1,514 @@
+import { useDeferredValue, useEffect, useMemo, useState, type MouseEvent } from 'react'
+import {
+  LuArrowDownUp,
+  LuChevronLeft,
+  LuChevronRight,
+  LuExternalLink,
+  LuRefreshCw,
+  LuSearch,
+  LuSquare,
+  LuSquareCheck,
+  LuTrash2,
+} from 'react-icons/lu'
+
+import { api, errorMessage } from '@/api'
+import { usePlaylistDetail } from '@/hooks/usePlaylistDetail'
+import { cn } from '@/lib/cn'
+import { formatDuration, formatTrackCount } from '@/lib/format'
+import type { Account, ProviderPlaylist, ProviderPlaylistTrack } from '@/types'
+
+import { Button } from '../ui/Button'
+import { CoverArt } from '../ui/CoverArt'
+import { EmptyState } from '../ui/EmptyState'
+import { FIELD_INPUT_CLASSES } from '../ui/fieldStyles'
+import { FilterSelect } from '../ui/FilterSelect'
+import { Modal } from '../ui/Modal'
+import { LoadingStatus, Skeleton } from '../ui/Skeleton'
+
+type TrackOrder = 'latest' | 'playlist'
+
+const PAGE_SIZE = 50
+const TRACK_ORDER_OPTIONS = [
+  { value: 'latest' as const, label: 'Latest added' },
+  { value: 'playlist' as const, label: 'Playlist order' },
+]
+const ADDED_DATE = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+})
+
+function addedTimestamp(value: string): number | null {
+  const text = value.trim()
+  if (!text) return null
+
+  let timestamp: number
+  if (/^\d{4}$/.test(text)) {
+    timestamp = Date.UTC(Number(text), 0, 1)
+  } else if (/^[+-]?\d+(?:\.\d+)?$/.test(text)) {
+    let epochSeconds = Number(text)
+    if (!Number.isFinite(epochSeconds)) return null
+    // Provider payloads mix Unix seconds, milliseconds, microseconds, and
+    // nanoseconds. Reduce the larger units before converting to JavaScript's
+    // millisecond timestamps.
+    while (Math.abs(epochSeconds) > 32_503_680_000) epochSeconds /= 1_000
+    timestamp = epochSeconds * 1_000
+  } else {
+    timestamp = Date.parse(text)
+  }
+  // Some provider-generated playlists use the Unix epoch as an "unknown"
+  // sentinel. Treat it as missing so every row does not claim it was added in
+  // 1970 and the fallback remains the provider's playlist order.
+  return Number.isFinite(timestamp) && timestamp >= Date.UTC(2000, 0, 1) ? timestamp : null
+}
+
+function addedLabel(value: string): string {
+  const timestamp = addedTimestamp(value)
+  return timestamp === null ? '' : `Added ${ADDED_DATE.format(timestamp)}`
+}
+
+function trackKey(track: ProviderPlaylistTrack): string {
+  return `${track.position}:${track.id}`
+}
+
+interface PlaylistDetailModalProps {
+  account: Account | null
+  playlist: ProviderPlaylist | null
+  onClose: () => void
+  onChanged: () => void
+}
+
+/** Provider-backed playlist inspector/editor. Track lists are fetched only
+ * when opened; search is deferred so thousand-track playlists stay responsive. */
+export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: PlaylistDetailModalProps) {
+  const provider = account?.id ?? null
+  const playlistId = playlist?.id ?? null
+  const { detail, loading, refreshing, error, refresh } = usePlaylistDetail(
+    provider,
+    playlistId,
+    playlist?.count,
+  )
+  const [query, setQuery] = useState('')
+  const [confirming, setConfirming] = useState<string | null>(null)
+  const [removing, setRemoving] = useState<string | null>(null)
+  const [editError, setEditError] = useState<string | null>(null)
+  const [order, setOrder] = useState<TrackOrder>('latest')
+  const [page, setPage] = useState(1)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(() => new Set())
+  const [selectionAnchor, setSelectionAnchor] = useState<string | null>(null)
+  const [bulkConfirming, setBulkConfirming] = useState(false)
+  const [bulkRemoving, setBulkRemoving] = useState(false)
+  const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase())
+
+  useEffect(() => {
+    setQuery('')
+    setConfirming(null)
+    setEditError(null)
+    setOrder('latest')
+    setPage(1)
+    setSelectedKeys(new Set())
+    setSelectionAnchor(null)
+    setBulkConfirming(false)
+  }, [provider, playlistId])
+
+  const orderedTracks = useMemo(() => {
+    if (!detail) return []
+    const filtered = deferredQuery ? detail.tracks.filter((track) =>
+      `${track.name} ${track.artist} ${track.album ?? ''}`.toLocaleLowerCase().includes(deferredQuery),
+    ) : detail.tracks
+    if (order === 'playlist') return filtered
+    return filtered.slice().sort((left, right) => {
+      const leftAdded = addedTimestamp(left.added_at)
+      const rightAdded = addedTimestamp(right.added_at)
+      if (leftAdded !== null && rightAdded !== null && leftAdded !== rightAdded) {
+        return rightAdded - leftAdded
+      }
+      if (leftAdded !== null) return -1
+      if (rightAdded !== null) return 1
+      // Mirrors append additions in source order. Providers such as Amazon,
+      // Apple, Deezer, Qobuz, and YouTube omit per-entry timestamps, so the
+      // last physical entry is the best available (and sync-correct) newest
+      // item. "Playlist order" remains available for the canonical sequence.
+      return right.position - left.position
+    })
+  }, [detail, deferredQuery, order])
+
+  const pageCount = Math.max(1, Math.ceil(orderedTracks.length / PAGE_SIZE))
+  const safePage = Math.min(page, pageCount)
+  const pageStart = (safePage - 1) * PAGE_SIZE
+  const pageTracks = orderedTracks.slice(pageStart, pageStart + PAGE_SIZE)
+  const selectedTracks = useMemo(
+    () => detail?.tracks.filter((track) => selectedKeys.has(trackKey(track))) ?? [],
+    [detail, selectedKeys],
+  )
+
+  function changeOrder(value: TrackOrder) {
+    setOrder(value)
+    setPage(1)
+    setConfirming(null)
+    setBulkConfirming(false)
+  }
+
+  function changeQuery(value: string) {
+    setQuery(value)
+    setPage(1)
+    setConfirming(null)
+    setBulkConfirming(false)
+  }
+
+  function toggleSelection(track: ProviderPlaylistTrack, event: MouseEvent<HTMLButtonElement>) {
+    const key = trackKey(track)
+    setSelectedKeys((current) => {
+      const next = new Set(current)
+      const anchorIndex = selectionAnchor === null
+        ? -1
+        : orderedTracks.findIndex((candidate) => trackKey(candidate) === selectionAnchor)
+      const targetIndex = orderedTracks.findIndex((candidate) => trackKey(candidate) === key)
+
+      if (event.shiftKey && anchorIndex >= 0 && targetIndex >= 0) {
+        const start = Math.min(anchorIndex, targetIndex)
+        const end = Math.max(anchorIndex, targetIndex)
+        orderedTracks.slice(start, end + 1).forEach((candidate) => next.add(trackKey(candidate)))
+      } else if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+    setSelectionAnchor(key)
+    setConfirming(null)
+    setBulkConfirming(false)
+  }
+
+  function clearSelection() {
+    setSelectedKeys(new Set())
+    setSelectionAnchor(null)
+    setBulkConfirming(false)
+  }
+
+  async function removeTrack(track: ProviderPlaylistTrack) {
+    if (!provider || !playlistId) return
+    const key = trackKey(track)
+    setRemoving(key)
+    setEditError(null)
+    try {
+      await api.removePlaylistTrack(provider, playlistId, {
+        position: track.position,
+        track_id: track.id,
+        occurrence_id: track.occurrence_id,
+      })
+      setConfirming(null)
+      setSelectedKeys((current) => {
+        const next = new Set(current)
+        next.delete(key)
+        return next
+      })
+      await refresh()
+      onChanged()
+    } catch (err) {
+      setEditError(errorMessage(err))
+    } finally {
+      setRemoving(null)
+    }
+  }
+
+  async function removeSelectedTracks() {
+    if (!provider || !playlistId || selectedTracks.length === 0) return
+    setBulkRemoving(true)
+    setEditError(null)
+    try {
+      await api.removePlaylistTracks(provider, playlistId, {
+        tracks: selectedTracks.map((track) => ({
+          position: track.position,
+          track_id: track.id,
+          occurrence_id: track.occurrence_id,
+        })),
+      })
+      clearSelection()
+      await refresh()
+      onChanged()
+    } catch (err) {
+      setEditError(errorMessage(err))
+    } finally {
+      setBulkRemoving(false)
+    }
+  }
+
+  const externalUrl = detail?.external_url || playlist?.external_url || ''
+  const trackCount = detail ? formatTrackCount(detail.count) : formatTrackCount(playlist?.count)
+
+  return (
+    <Modal
+      open={Boolean(account && playlist)}
+      onClose={onClose}
+      title={detail?.name || playlist?.name || 'Playlist'}
+      description={[account?.name, trackCount].filter(Boolean).join(' · ')}
+      widthClassName="max-w-5xl"
+    >
+      <div className="flex flex-col gap-4 pb-1">
+        <div className="flex flex-col gap-4 border-b border-border pb-4 sm:flex-row sm:items-center">
+          <CoverArt image={detail?.image || playlist?.image || ''} className="size-20 rounded-card sm:size-24" />
+          <div className="min-w-0 flex-1">
+            <p className="text-display truncate text-lg text-text">{detail?.name || playlist?.name}</p>
+            {detail?.description ? (
+              <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-text-3">{detail.description}</p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<LuRefreshCw className={cn('size-3.5', refreshing && 'animate-spin')} aria-hidden="true" />}
+              onClick={() => void refresh()}
+              disabled={refreshing}
+            >
+              Refresh
+            </Button>
+            {externalUrl ? (
+              <a
+                href={externalUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-11 items-center justify-center gap-2 rounded-control px-3 text-xs font-medium text-text-2 transition-colors hover:bg-surface-2 hover:text-text md:h-8 md:px-2.5"
+              >
+                Open in {account?.name}
+                <LuExternalLink className="size-3.5" aria-hidden="true" />
+              </a>
+            ) : null}
+          </div>
+        </div>
+
+        {detail?.editable ? (
+          <div className="flex items-start gap-2.5 rounded-control border border-warning/30 bg-warning-soft px-3.5 py-3 text-xs leading-relaxed text-text-2">
+            <span className="font-mono font-bold text-warning" aria-hidden="true">~</span>
+            <p>
+              {provider === 'spotify'
+                ? 'Spotify is authoritative for your one-way syncs. Manual edits here flow to mirrors on the next run.'
+                : `This changes ${account?.name} directly. If Spotify owns this mirror, make the same edit in Spotify or the next sync will restore it.`}
+            </p>
+          </div>
+        ) : detail ? (
+          <p className="rounded-control bg-neutral-soft px-3.5 py-3 text-xs text-text-2">
+            This playlist is read-only on {account?.name}. You can inspect it here or open it on the service.
+          </p>
+        ) : null}
+
+        {detail && detail.tracks.length > 0 ? (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_12rem]">
+            <label className="relative block">
+              <span className="sr-only">Search this playlist</span>
+              <LuSearch className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-3" aria-hidden="true" />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => changeQuery(event.target.value)}
+                placeholder={`Search ${detail.tracks.length} tracks`}
+                className={cn(FIELD_INPUT_CLASSES, 'pl-9')}
+              />
+            </label>
+            <FilterSelect
+              ariaLabel="Sort playlist tracks"
+              caption="Order"
+              value={order}
+              options={TRACK_ORDER_OPTIONS}
+              onChange={changeOrder}
+              icon={<LuArrowDownUp className="size-3.5" />}
+            />
+          </div>
+        ) : null}
+
+        {detail?.editable && selectedTracks.length > 0 ? (
+          <div className="rounded-control border border-accent/30 bg-accent-soft px-3.5 py-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-text">
+                  {selectedTracks.length} {selectedTracks.length === 1 ? 'track' : 'tracks'} selected
+                </p>
+                <p className="mt-0.5 text-xs text-text-3">Shift-click another track to select a range.</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button variant="ghost" size="sm" onClick={clearSelection} disabled={bulkRemoving}>
+                  Clear
+                </Button>
+                <Button
+                  variant="danger-ghost"
+                  size="sm"
+                  icon={<LuTrash2 className="size-3.5" aria-hidden="true" />}
+                  onClick={() => setBulkConfirming(true)}
+                  disabled={bulkRemoving}
+                >
+                  Remove selected
+                </Button>
+              </div>
+            </div>
+            {bulkConfirming ? (
+              <div className="mt-3 flex flex-col gap-2 border-t border-danger/20 pt-3 sm:flex-row sm:items-center">
+                <p className="mr-auto text-xs text-text-2">
+                  Remove {selectedTracks.length} selected {selectedTracks.length === 1 ? 'track' : 'tracks'} from {account?.name}?
+                </p>
+                <Button variant="ghost" size="sm" onClick={() => setBulkConfirming(false)} disabled={bulkRemoving}>
+                  Keep selected
+                </Button>
+                <Button variant="danger-ghost" size="sm" loading={bulkRemoving} onClick={() => void removeSelectedTracks()}>
+                  {bulkRemoving ? 'Removing…' : `Remove ${selectedTracks.length} ${selectedTracks.length === 1 ? 'track' : 'tracks'}`}
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {editError ? (
+          <p role="alert" className="rounded-control bg-danger-soft px-3.5 py-2.5 text-sm text-danger">
+            {editError}
+          </p>
+        ) : null}
+
+        {loading && !detail ? (
+          <LoadingStatus label={`Loading ${playlist?.name ?? 'playlist'} tracks…`}>
+            <div className="flex flex-col gap-2">
+              {[0, 1, 2, 3, 4, 5].map((index) => (
+                <Skeleton key={index} className="h-14 w-full" />
+              ))}
+            </div>
+          </LoadingStatus>
+        ) : error && !detail ? (
+          <EmptyState
+            title="Playlist couldn't be opened"
+            description={error}
+            action={<Button onClick={() => void refresh()}>Retry</Button>}
+          />
+        ) : detail && detail.tracks.length === 0 ? (
+          <EmptyState title="This playlist is empty" description={`Add tracks in ${account?.name}, then refresh this view.`} />
+        ) : detail && orderedTracks.length === 0 ? (
+          <EmptyState title="No matching tracks" description={`Nothing in this playlist matches “${query.trim()}”.`} />
+        ) : detail ? (
+          <div className="flex flex-col gap-2">
+            <ol className="thin-scrollbar max-h-[52vh] overflow-y-auto rounded-card border border-border bg-inset">
+              {pageTracks.map((track, rowIndex) => {
+                const key = trackKey(track)
+                const asking = confirming === key
+                const selected = selectedKeys.has(key)
+                const dateAdded = addedLabel(track.added_at)
+                return (
+                  <li
+                    key={key}
+                    className={cn(
+                      'playlist-track-row border-b border-border transition-colors last:border-b-0',
+                      selected && 'bg-accent-soft/60',
+                    )}
+                  >
+                    <div className="flex min-h-14 items-center gap-3 px-3 py-2 sm:px-4">
+                      <span className="w-8 shrink-0 text-right font-mono text-[10px] text-text-3" aria-hidden="true">
+                        {String(pageStart + rowIndex + 1).padStart(2, '0')}
+                      </span>
+                      {detail.editable ? (
+                        <button
+                          type="button"
+                          onClick={(event) => toggleSelection(track, event)}
+                          aria-label={`${selected ? 'Unselect' : 'Select'} ${track.name}`}
+                          aria-pressed={selected}
+                          title="Click to select; Shift-click to select a range"
+                          className="group flex min-w-0 flex-1 items-center gap-3 rounded-control text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+                        >
+                          <span className={cn('shrink-0 text-text-3 transition-colors group-hover:text-accent', selected && 'text-accent')}>
+                            {selected
+                              ? <LuSquareCheck className="size-4" aria-hidden="true" />
+                              : <LuSquare className="size-4" aria-hidden="true" />}
+                          </span>
+                          <CoverArt image={track.image} className="size-10" />
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-[13.5px] font-semibold text-text">{track.name}</span>
+                            <span className="block truncate text-xs text-text-3">
+                              {[track.artist, track.album, dateAdded].filter(Boolean).join(' · ') || 'Unknown artist'}
+                            </span>
+                          </span>
+                        </button>
+                      ) : (
+                        <div className="flex min-w-0 flex-1 items-center gap-3">
+                          <CoverArt image={track.image} className="size-10" />
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-[13.5px] font-semibold text-text">{track.name}</p>
+                            <p className="truncate text-xs text-text-3">
+                              {[track.artist, track.album, dateAdded].filter(Boolean).join(' · ') || 'Unknown artist'}
+                            </p>
+                          </div>
+                        </div>
+                      )}
+                      <span className="hidden w-14 shrink-0 text-right font-mono text-[11px] text-text-3 sm:block">
+                        {formatDuration(track.duration_ms ? track.duration_ms / 1000 : null) ?? '—'}
+                      </span>
+                      {track.external_url ? (
+                        <a
+                          href={track.external_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          aria-label={`Open ${track.name} in ${account?.name}`}
+                          title={`Open in ${account?.name}`}
+                          className="inline-flex size-11 shrink-0 items-center justify-center rounded-control text-text-3 hover:bg-surface-2 hover:text-text md:size-8"
+                        >
+                          <LuExternalLink className="size-4" aria-hidden="true" />
+                        </a>
+                      ) : null}
+                      {detail.editable ? (
+                        <button
+                          type="button"
+                          onClick={() => { setConfirming(asking ? null : key); setBulkConfirming(false) }}
+                          aria-label={`Remove ${track.name} from this playlist`}
+                          aria-expanded={asking}
+                          disabled={bulkRemoving}
+                          className="inline-flex size-11 shrink-0 items-center justify-center rounded-control text-text-3 hover:bg-danger-soft hover:text-danger md:size-8"
+                        >
+                          <LuTrash2 className="size-4" aria-hidden="true" />
+                        </button>
+                      ) : null}
+                    </div>
+                    {asking ? (
+                      <div className="flex flex-col gap-2 border-t border-danger/20 bg-danger-soft px-4 py-3 sm:flex-row sm:items-center sm:justify-end">
+                        <p className="mr-auto text-xs text-text-2">Remove “{track.name}” from {account?.name}?</p>
+                        <Button variant="ghost" size="sm" onClick={() => setConfirming(null)} disabled={removing === key}>
+                          Keep track
+                        </Button>
+                        <Button variant="danger-ghost" size="sm" loading={removing === key} onClick={() => void removeTrack(track)}>
+                          {removing === key ? 'Removing…' : 'Remove track'}
+                        </Button>
+                      </div>
+                    ) : null}
+                  </li>
+                )
+              })}
+            </ol>
+            <div className="flex flex-col gap-2 px-0.5 text-xs text-text-3 sm:flex-row sm:items-center sm:justify-between">
+              <p aria-live="polite">
+                Showing {pageStart + 1}–{pageStart + pageTracks.length} of {orderedTracks.length} tracks · {PAGE_SIZE} per page
+              </p>
+              {pageCount > 1 ? (
+                <div className="flex items-center gap-1.5">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<LuChevronLeft className="size-3.5" aria-hidden="true" />}
+                    onClick={() => { setPage(Math.max(1, safePage - 1)); setConfirming(null) }}
+                    disabled={safePage === 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="min-w-20 text-center font-mono text-[10.5px]">Page {safePage} / {pageCount}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => { setPage(Math.min(pageCount, safePage + 1)); setConfirming(null) }}
+                    disabled={safePage === pageCount}
+                  >
+                    Next
+                    <LuChevronRight className="size-3.5" aria-hidden="true" />
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/playlists/ProviderPlaylistsCard.tsx
+++ b/frontend/src/components/playlists/ProviderPlaylistsCard.tsx
@@ -1,11 +1,13 @@
 import { Link } from 'react-router-dom'
+import { LuExternalLink, LuListMusic } from 'react-icons/lu'
 
 import type { ProviderPlaylistsEntry } from '@/hooks/useProviderPlaylists'
 import { cn } from '@/lib/cn'
-import { serviceLogoId, tagText } from '@/lib/constants'
+import { serviceHomeUrl, serviceLogoId, tagText } from '@/lib/constants'
 import { formatTrackCount } from '@/lib/format'
-import type { Account } from '@/types'
+import type { Account, ProviderPlaylist } from '@/types'
 
+import { Button } from '../ui/Button'
 import { Card } from '../ui/Card'
 import { CoverArt } from '../ui/CoverArt'
 import { EmptyState } from '../ui/EmptyState'
@@ -16,9 +18,20 @@ import { BUTTON_BASE_CLASSES, BUTTON_SIZE_CLASSES, BUTTON_VARIANT_CLASSES } from
 
 /** One provider's playlists for the Browse section. Handles all four states
  * explicitly: not connected, loading, errored, and loaded (possibly empty). */
-export function ProviderPlaylistsCard({ account, entry }: { account: Account; entry: ProviderPlaylistsEntry | undefined }) {
+export function ProviderPlaylistsCard({
+  account,
+  entry,
+  onOpenPlaylist,
+  onRetry,
+}: {
+  account: Account
+  entry: ProviderPlaylistsEntry | undefined
+  onOpenPlaylist: (playlist: ProviderPlaylist) => void
+  onRetry: () => void
+}) {
   const connected = account.state === 'connected'
   const logoId = serviceLogoId(account.id)
+  const homeUrl = serviceHomeUrl(account.id)
 
   return (
     <Card className="flex flex-col gap-3 p-4 sm:p-5">
@@ -37,7 +50,20 @@ export function ProviderPlaylistsCard({ account, entry }: { account: Account; en
             </span>
           )}
         </div>
-        <StatusPill state={account.state} />
+        <div className="flex w-full items-center justify-between gap-2">
+          <StatusPill state={account.state} />
+          {connected && homeUrl ? (
+            <a
+              href={homeUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex min-h-8 items-center gap-1.5 rounded-control px-2 text-[11.5px] font-semibold text-text-3 hover:bg-surface-2 hover:text-text-2"
+            >
+              Open service
+              <LuExternalLink className="size-3" aria-hidden="true" />
+            </a>
+          ) : null}
+        </div>
       </div>
 
       {entry?.error && entry.playlists.length > 0 && (
@@ -66,24 +92,52 @@ export function ProviderPlaylistsCard({ account, entry }: { account: Account; en
           </div>
         </LoadingStatus>
       ) : entry.error && entry.playlists.length === 0 ? (
-        <p className="text-sm text-danger">Could not load playlists: {entry.error}</p>
+        <div className="flex flex-col items-start gap-3 rounded-control bg-danger-soft p-3">
+          <p className="text-sm text-danger">Could not load playlists: {entry.error}</p>
+          <Button variant="secondary" size="sm" onClick={onRetry}>Retry</Button>
+        </div>
       ) : entry.playlists.length > 0 ? (
         <ul className="thin-scrollbar flex max-h-80 flex-col divide-y divide-border overflow-y-auto">
           {entry.playlists.map((p, i) => (
             <li key={p.id} className="flex items-center gap-3 py-2">
-              <span className="shrink-0 font-mono text-[10px] text-text-3" aria-hidden="true">
-                {String(i + 1).padStart(2, '0')}
-              </span>
-              <CoverArt image={p.image} />
-              <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium text-text">{p.name}</span>
-              {formatTrackCount(p.count) && (
-                <span className="shrink-0 font-mono text-[11.5px] text-text-3">{formatTrackCount(p.count)}</span>
-              )}
+              <button
+                type="button"
+                onClick={() => onOpenPlaylist(p)}
+                className="group flex min-w-0 flex-1 items-center gap-3 rounded-control text-left hover:text-accent"
+                aria-label={`Open ${p.name} inside SongMirror`}
+              >
+                <span className="shrink-0 font-mono text-[10px] text-text-3" aria-hidden="true">
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <CoverArt image={p.image} />
+                <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium text-text group-hover:text-accent">{p.name}</span>
+                {formatTrackCount(p.count) ? (
+                  <span className="shrink-0 font-mono text-[11.5px] text-text-3">{formatTrackCount(p.count)}</span>
+                ) : null}
+                <LuListMusic className="size-3.5 shrink-0 text-text-3 group-hover:text-accent" aria-hidden="true" />
+              </button>
+              {p.external_url ? (
+                <a
+                  href={p.external_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Open ${p.name} in ${account.name}`}
+                  title={`Open in ${account.name}`}
+                  className="inline-flex size-11 shrink-0 items-center justify-center rounded-control text-text-3 hover:bg-surface-2 hover:text-text md:size-8"
+                >
+                  <LuExternalLink className="size-3.5" aria-hidden="true" />
+                </a>
+              ) : null}
             </li>
           ))}
         </ul>
       ) : (
-        <EmptyState className="py-6" title="No playlists found" description="This service doesn't have any playlists yet." />
+        <EmptyState
+          className="py-6"
+          title="No playlists found"
+          description="No playlists were returned. Refresh once before creating a new one."
+          action={<Button variant="secondary" size="sm" onClick={onRetry}>Refresh</Button>}
+        />
       )}
     </Card>
   )

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -15,7 +15,14 @@ import { useSettings } from '@/hooks/useSettings'
 import { cn } from '@/lib/cn'
 import { serviceLogoId, tagDot, tagText } from '@/lib/constants'
 import { isValidIntervalText, isValidPositiveInt } from '@/lib/format'
-import { buildSyncSummaryRows, enabledProvidersOf, lockedSourceOf, syncPeersOf } from '@/lib/syncSummary'
+import {
+  authorityProvidersOf,
+  buildSyncSummaryRows,
+  enabledProvidersOf,
+  lockedProvidersOf,
+  parseCsv,
+  syncPeersOf,
+} from '@/lib/syncSummary'
 import { PlaylistFilterField } from '../settings/PlaylistFilterField'
 import type { Account, SyncJob, SyncJobUpsertRequest, SyncMode } from '@/types'
 
@@ -27,6 +34,7 @@ interface JobFormState {
   enabled: boolean
   mode: SyncMode
   source: string
+  authorities: string
   providers: string
   playlists: string
   interval: string
@@ -43,6 +51,7 @@ const NEW_JOB_DEFAULTS: JobFormState = {
   enabled: true,
   mode: 'oneway',
   source: 'spotify',
+  authorities: '',
   providers: '',
   playlists: '',
   interval: '15m',
@@ -60,6 +69,7 @@ function formFromJob(job: SyncJob | null): JobFormState {
     enabled: job.enabled,
     mode: job.mode,
     source: job.source,
+    authorities: job.authorities || '',
     providers: job.providers,
     playlists: job.playlists,
     interval: job.interval,
@@ -100,11 +110,13 @@ function ProviderChip({
   account,
   checked,
   locked,
+  role,
   onToggle,
 }: {
   account: Account
   checked: boolean
   locked: boolean
+  role?: 'source' | 'order' | 'authority' | 'mirror'
   onToggle: () => void
 }) {
   const logoId = serviceLogoId(account.id)
@@ -114,13 +126,13 @@ function ProviderChip({
     <button
       type="button"
       onClick={connected && !locked ? onToggle : undefined}
-      disabled={!connected}
+      disabled={!connected || locked}
       aria-pressed={connected ? checked : undefined}
       title={
         !connected
           ? `Connect ${account.name} on the Accounts page to include it in syncing.`
           : locked
-            ? `${account.name} is the sync source, always included, and it's never modified.`
+            ? `${account.name} is ${role === 'order' ? 'the order authority' : role === 'authority' ? 'an authority' : 'the sync source'} and is always included.`
             : undefined
       }
       className={cn(
@@ -138,9 +150,9 @@ function ProviderChip({
         <span className={cn('size-2 shrink-0 rounded-full', tagDot(account.id))} aria-hidden="true" />
       )}
       {account.name}
-      {locked && connected && (
+      {role && connected && checked && (
         <span className="rounded-full bg-accent px-1.5 py-[1px] font-mono text-[9px] font-bold uppercase tracking-wide text-on-accent">
-          source
+          {role}
         </span>
       )}
       {!connected && <span className="font-normal text-text-3">not connected</span>}
@@ -290,16 +302,93 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   const syncPeers = syncPeersOf(accounts)
   const jellyfinConnected = accounts.some((a) => a.id === 'jellyfin' && a.state === 'connected')
 
-  // The configurable one-way source of truth (default: spotify). Only
-  // meaningful in one-way mode — N-way has no single source, so nothing is
-  // locked there even if a non-default source was saved from an earlier
-  // one-way session.
+  // One-way uses this as its source of truth. In group mode it is the order
+  // authority: playlist names and sequence follow it, while membership can be
+  // changed on any authority.
   const syncSource = form.source || 'spotify'
-  const lockedSourceId = lockedSourceOf({ mode: form.mode, source: form.source })
+  const authorityIds = authorityProvidersOf({ mode: form.mode, authorities: form.authorities })
+  const lockedProviderIds = lockedProvidersOf({
+    mode: form.mode,
+    source: form.source,
+    authorities: form.authorities,
+  })
   const nonSpotifySourceConflict =
     form.mode !== 'nway' && syncSource !== 'spotify' && (form.download || jellyfinConnected)
 
   const enabledProviders = enabledProvidersOf({ providers: form.providers }, syncPeers)
+  const connectedPeerIds = new Set(syncPeers.filter((account) => account.state === 'connected').map((account) => account.id))
+
+  function csvInPeerOrder(ids: Set<string>) {
+    return syncPeers.filter((account) => ids.has(account.id)).map((account) => account.id).join(',')
+  }
+
+  function selectMode(mode: SyncMode) {
+    setForm((prev) => {
+      const next = { ...prev, mode }
+      const connected = syncPeers.filter((account) => account.state === 'connected').map((account) => account.id)
+      if (mode === 'group') {
+        const source = connected.includes(prev.source)
+          ? prev.source
+          : connected.includes('spotify')
+            ? 'spotify'
+            : connected[0] || prev.source
+        const authorities = new Set(parseCsv(prev.authorities).filter((id) => connected.includes(id)))
+        if (source) authorities.add(source)
+        if (authorities.size < 2) {
+          const second = connected.find((id) => id !== source)
+          if (second) authorities.add(second)
+        }
+        const providers = new Set(parseCsv(prev.providers))
+        for (const id of authorities) providers.add(id)
+        next.source = source
+        next.authorities = csvInPeerOrder(authorities)
+        next.providers = csvInPeerOrder(providers)
+      } else if (mode === 'oneway') {
+        const providers = new Set(parseCsv(prev.providers))
+        if (prev.source) providers.add(prev.source)
+        next.providers = csvInPeerOrder(providers)
+      }
+      return next
+    })
+  }
+
+  function selectOrderAuthority(id: string) {
+    setForm((prev) => {
+      const providers = new Set(parseCsv(prev.providers))
+      providers.add(id)
+      if (prev.mode !== 'group') {
+        return { ...prev, source: id, providers: csvInPeerOrder(providers) }
+      }
+      const authorities = new Set(parseCsv(prev.authorities))
+      authorities.add(id)
+      return {
+        ...prev,
+        source: id,
+        authorities: csvInPeerOrder(authorities),
+        providers: csvInPeerOrder(providers),
+      }
+    })
+  }
+
+  function toggleAuthority(id: string) {
+    if (!connectedPeerIds.has(id)) return
+    setForm((prev) => {
+      const authorities = new Set(parseCsv(prev.authorities))
+      if (authorities.has(id)) {
+        if (id === (prev.source || 'spotify')) return prev
+        authorities.delete(id)
+      } else {
+        authorities.add(id)
+      }
+      const providers = new Set(parseCsv(prev.providers))
+      providers.add(id)
+      return {
+        ...prev,
+        authorities: csvInPeerOrder(authorities),
+        providers: csvInPeerOrder(providers),
+      }
+    })
+  }
 
   // Step 3's playlist picker has to browse whichever provider is actually
   // meaningful for this job, not always Spotify (the picker's original,
@@ -312,23 +401,27 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     form.mode !== 'nway' ? syncSource : (enabledProviders.has('spotify') ? 'spotify' : syncPeers.find((a) => enabledProviders.has(a.id))?.id) || null
 
   function toggleProvider(id: string) {
-    if (id === lockedSourceId) return // the source — never toggleable
+    if (lockedProviderIds.has(id)) return
     const next = new Set(enabledProviders)
-    if (lockedSourceId) next.add(lockedSourceId) // materializing an explicit list must never drop the source
+    for (const lockedId of lockedProviderIds) next.add(lockedId)
     if (next.has(id)) next.delete(id)
     else next.add(id)
-    setField('providers', [...next].join(','))
+    setField('providers', csvInPeerOrder(next))
   }
 
   const nameValid = form.name.trim().length > 0
   const intervalValid = isValidIntervalText(form.interval)
   const maxAddsValid = isValidPositiveInt(form.max_adds)
   const maxRemovalsValid = !form.mirror_removals || isValidPositiveInt(form.max_removals)
-  const formValid = nameValid && intervalValid && maxAddsValid && maxRemovalsValid
+  const groupValid =
+    form.mode !== 'group' ||
+    (authorityIds.size >= 2 && authorityIds.has(syncSource) &&
+      [...authorityIds].every((id) => connectedPeerIds.has(id) && enabledProviders.has(id)))
+  const formValid = nameValid && intervalValid && maxAddsValid && maxRemovalsValid && groupValid
 
   // Only Direction's name (always valid) aside, Schedule (interval) and
   // Limits (caps) are the only steps with a bad state to block Next on.
-  const stepValid = [true, true, true, intervalValid, maxAddsValid && maxRemovalsValid]
+  const stepValid = [groupValid, true, true, intervalValid, maxAddsValid && maxRemovalsValid]
   const isLastStep = step === STEPS.length - 1
 
   const previewJob: SyncJob = {
@@ -337,6 +430,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     enabled: form.enabled,
     mode: form.mode,
     source: form.source,
+    authorities: form.authorities,
     providers: form.providers,
     playlists: form.playlists,
     interval: form.interval,
@@ -357,6 +451,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
         enabled: form.enabled,
         mode: form.mode,
         source: form.source,
+        authorities: form.authorities,
         providers: form.providers,
         playlists: form.playlists,
         interval: form.interval,
@@ -422,8 +517,8 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                 <RadioCard
                   name="sync-mode"
                   value="oneway"
-                  checked={form.mode !== 'nway'}
-                  onChange={() => setField('mode', 'oneway')}
+                  checked={form.mode === 'oneway'}
+                  onChange={() => selectMode('oneway')}
                   title="One-way →"
                   description="One provider is the source of truth. Everyone else follows it, and it's never modified."
                 />
@@ -431,13 +526,22 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                   name="sync-mode"
                   value="nway"
                   checked={form.mode === 'nway'}
-                  onChange={() => setField('mode', 'nway')}
+                  onChange={() => selectMode('nway')}
                   title="Bidirectional (N-way) ⇄"
                   description="A track added or removed on any connected service propagates to all the others."
                 />
+                <RadioCard
+                  name="sync-mode"
+                  value="group"
+                  checked={form.mode === 'group'}
+                  onChange={() => selectMode('group')}
+                  title="Authority group ⇆"
+                  description="Two or more trusted services contribute changes; every other selected service only mirrors them."
+                  className="sm:col-span-2"
+                />
               </div>
 
-              {form.mode !== 'nway' && (
+              {form.mode === 'oneway' && (
                 <div className="flex flex-col gap-2.5 border-t border-border pt-3.5">
                   <div>
                     <span className="text-[12.5px] font-semibold text-text-2">Source of truth</span>
@@ -452,7 +556,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                         key={account.id}
                         account={account}
                         selected={syncSource === account.id}
-                        onSelect={() => setField('source', account.id)}
+                        onSelect={() => selectOrderAuthority(account.id)}
                       />
                     ))}
                   </div>
@@ -465,20 +569,100 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                   )}
                 </div>
               )}
+
+              {form.mode === 'group' && (
+                <div className="flex flex-col gap-4 border-t border-border pt-3.5">
+                  <div className="flex flex-col gap-2.5">
+                    <div>
+                      <span className="text-[12.5px] font-semibold text-text-2">Order authority</span>
+                      <p className="mt-1 text-xs leading-relaxed text-text-3">
+                        Playlist names and track sequence follow this service. New membership can still come from
+                        any authority below.
+                      </p>
+                    </div>
+                    <div role="radiogroup" aria-label="Order authority" className="flex flex-wrap gap-2">
+                      {syncPeers.map((account) => (
+                        <SourceChip
+                          key={account.id}
+                          account={account}
+                          selected={syncSource === account.id}
+                          onSelect={() => selectOrderAuthority(account.id)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-2.5">
+                    <div>
+                      <span className="text-[12.5px] font-semibold text-text-2">Membership authorities</span>
+                      <p className="mt-1 text-xs leading-relaxed text-text-3">
+                        Additions and confirmed removals on any selected authority flow to the full group. Choose at
+                        least two; the order authority is always included.
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {syncPeers.map((account) => {
+                        const selected = authorityIds.has(account.id)
+                        const isOrder = account.id === syncSource
+                        return (
+                          <ProviderChip
+                            key={account.id}
+                            account={account}
+                            checked={selected}
+                            locked={isOrder}
+                            role={isOrder && selected ? 'order' : selected ? 'authority' : undefined}
+                            onToggle={() => toggleAuthority(account.id)}
+                          />
+                        )
+                      })}
+                    </div>
+                    {!groupValid && (
+                      <p className="text-xs leading-relaxed text-danger">
+                        Select at least two connected authorities, including the order authority.
+                      </p>
+                    )}
+                  </div>
+
+                  {nonSpotifySourceConflict && (
+                    <p className="flex items-start gap-1.5 text-xs leading-relaxed text-text-3">
+                      <LuInfo className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                      Local downloads + Jellyfin covers currently require Spotify as the order authority, so they'll
+                      be skipped.
+                    </p>
+                  )}
+                </div>
+              )}
             </>
           )}
 
           {step === 1 && (
             <div className="flex flex-wrap gap-2">
-              {syncPeers.map((account) => (
-                <ProviderChip
-                  key={account.id}
-                  account={account}
-                  checked={account.id === lockedSourceId || enabledProviders.has(account.id)}
-                  locked={account.id === lockedSourceId}
-                  onToggle={() => toggleProvider(account.id)}
-                />
-              ))}
+              {syncPeers.map((account) => {
+                const locked = lockedProviderIds.has(account.id)
+                const checked = locked || enabledProviders.has(account.id)
+                const role =
+                  form.mode === 'group'
+                    ? account.id === syncSource && authorityIds.has(account.id)
+                      ? 'order'
+                      : authorityIds.has(account.id)
+                        ? 'authority'
+                        : checked
+                          ? 'mirror'
+                          : undefined
+                    : form.mode === 'oneway' && account.id === syncSource
+                      ? 'source'
+                      : undefined
+                return (
+                  <ProviderChip
+                    key={account.id}
+                    account={account}
+                    checked={checked}
+                    locked={locked}
+                    role={role}
+                    onToggle={() => toggleProvider(account.id)}
+                  />
+                )
+              })}
             </div>
           )}
 
@@ -555,14 +739,32 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     checked={form.mirror_removals}
                     onChange={(v) => setField('mirror_removals', v)}
                     label="Mirror removals"
-                    description="Off (default): a track removed on one service is kept on the others — so a song losing licensing on one platform never disappears everywhere. On: removals sync too, capped per pass."
+                    description={
+                      form.mode === 'group'
+                        ? 'Off (default): removals and mirror-only tracks are kept. On: confirmed removals from either authority—and tracks found only on mirrors—are pruned everywhere, capped per pass.'
+                        : form.mode === 'nway'
+                          ? 'Off (default): a track removed on one service is kept on the others. On: confirmed removals from any service sync too, capped per pass.'
+                          : 'Off (default): tracks missing from the source are kept on mirrors. On: source removals sync too, capped per pass.'
+                    }
                   />
                   <Tooltip
                     content={
                       <>
-                        A track removed on <span className="font-semibold text-text">any</span> service — including one
-                        quietly pulled by a licensing change — is deleted from all the others, and its downloaded copy
-                        goes too. Removals under the cap apply without review.
+                        {form.mode === 'group' ? (
+                          <>
+                            A confirmed removal on <span className="font-semibold text-text">either authority</span>, or
+                            a track added only to a mirror, is removed across the group. Mirror edits never become
+                            authoritative.
+                          </>
+                        ) : form.mode === 'nway' ? (
+                          <>
+                            A track removed on <span className="font-semibold text-text">any</span> service is deleted
+                            from all the others after confirmation.
+                          </>
+                        ) : (
+                          <>A track absent from the source is removed from every selected mirror.</>
+                        )}{' '}
+                        Removals under the cap apply without review.
                       </>
                     }
                   >

--- a/frontend/src/components/ui/RadioCard.tsx
+++ b/frontend/src/components/ui/RadioCard.tsx
@@ -8,17 +8,19 @@ interface RadioCardProps {
   title: string
   description: string
   disabled?: boolean
+  className?: string
 }
 
 /** Selected = accent border + soft wash, radio filled (a 5px ring trick, no
  * extra markup); for the two or three choices that deserve a sentence. */
-export function RadioCard({ name, value, checked, onChange, title, description, disabled }: RadioCardProps) {
+export function RadioCard({ name, value, checked, onChange, title, description, disabled, className }: RadioCardProps) {
   return (
     <label
       className={cn(
         'flex cursor-pointer gap-[11px] rounded-card border-[1.5px] p-[13px_14px] transition-colors duration-fast',
         checked ? 'border-accent bg-accent-soft' : 'border-border hover:border-border-strong',
         disabled && 'cursor-not-allowed opacity-45',
+        className,
       )}
     >
       <span

--- a/frontend/src/hooks/usePlaylistDetail.ts
+++ b/frontend/src/hooks/usePlaylistDetail.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react'
+import useSWR from 'swr'
+
+import { api, errorMessage } from '@/api'
+import type { ProviderPlaylistDetail } from '@/types'
+
+/** On-demand playlist contents. The server's SQLite-backed playlist cache makes
+ * reopens instant; the visible Refresh action explicitly bypasses that cache. */
+export function usePlaylistDetail(
+  provider: string | null,
+  playlistId: string | null,
+  expectedCount?: number | null,
+) {
+  const key = provider && playlistId
+    ? ['playlist-detail', provider, playlistId, expectedCount]
+    : null
+  const { data, error, isLoading, isValidating, mutate } = useSWR<ProviderPlaylistDetail>(
+    key,
+    () => api.getPlaylistDetail(provider as string, playlistId as string, { expectedCount }),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 2_000,
+    },
+  )
+
+  const refresh = useCallback(async () => {
+    await mutate(
+      api.getPlaylistDetail(provider as string, playlistId as string, {
+        refresh: true,
+        expectedCount,
+      }),
+      { revalidate: false },
+    )
+  }, [expectedCount, mutate, playlistId, provider])
+
+  return {
+    detail: data ?? null,
+    loading: isLoading,
+    refreshing: isValidating,
+    error: error ? errorMessage(error) : null,
+    refresh,
+  }
+}

--- a/frontend/src/hooks/useProviderPlaylists.ts
+++ b/frontend/src/hooks/useProviderPlaylists.ts
@@ -31,7 +31,8 @@ function isProviderPlaylistArray(value: unknown): value is ProviderPlaylist[] {
         'count' in playlist &&
         (playlist.count === null || typeof playlist.count === 'number') &&
         'image' in playlist &&
-        typeof playlist.image === 'string',
+        typeof playlist.image === 'string' &&
+        (!('external_url' in playlist) || typeof playlist.external_url === 'string'),
     )
   )
 }

--- a/frontend/src/hooks/useSyncs.ts
+++ b/frontend/src/hooks/useSyncs.ts
@@ -12,7 +12,8 @@ function isSyncJobArray(value: unknown): value is SyncJob[] {
         typeof job.id === 'string' &&
         typeof job.name === 'string' &&
         typeof job.enabled === 'boolean' &&
-        (job.mode === 'oneway' || job.mode === 'nway'),
+        (job.mode === 'oneway' || job.mode === 'group' || job.mode === 'nway') &&
+        ('authorities' in job ? typeof job.authorities === 'string' : true),
     )
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -240,3 +240,10 @@ body {
   background-color: var(--color-border-strong);
   border-radius: 9999px;
 }
+
+/* Playlist inspection can exceed 1,000 tracks. Keep the real ordered DOM for
+   find/accessibility while letting the browser skip paint/layout off-screen. */
+.playlist-track-row {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 56px;
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -100,6 +100,20 @@ export function serviceLogoId(idOrTag: string): 'spotify' | 'tidal' | 'qobuz' | 
   return null
 }
 
+const SERVICE_HOME_URLS: Record<string, string> = {
+  spotify: 'https://open.spotify.com/',
+  tidal: 'https://listen.tidal.com/',
+  qobuz: 'https://play.qobuz.com/',
+  deezer: 'https://www.deezer.com/',
+  amazon: 'https://music.amazon.com/',
+  apple: 'https://music.apple.com/',
+  ytmusic: 'https://music.youtube.com/',
+}
+
+export function serviceHomeUrl(idOrTag: string): string {
+  return SERVICE_HOME_URLS[activitySourceId(idOrTag)] ?? ''
+}
+
 interface KindStyle {
   /** Plain-language name exposed alongside EventRow's visual action icon. */
   label: string

--- a/frontend/src/lib/persistedResource.ts
+++ b/frontend/src/lib/persistedResource.ts
@@ -3,7 +3,7 @@ import useSWR from 'swr'
 
 import { errorMessage } from '@/api'
 
-const CACHE_SCHEMA_VERSION = 1
+const CACHE_SCHEMA_VERSION = 2
 const CACHE_PREFIX = `songmirror-cache-v${CACHE_SCHEMA_VERSION}:`
 
 interface CacheEnvelope<T> {

--- a/frontend/src/lib/syncSummary.ts
+++ b/frontend/src/lib/syncSummary.ts
@@ -1,7 +1,7 @@
 import type { Account, SyncJob } from '@/types'
 
-export function parseCsv(value: string): string[] {
-  return value
+export function parseCsv(value: string | null | undefined): string[] {
+  return (value || '')
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean)
@@ -20,10 +20,21 @@ export function syncPeersOf(accounts: Account[]): Account[] {
   return accounts.filter((a) => a.transferable)
 }
 
-/** Whichever peer is locked as the source in one-way mode — `null` in
- * N-way, which has no single source. */
+/** Whichever peer is locked as the source in one-way mode. Group jobs lock
+ * every authority separately; N-way has no locked provider. */
 export function lockedSourceOf(job: Pick<SyncJob, 'mode' | 'source'>): string | null {
-  return job.mode === 'nway' ? null : job.source || 'spotify'
+  return job.mode === 'oneway' ? job.source || 'spotify' : null
+}
+
+export function authorityProvidersOf(job: Pick<SyncJob, 'mode' | 'authorities'>): Set<string> {
+  return job.mode === 'group' ? new Set(parseCsv(job.authorities)) : new Set()
+}
+
+export function lockedProvidersOf(
+  job: Pick<SyncJob, 'mode' | 'source' | 'authorities'>,
+): Set<string> {
+  if (job.mode === 'oneway') return new Set([job.source || 'spotify'])
+  return authorityProvidersOf(job)
 }
 
 /** Which providers a job explicitly includes. Empty means none; treating it
@@ -53,11 +64,24 @@ export function buildSyncSummaryRows(job: SyncJob, peers: Account[], downloadDir
 
   const enabled = enabledProvidersOf(job, peers)
   const lockedId = lockedSourceOf(job)
-  const enabledNames = peers.filter((a) => a.id === lockedId || enabled.has(a.id)).map((a) => a.name)
+  const authorities = authorityProvidersOf(job)
+  const included = new Set([...enabled, ...(lockedId ? [lockedId] : []), ...authorities])
+  const enabledNames = peers.filter((a) => included.has(a.id)).map((a) => a.name)
   if (job.mode === 'nway') {
     // No single source in N-way — just list who's included.
     const who = enabledNames.length > 0 ? enabledNames.join(' ⇄ ') : 'no services selected'
     rows.push({ label: 'Direction', value: `Bidirectional (N-way) · ${who}` })
+  } else if (job.mode === 'group') {
+    const sourceId = job.source || 'spotify'
+    const orderedAuthorities = [
+      ...peers.filter((a) => a.id === sourceId && authorities.has(a.id)),
+      ...peers.filter((a) => a.id !== sourceId && authorities.has(a.id)),
+    ]
+    const authorityNames = orderedAuthorities.map((a) => a.name)
+    const mirrorNames = peers.filter((a) => included.has(a.id) && !authorities.has(a.id)).map((a) => a.name)
+    const authorityLabel = authorityNames.length > 0 ? authorityNames.join(' + ') : 'no authorities selected'
+    const who = mirrorNames.length > 0 ? `${authorityLabel} → ${mirrorNames.join(', ')}` : `${authorityLabel} only`
+    rows.push({ label: 'Direction', value: `Authoritative group · ${who}` })
   } else {
     const sourceName = peers.find((a) => a.id === (job.source || 'spotify'))?.name ?? 'Spotify'
     const others = enabledNames.filter((n) => n !== sourceName)

--- a/frontend/src/pages/Playlists.tsx
+++ b/frontend/src/pages/Playlists.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 
 import { LinkCard } from '@/components/playlists/LinkCard'
 import { LinkEditorModal } from '@/components/playlists/LinkEditorModal'
+import { PlaylistDetailModal } from '@/components/playlists/PlaylistDetailModal'
 import { ProviderPlaylistsCard } from '@/components/playlists/ProviderPlaylistsCard'
 import { Button } from '@/components/ui/Button'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -9,16 +10,20 @@ import { LoadingStatus, Skeleton } from '@/components/ui/Skeleton'
 import { useAccounts } from '@/hooks/useAccounts'
 import { useLinks } from '@/hooks/useLinks'
 import { useProviderPlaylists } from '@/hooks/useProviderPlaylists'
-import type { PlaylistLink } from '@/types'
+import type { Account, PlaylistLink, ProviderPlaylist } from '@/types'
 
 export default function Playlists() {
   const { accounts, loading: accountsLoading, error: accountsError } = useAccounts()
   const connectedAccounts = useMemo(() => accounts?.filter((a) => a.state === 'connected') ?? [], [accounts])
   const connectedIds = useMemo(() => connectedAccounts.map((a) => a.id), [connectedAccounts])
-  const { entries } = useProviderPlaylists(connectedIds)
+  const { entries, refresh: refreshPlaylists } = useProviderPlaylists(connectedIds)
   const { links, loading: linksLoading, error: linksError, refresh: refreshLinks } = useLinks()
 
   const [editorTarget, setEditorTarget] = useState<PlaylistLink | 'new' | null>(null)
+  const [viewerTarget, setViewerTarget] = useState<{
+    account: Account
+    playlist: ProviderPlaylist
+  } | null>(null)
 
   return (
     <div className="flex flex-col gap-8">
@@ -45,7 +50,13 @@ export default function Playlists() {
         ) : accounts && accounts.length > 0 ? (
           <div className="grid grid-cols-1 items-start gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {accounts.map((account) => (
-              <ProviderPlaylistsCard key={account.id} account={account} entry={entries[account.id]} />
+              <ProviderPlaylistsCard
+                key={account.id}
+                account={account}
+                entry={entries[account.id]}
+                onOpenPlaylist={(playlist) => setViewerTarget({ account, playlist })}
+                onRetry={() => void refreshPlaylists()}
+              />
             ))}
           </div>
         ) : (
@@ -119,6 +130,12 @@ export default function Playlists() {
           setEditorTarget(null)
           void refreshLinks()
         }}
+      />
+      <PlaylistDetailModal
+        account={viewerTarget?.account ?? null}
+        playlist={viewerTarget?.playlist ?? null}
+        onClose={() => setViewerTarget(null)}
+        onChanged={() => void refreshPlaylists()}
       />
     </div>
   )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -260,9 +260,43 @@ export interface ProviderPlaylist {
   name: string
   count: number | null
   image: string
+  /** First-party web-player URL for opening this exact playlist. */
+  external_url: string
   /** False for a followed (non-owned) playlist. Only Spotify distinguishes the
    * two today; absent/true elsewhere. Drives the Created/Followed grouping. */
   owned?: boolean
+}
+
+export interface ProviderPlaylistTrack {
+  /** Zero-based position from the provider read; used as an optimistic edit guard. */
+  position: number
+  id: string
+  isrc: string
+  occurrence_id: string
+  name: string
+  artist: string
+  album: string | null
+  duration_ms: number | null
+  image: string
+  added_at: string
+  external_url: string
+}
+
+export interface ProviderPlaylistDetail extends ProviderPlaylist {
+  provider: string
+  description: string
+  editable: boolean
+  tracks: ProviderPlaylistTrack[]
+}
+
+export interface RemovePlaylistTrackRequest {
+  position: number
+  track_id: string
+  occurrence_id?: string
+}
+
+export interface RemovePlaylistTracksRequest {
+  tracks: RemovePlaylistTrackRequest[]
 }
 
 export type LinkDirection = 'oneway' | 'nway'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -130,6 +130,8 @@ export interface HeldRemoval {
 
 export type ChangeDiagnosticCategory =
   | 'identity_migration'
+  | 'authority_baseline'
+  | 'playlist_recreated'
   | 'unconfirmed_absence'
   | 'confirmed_absence'
   | 'incomplete_read'
@@ -198,7 +200,7 @@ export interface SyncStatus {
   jobs: SyncJobStatus[]
 }
 
-export type SyncMode = 'oneway' | 'nway'
+export type SyncMode = 'oneway' | 'group' | 'nway'
 
 /** GET/POST/PUT /api/syncs — one independent, named sync configuration
  * (multiple jobs can run side by side, Soundiiz-style). `providers` and
@@ -211,7 +213,12 @@ export interface SyncJob {
   name: string
   enabled: boolean
   mode: SyncMode
+  /** One-way source, or the provider whose playlist names/order lead an
+   * authoritative group. Ignored for fully N-way jobs. */
   source: string
+  /** Comma-separated membership authorities in group mode. Mirrors never
+   * contribute playlist changes back into this set. */
+  authorities: string
   providers: string
   playlists: string
   interval: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "songmirror"
 version = "0.1.0"
-description = "Bidirectional N-way playlist sync across major music services, with optional local audio copies"
+description = "One-way, authoritative-group, and N-way playlist sync across major music services"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/songmirror/deezer_web.py
+++ b/songmirror/deezer_web.py
@@ -128,7 +128,10 @@ query SongMirrorDeezerPlaylistTracks($playlistId: String!, $first: Int!, $cursor
         cursor
         node {
           id title duration
-          album { id displayTitle }
+          album {
+            id displayTitle
+            cover { urls(pictureRequest: {width: 128, height: 128}) }
+          }
           contributors { edges { node { ... on Artist { id name } } } }
         }
       }

--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -7,6 +7,9 @@ The main tables in one file:
               passes match by hard identifier instead of re-searching.
 - sync_state: a playlist's Spotify snapshot_id after a clean pass, so an
               unchanged pair can be skipped wholesale.
+- playlist_cache / playlist_track_cache: the last complete normalized playlist
+              read, so the in-app editor can reopen large playlists without a
+              fresh provider round trip.
 
 SQLite over a pickle blob: incremental writes, crash-safe, and inspectable
 (`sqlite3 song_cache.db "SELECT name, artist, last_seen FROM songs"`).
@@ -129,6 +132,48 @@ CREATE TABLE IF NOT EXISTS playlist_order (
     PRIMARY KEY (playlist, source, captured_at)
 )
 """,
+    # Persistent, inspectable cache for the in-app playlist ledger. Keep the
+    # playlist metadata and ordered physical entries relational rather than in
+    # one opaque JSON blob: this makes provider coverage/order easy to audit and
+    # lets a future migration enrich individual rows without rewriting a large
+    # payload.
+    """
+CREATE TABLE IF NOT EXISTS playlist_cache (
+    provider     TEXT NOT NULL,
+    playlist_id  TEXT NOT NULL,
+    name         TEXT NOT NULL,
+    description  TEXT NOT NULL,
+    count        INTEGER NOT NULL,
+    image        TEXT NOT NULL,
+    owned        INTEGER NOT NULL,
+    editable     INTEGER NOT NULL,
+    external_url TEXT NOT NULL,
+    refreshed_at TEXT NOT NULL,
+    PRIMARY KEY (provider, playlist_id)
+)
+""",
+    """
+CREATE TABLE IF NOT EXISTS playlist_track_cache (
+    provider      TEXT NOT NULL,
+    playlist_id   TEXT NOT NULL,
+    position      INTEGER NOT NULL,
+    track_id      TEXT NOT NULL,
+    isrc          TEXT NOT NULL,
+    occurrence_id TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    artist        TEXT NOT NULL,
+    album         TEXT,
+    duration_ms   INTEGER,
+    image         TEXT NOT NULL,
+    added_at      TEXT NOT NULL,
+    external_url  TEXT NOT NULL,
+    PRIMARY KEY (provider, playlist_id, position)
+)
+""",
+    """
+CREATE INDEX IF NOT EXISTS idx_playlist_track_cache_track
+ON playlist_track_cache (provider, track_id)
+""",
 ]
 
 UPSERT = """
@@ -157,6 +202,17 @@ def connect(path):
         conn.execute("DROP TABLE playlist_state")
     for schema in SCHEMAS:
         conn.execute(schema)
+    cache_cols = [
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(playlist_track_cache)"
+        ).fetchall()
+    ]
+    if cache_cols and "isrc" not in cache_cols:
+        conn.execute(
+            "ALTER TABLE playlist_track_cache "
+            "ADD COLUMN isrc TEXT NOT NULL DEFAULT ''"
+        )
     # Existing non-empty baselines predate playlist_state_meta. Mark them as
     # initialized in place; providers with no rows remain correctly classified
     # as bootstrap peers on their next N-way pass.
@@ -265,6 +321,60 @@ def get_identities(conn, source, track_ids):
     return _in_chunks(
         conn, "SELECT track_id, canonical_id FROM track_identity WHERE source = ? "
               "AND track_id IN ({marks})", [source], track_ids)
+
+
+def get_identity_crosswalk(conn, source, target, source_track_ids):
+    """{source_track_id: target_track_id} joined through a proven hard identity.
+
+    This deliberately reads the current identity table, including tracks last
+    seen in a playlist that has since been deleted. That history is the fastest
+    and most precise way to rebuild a replacement without catalog searches.
+    When one recording has several target catalog ids, prefer the most recently
+    proven one deterministically.
+    """
+    out = {}
+    ids = [track_id for track_id in source_track_ids if track_id]
+    for i in range(0, len(ids), 500):
+        chunk = ids[i : i + 500]
+        marks = ",".join("?" * len(chunk))
+        rows = conn.execute(
+            f"SELECT src.track_id, dst.track_id "
+            f"FROM track_identity AS src "
+            f"JOIN track_identity AS dst ON dst.canonical_id = src.canonical_id "
+            f"WHERE src.source = ? AND dst.source = ? "
+            f"AND src.canonical_id LIKE 'i:%' AND src.track_id IN ({marks}) "
+            f"ORDER BY dst.updated DESC, dst.track_id",
+            [source, target, *chunk],
+        )
+        for source_id, target_id in rows:
+            out.setdefault(source_id, target_id)
+    return out
+
+
+def get_song_history(conn, source):
+    """Provider tracks seen before, newest evidence first, in target-like shape."""
+    rows = conn.execute(
+        "SELECT id, isrc, name, artist, album, duration_ms, meta, last_seen "
+        "FROM songs WHERE source = ? ORDER BY last_seen DESC, id",
+        (source,),
+    )
+    out = []
+    for track_id, isrc, name, artist, album, duration_ms, meta, last_seen in rows:
+        try:
+            track = json.loads(meta) if meta else {}
+        except (TypeError, json.JSONDecodeError):
+            track = {}
+        track.setdefault("id", track_id)
+        track.setdefault("isrc", isrc)
+        track.setdefault("name", name or "")
+        track.setdefault("artist", artist or "")
+        track.setdefault("artists", [artist] if artist else [])
+        track.setdefault("album", album)
+        track.setdefault("duration_ms", duration_ms)
+        track["_archive_id"] = track_id
+        track["_archive_last_seen"] = last_seen
+        out.append(track)
+    return out
 
 
 def get_identity_history(conn, source, track_ids):
@@ -457,4 +567,197 @@ def clear_playlist_state(conn, playlist):
     conn.execute("DELETE FROM playlist_state WHERE playlist = ?", (playlist,))
     conn.execute("DELETE FROM playlist_state_meta WHERE playlist = ?", (playlist,))
     conn.execute("DELETE FROM playlist_pending_removal WHERE playlist = ?", (playlist,))
+    conn.commit()
+
+
+def get_playlist_detail_cache(conn, provider, playlist_id):
+    """Return the last complete normalized playlist read, or ``None``.
+
+    Tracks are always returned in provider playlist order. A header without its
+    declared number of rows is treated as an interrupted/corrupt cache miss.
+    """
+    row = conn.execute(
+        "SELECT name, description, count, image, owned, editable, external_url "
+        "FROM playlist_cache WHERE provider = ? AND playlist_id = ?",
+        (str(provider), str(playlist_id)),
+    ).fetchone()
+    if row is None:
+        return None
+    tracks = conn.execute(
+        "SELECT position, track_id, isrc, occurrence_id, name, artist, album, "
+        "duration_ms, image, added_at, external_url "
+        "FROM playlist_track_cache WHERE provider = ? AND playlist_id = ? "
+        "ORDER BY position",
+        (str(provider), str(playlist_id)),
+    ).fetchall()
+    if len(tracks) != int(row[2]):
+        return None
+    return {
+        "provider": str(provider),
+        "id": str(playlist_id),
+        "name": row[0],
+        "description": row[1],
+        "count": int(row[2]),
+        "image": row[3],
+        "owned": bool(row[4]),
+        "editable": bool(row[5]),
+        "external_url": row[6],
+        "tracks": [
+            {
+                "position": int(track[0]),
+                "id": track[1],
+                "isrc": track[2],
+                "occurrence_id": track[3],
+                "name": track[4],
+                "artist": track[5],
+                "album": track[6],
+                "duration_ms": track[7],
+                "image": track[8],
+                "added_at": track[9],
+                "external_url": track[10],
+            }
+            for track in tracks
+        ],
+    }
+
+
+def set_playlist_detail_cache(conn, detail):
+    """Atomically replace one playlist ledger and archive its provider songs."""
+    provider = str(detail["provider"])
+    playlist_id = str(detail["id"])
+    tracks = list(detail.get("tracks") or [])
+    now = _now()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO playlist_cache VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                provider,
+                playlist_id,
+                str(detail.get("name") or ""),
+                str(detail.get("description") or ""),
+                len(tracks),
+                str(detail.get("image") or ""),
+                int(bool(detail.get("owned", True))),
+                int(bool(detail.get("editable", False))),
+                str(detail.get("external_url") or ""),
+                now,
+            ),
+        )
+        conn.execute(
+            "DELETE FROM playlist_track_cache WHERE provider = ? AND playlist_id = ?",
+            (provider, playlist_id),
+        )
+        conn.executemany(
+            "INSERT INTO playlist_track_cache "
+            "(provider, playlist_id, position, track_id, isrc, occurrence_id, "
+            "name, artist, album, duration_ms, image, added_at, external_url) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    provider,
+                    playlist_id,
+                    int(track["position"]),
+                    str(track["id"]),
+                    str(track.get("isrc") or ""),
+                    str(track.get("occurrence_id") or ""),
+                    str(track.get("name") or "Unknown track"),
+                    str(track.get("artist") or ""),
+                    track.get("album"),
+                    track.get("duration_ms"),
+                    str(track.get("image") or ""),
+                    str(track.get("added_at") or ""),
+                    str(track.get("external_url") or ""),
+                )
+                for track in tracks
+            ],
+        )
+        # A playlist read is also authoritative evidence that these provider
+        # songs exist. Feed the same rows into the durable all-provider archive
+        # instead of maintaining a disconnected UI-only cache.
+        conn.executemany(
+            UPSERT,
+            [
+                (
+                    provider,
+                    str(track["id"]),
+                    track.get("isrc"),
+                    str(track.get("name") or "Unknown track"),
+                    str(track.get("artist") or ""),
+                    track.get("album"),
+                    track.get("duration_ms"),
+                    json.dumps(track, ensure_ascii=False),
+                    now,
+                    now,
+                )
+                for track in tracks
+            ],
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def invalidate_playlist_detail_cache(conn, provider, playlist_id):
+    """Drop one cached ledger before/after a write whose result may be partial."""
+    conn.execute(
+        "DELETE FROM playlist_track_cache WHERE provider = ? AND playlist_id = ?",
+        (str(provider), str(playlist_id)),
+    )
+    conn.execute(
+        "DELETE FROM playlist_cache WHERE provider = ? AND playlist_id = ?",
+        (str(provider), str(playlist_id)),
+    )
+    conn.commit()
+
+
+def prune_playlist_detail_cache(conn, provider, playlist_ids):
+    """Discard cached ledgers for provider playlists that no longer exist."""
+    provider = str(provider)
+    keep = {str(playlist_id) for playlist_id in playlist_ids if playlist_id is not None}
+    cached = {
+        row[0]
+        for row in conn.execute(
+            "SELECT playlist_id FROM playlist_cache WHERE provider = ?", (provider,)
+        ).fetchall()
+    }
+    stale = cached - keep
+    if not stale:
+        return
+    conn.executemany(
+        "DELETE FROM playlist_track_cache WHERE provider = ? AND playlist_id = ?",
+        [(provider, playlist_id) for playlist_id in stale],
+    )
+    conn.executemany(
+        "DELETE FROM playlist_cache WHERE provider = ? AND playlist_id = ?",
+        [(provider, playlist_id) for playlist_id in stale],
+    )
+    conn.commit()
+
+
+def reset_playlist_peer_state(conn, playlist, source):
+    """Forget one provider's state after its physical playlist is recreated.
+
+    Playlist state is keyed by logical pairing so it survives ordinary provider
+    metadata changes. A newly created playlist is the exception: carrying the
+    deleted playlist's baseline forward makes an empty replacement look like a
+    collapsed API read. Clear both N-way membership and the one-way snapshot so
+    the replacement bootstraps from the current source instead of being skipped.
+    """
+    conn.execute(
+        "DELETE FROM playlist_state WHERE playlist = ? AND source = ?",
+        (playlist, source),
+    )
+    conn.execute(
+        "DELETE FROM playlist_state_meta WHERE playlist = ? AND source = ?",
+        (playlist, source),
+    )
+    conn.execute(
+        "DELETE FROM playlist_pending_removal WHERE playlist = ? AND source = ?",
+        (playlist, source),
+    )
+    conn.execute(
+        "DELETE FROM sync_state WHERE pair = ? AND target = ?",
+        (playlist, source),
+    )
     conn.commit()

--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -74,9 +74,10 @@ CREATE TABLE IF NOT EXISTS playlist_state (
     # an empty canonical set remains representable.
     """
 CREATE TABLE IF NOT EXISTS playlist_state_meta (
-    playlist       TEXT NOT NULL,
-    source         TEXT NOT NULL,
-    initialized_at TEXT NOT NULL,
+    playlist            TEXT NOT NULL,
+    source              TEXT NOT NULL,
+    initialized_at      TEXT NOT NULL,
+    physical_playlist_id TEXT,
     PRIMARY KEY (playlist, source)
 )
 """,
@@ -212,6 +213,17 @@ def connect(path):
         conn.execute(
             "ALTER TABLE playlist_track_cache "
             "ADD COLUMN isrc TEXT NOT NULL DEFAULT ''"
+        )
+    state_meta_cols = [
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(playlist_state_meta)"
+        ).fetchall()
+    ]
+    if state_meta_cols and "physical_playlist_id" not in state_meta_cols:
+        conn.execute(
+            "ALTER TABLE playlist_state_meta "
+            "ADD COLUMN physical_playlist_id TEXT"
         )
     # Existing non-empty baselines predate playlist_state_meta. Mark them as
     # initialized in place; providers with no rows remain correctly classified
@@ -459,6 +471,16 @@ def has_playlist_state(conn, playlist, source):
     return row is not None
 
 
+def get_playlist_physical_id(conn, playlist, source):
+    """Provider playlist id associated with this baseline, if recorded."""
+    row = conn.execute(
+        "SELECT physical_playlist_id FROM playlist_state_meta "
+        "WHERE playlist = ? AND source = ?",
+        (playlist, source),
+    ).fetchone()
+    return row[0] if row and row[0] else None
+
+
 def get_pending_removals(conn, playlist, source):
     """Canonical ids absent on one prior trusted N-way pass for this source."""
     rows = conn.execute(
@@ -469,7 +491,8 @@ def get_pending_removals(conn, playlist, source):
     return {row[0] for row in rows.fetchall()}
 
 
-def commit_reconcile_membership(conn, playlist, state_updates, pending_updates):
+def commit_reconcile_membership(conn, playlist, state_updates, pending_updates,
+                                physical_playlist_ids=None):
     """Atomically replace selected baselines and pending removal observations.
 
     A source absent from either mapping is untouched. An empty set explicitly
@@ -478,11 +501,17 @@ def commit_reconcile_membership(conn, playlist, state_updates, pending_updates):
     when it did not, and a failed pass never confirms a deletion.
     """
     now = _now()
+    physical_playlist_ids = physical_playlist_ids or {}
     try:
         for source, canonical_ids in state_updates.items():
             conn.execute(
-                "INSERT OR REPLACE INTO playlist_state_meta VALUES (?, ?, ?)",
-                (playlist, source, now),
+                "INSERT INTO playlist_state_meta "
+                "(playlist, source, initialized_at, physical_playlist_id) VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(playlist, source) DO UPDATE SET "
+                "initialized_at = excluded.initialized_at, "
+                "physical_playlist_id = COALESCE(excluded.physical_playlist_id, "
+                "playlist_state_meta.physical_playlist_id)",
+                (playlist, source, now, physical_playlist_ids.get(source)),
             )
             conn.execute(
                 "DELETE FROM playlist_state WHERE playlist = ? AND source = ?",
@@ -529,7 +558,8 @@ def set_reconcile_identities(conn, playlist, repaired_states, learned_identities
     try:
         for source, canonical_ids in repaired_states.items():
             conn.execute(
-                "INSERT OR REPLACE INTO playlist_state_meta VALUES (?, ?, ?)",
+                "INSERT INTO playlist_state_meta (playlist, source, initialized_at) VALUES (?, ?, ?) "
+                "ON CONFLICT(playlist, source) DO UPDATE SET initialized_at = excluded.initialized_at",
                 (playlist, source, now),
             )
             conn.execute(

--- a/songmirror/engine/config.py
+++ b/songmirror/engine/config.py
@@ -17,7 +17,7 @@ DEFAULT_CACHE_FILE = "apple_resolve_cache.json"
 DEFAULT_SONG_CACHE_FILE = "song_cache.db"
 DEFAULT_STOREFRONT = "us"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:8888/callback"
-DEFAULT_SYNC_MODE = "oneway"                          # oneway (source->targets) | nway (bidirectional)
+DEFAULT_SYNC_MODE = "oneway"                          # oneway | group | nway
 DEFAULT_PROVIDERS = "spotify,tidal,qobuz,deezer,amazon,apple,ytmusic"  # participating providers
 DEFAULT_SYNC_SOURCE = "spotify"                       # one-way source of truth (any connected provider)
 DEFAULT_SPOTIFY_CACHE_FILE = "spotify_resolve_cache.json"
@@ -82,6 +82,7 @@ class Options:
     sync_mode: str = DEFAULT_SYNC_MODE
     providers: str = DEFAULT_PROVIDERS
     sync_source: str = DEFAULT_SYNC_SOURCE
+    authorities: str = ""
     spotify_cache_file: str = DEFAULT_SPOTIFY_CACHE_FILE
     apply_large_removals: bool = False
 
@@ -116,13 +117,17 @@ def parse_args(argv=None):
                    help=f"ISRC/search resolution cache (default: {DEFAULT_CACHE_FILE}).")
     p.add_argument("--song-cache-file", default=os.getenv("SONG_CACHE_FILE", DEFAULT_SONG_CACHE_FILE),
                    help=f"Ever-growing SQLite song archive (default: {DEFAULT_SONG_CACHE_FILE}).")
-    p.add_argument("--sync-mode", default=os.getenv("SYNC_MODE", DEFAULT_SYNC_MODE), choices=("oneway", "nway"),
-                   help=f"oneway = Spotify->targets (default); nway = bidirectional across all providers.")
+    p.add_argument("--sync-mode", default=os.getenv("SYNC_MODE", DEFAULT_SYNC_MODE),
+                   choices=("oneway", "group", "nway"),
+                   help="oneway = one source; group = selected authorities feed mirrors; "
+                        "nway = every provider is bidirectional.")
     p.add_argument("--providers", default=os.getenv("PROVIDERS", DEFAULT_PROVIDERS),
                    help=f"Providers participating in sync, comma-separated (default: {DEFAULT_PROVIDERS}).")
     p.add_argument("--sync-source", default=os.getenv("SYNC_SOURCE", DEFAULT_SYNC_SOURCE),
                    choices=("spotify", "tidal", "qobuz", "deezer", "amazon", "apple", "ytmusic"),
-                   help=f"One-way source of truth (default: {DEFAULT_SYNC_SOURCE}).")
+                   help=f"One-way source or group order authority (default: {DEFAULT_SYNC_SOURCE}).")
+    p.add_argument("--authorities", default=os.getenv("SYNC_AUTHORITIES", ""),
+                   help="Authoritative-group providers, comma-separated (group mode only).")
     p.add_argument("--spotify-cache-file", default=os.getenv("SPOTIFY_CACHE_FILE", DEFAULT_SPOTIFY_CACHE_FILE),
                    help=f"Spotify resolution cache for N-way writes (default: {DEFAULT_SPOTIFY_CACHE_FILE}).")
     a = p.parse_args(argv)
@@ -131,11 +136,21 @@ def parse_args(argv=None):
         p.error("--max-removals must be >= 0")
     if a.max_adds < 1:
         p.error("--max-adds must be >= 1")
+    if a.sync_mode == "group":
+        providers = {part.strip() for part in a.providers.split(",") if part.strip()}
+        authorities = {part.strip() for part in a.authorities.split(",") if part.strip()}
+        if len(authorities) < 2:
+            p.error("--sync-mode group needs at least two --authorities")
+        if a.sync_source not in authorities:
+            p.error("--sync-source must be one of --authorities in group mode")
+        if not authorities <= providers:
+            p.error("every --authorities entry must also appear in --providers")
     return Options(
         execute=a.execute, loop=a.loop, interval_s=parse_interval(a.interval), playlists=a.playlists,
         max_removals=a.max_removals, max_adds=a.max_adds, download_dir=a.download_dir,
         storefront=a.storefront, cache_file=a.cache_file, song_cache_file=a.song_cache_file,
         refresh_local=a.refresh_local, sync_mode=a.sync_mode, providers=a.providers,
-        sync_source=a.sync_source, spotify_cache_file=a.spotify_cache_file,
+        sync_source=a.sync_source, authorities=a.authorities,
+        spotify_cache_file=a.spotify_cache_file,
         apply_large_removals=a.apply_large_removals,
     )

--- a/songmirror/engine/matching.py
+++ b/songmirror/engine/matching.py
@@ -31,6 +31,19 @@ FROM_RELEASE_RE = re.compile(
     r'\s*(?:[-–—]\s*from|[\(\[]\s*from)\s+["“][^"”]+["”]\s*[\)\]]?\s*$',
     re.IGNORECASE,
 )
+CREATIVE_VERSION_PATTERNS = (
+    ("live", re.compile(r"\blive\b", re.IGNORECASE)),
+    ("acoustic", re.compile(r"\b(?:acoustic|unplugged)\b", re.IGNORECASE)),
+    ("remix", re.compile(r"\b(?:remix|rework|extended mix|radio edit)\b", re.IGNORECASE)),
+    ("instrumental", re.compile(r"\binstrumental\b", re.IGNORECASE)),
+    ("karaoke", re.compile(r"\bkaraoke\b", re.IGNORECASE)),
+    ("piano", re.compile(r"\bpiano\b", re.IGNORECASE)),
+    ("demo", re.compile(r"\bdemo\b", re.IGNORECASE)),
+    ("session", re.compile(r"\bsession\b", re.IGNORECASE)),
+    ("alternate-speed", re.compile(r"\b(?:sped up|slowed(?: down)?|nightcore)\b", re.IGNORECASE)),
+    ("mix-format", re.compile(r"\b(?:mono|stereo)\b", re.IGNORECASE)),
+    ("cover", re.compile(r"\bcover\b", re.IGNORECASE)),
+)
 
 
 def _added_at_epoch(value):
@@ -150,6 +163,26 @@ def catalog_name(name):
     return loose_name(cleaned)
 
 
+def creative_version_markers(name):
+    """Recording-changing title qualifiers that must agree during fuzzy search.
+
+    Search APIs regularly rank a live/acoustic/remix release above the ordinary
+    studio track. Similar title/artist text (and occasionally similar duration)
+    is not enough evidence to substitute one for the other. Generic "version"
+    is used only when no more specific qualifier explains it, so "Piano
+    Version" and "Piano" still describe the same creative variant.
+    """
+    normalized = normalize_text(name)
+    markers = {
+        marker
+        for marker, pattern in CREATIVE_VERSION_PATTERNS
+        if pattern.search(normalized)
+    }
+    if not markers and re.search(r"\bversion\b", normalized):
+        markers.add("alternate-version")
+    return markers
+
+
 def romanized(text):
     """ASCII romanization for cross-script matching (Камин->kamin, ত্রি->tri).
     Cyrillic / Bengali / Greek / Arabic romanize reliably; CJK yields a Chinese
@@ -196,6 +229,8 @@ def fuzzy_in(key, keys, threshold=FUZZY_THRESHOLD):
 def score_candidate(name, artists, duration_ms, cand_name, cand_artist, cand_duration_ms):
     """(score in 0..1, acceptable) for a search-result candidate vs the wanted
     track — the fuzzy fallback when no ISRC/link resolves it."""
+    if creative_version_markers(name) != creative_version_markers(cand_name):
+        return 0.0, False
     if isinstance(artists, str):
         artists = [artists]
     q_names, c_names = _name_variants(name), _name_variants(cand_name)
@@ -276,12 +311,15 @@ def compute_diff(sp_tracks, target_tracks, expected_by_sp, target_id_of, thresho
 
     expected_all = set()
     sp_keys = set()
+    sp_keys_by_version = {}
     to_add = []
     for tr in sp_tracks:
         expected = expected_by_sp.get(tr.get("id")) or set()
         expected_all |= expected
         keys = spotify_track_keys(tr)
         sp_keys |= keys
+        version = frozenset(creative_version_markers(tr.get("name")))
+        sp_keys_by_version.setdefault(version, set()).update(keys)
         if expected & target_ids:
             continue
         if keys & target_keys:
@@ -295,7 +333,10 @@ def compute_diff(sp_tracks, target_tracks, expected_by_sp, target_id_of, thresho
         if tid and tid in expected_all:
             continue
         key = track_key(t["name"], t["artist"])
-        if key in sp_keys or fuzzy_in(key, sp_keys, threshold):
+        compatible_keys = sp_keys_by_version.get(
+            frozenset(creative_version_markers(t.get("name"))), set()
+        )
+        if key in sp_keys or fuzzy_in(key, compatible_keys, threshold):
             continue
         to_remove.append(t)
     return to_add, to_remove
@@ -307,12 +348,19 @@ def protect_removals(to_remove, not_found_tracks, threshold=0.8):
     drop the song with no replacement. Deliberately loose threshold: wrongly
     holding leaves an extra track; wrongly deleting loses music."""
     nf_keys = set()
+    nf_keys_by_version = {}
     for track in not_found_tracks:
-        nf_keys |= spotify_track_keys(track)
+        keys = spotify_track_keys(track)
+        nf_keys |= keys
+        version = frozenset(creative_version_markers(track.get("name")))
+        nf_keys_by_version.setdefault(version, set()).update(keys)
     safe, held = [], []
     for track in to_remove:
         key = track_key(track["name"], track["artist"])
-        if key in nf_keys or fuzzy_in(key, nf_keys, threshold):
+        compatible_keys = nf_keys_by_version.get(
+            frozenset(creative_version_markers(track.get("name"))), set()
+        )
+        if key in nf_keys or fuzzy_in(key, compatible_keys, threshold):
             held.append(track)
         else:
             safe.append(track)

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -16,7 +16,7 @@ from . import archive, spotify, spotify_cookie
 from .config import spotify_write_backend
 from .logs import fmt_counts, fmt_secs, log, log_note, log_section, log_summary, log_warn, paint
 from .targets import TargetAuthError, build_one, build_peers, build_targets, mirror_pair, reconcile
-from .targets.base import _normalize
+from .targets.base import _normalize, reconcile_state_key
 
 
 def _load_json(path):
@@ -214,14 +214,14 @@ def run_pass(opts, should_continue=None):
     # saves win; the headless CLI falls back to a plain .env. Either way this
     # picks up re-captured tokens without a restart.
     load_dotenv(os.getenv("SONGMIRROR_ENV_FILE") or ".env", override=True)
-    # Writable (modify scopes) only for an actual N-way execute — so dry-runs
-    # preview without forcing the one-time re-auth a scope change triggers.
-    source_provider = opts.sync_source if opts.sync_mode == "oneway" else "spotify"
+    # Group mode's order authority also supplies playlist names and ordering.
+    # It remains writable because additions from another authority flow back.
+    source_provider = opts.sync_source if opts.sync_mode in {"oneway", "group"} else "spotify"
     wanted_providers = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
     spotify_requested = not wanted_providers or "spotify" in wanted_providers
-    # Spotify needs a writable client whenever it's a write destination: any N-way
-    # execute, or a one-way execute where another provider is the source and
-    # Spotify is one of the (writable) targets.
+    # Spotify needs a writable client whenever it's a write destination: any
+    # N-way/group execute, or a one-way execute where another provider is the
+    # source and Spotify is one of the targets.
     spotify_is_target = (opts.sync_mode == "oneway" and source_provider != "spotify"
                          and spotify_requested)
     sp = None
@@ -231,14 +231,15 @@ def run_pass(opts, should_continue=None):
             log_note("Spotify is using its signed-in web session (no developer API)", tag="spotify")
         else:
             try:
-                sp = spotify.client(writable=opts.execute and (opts.sync_mode == "nway" or spotify_is_target))
+                sp = spotify.client(writable=opts.execute and (
+                    opts.sync_mode in {"nway", "group"} or spotify_is_target))
             except RuntimeError as exc:
                 if source_provider == "spotify":
                     raise
                 log_note(f"Spotify skipped: {exc}", tag="spotify")
 
-    # The library whose playlists drive this pass: always Spotify for N-way (the
-    # symmetric reconcile's name master), the chosen source-of-truth for one-way.
+    # The library whose playlists drive this pass: Spotify for N-way; the chosen
+    # source/order authority for one-way and authoritative-group modes.
     source = build_one(source_provider, opts, sp)
     if source is None:
         log_warn(f"sync source '{source_provider}' is not connected", indent="  ")
@@ -250,7 +251,11 @@ def run_pass(opts, should_continue=None):
 
     mode = paint("EXECUTE", "green", "bold") if opts.execute else paint("DRY RUN", "yellow", "bold")
     log(paint("═══ Omni playlist mirror ═══", "bold", "cyan"))
-    log(f"  mode: {mode}" + (paint("   ⇄ N-WAY", "magenta", "bold") if opts.sync_mode == "nway" else ""))
+    mode_label = (
+        paint("   ⇄ N-WAY", "magenta", "bold") if opts.sync_mode == "nway" else
+        paint("   ⇆ AUTHORITY GROUP", "magenta", "bold") if opts.sync_mode == "group" else ""
+    )
+    log(f"  mode: {mode}{mode_label}")
     log(f"  source: {paint(source.name, 'cyan')}")
     log(f"  playlists: {paint(str(len(selected)), 'bold')} selected"
         + (paint(f" ({', '.join(source.playlist_name(p) for p in selected)})", "grey") if selected else ""))
@@ -268,15 +273,19 @@ def run_pass(opts, should_continue=None):
         downloads.refresh(sp, selected, opts.download_dir)
         return _summary(opts, [], pass_started)
 
-    if opts.sync_mode == "nway":
+    if opts.sync_mode in {"nway", "group"}:
         songs = archive.connect(opts.song_cache_file)
         try:
-            per_target = _run_nway(opts, sp, selected, songs, ctrl)
+            if opts.sync_mode == "group":
+                per_target = _run_authoritative_group(opts, sp, selected, songs, ctrl)
+            else:
+                per_target = _run_nway(opts, sp, selected, songs, ctrl)
         finally:
             songs.close()
         c = ctrl()
         if c == "run":
-            _post_sync(opts, sp, selected, should_continue=ctrl)
+            _post_sync(opts, sp, selected, source_is_spotify=source.source == "spotify",
+                       should_continue=ctrl)
         return _summary(opts, per_target, pass_started, interrupted=(None if c == "run" else c))
 
     targets = build_targets(opts, sp)
@@ -416,13 +425,55 @@ def _post_sync(opts, sp, selected, source_is_spotify=True, should_continue=None)
 
 
 def _run_nway(opts, sp, selected, songs, should_continue=None):
-    """Bidirectional reconcile: each selected playlist across all peer providers,
-    sequentially (each reconcile reads then writes every peer). A change on any
-    provider propagates to the others via the stored canonical snapshot."""
+    """Reconcile with every selected provider contributing membership."""
+    return _run_peer_reconcile(
+        opts, sp, selected, songs, should_continue,
+        label="N-way", authority_sources=None,
+    )
+
+
+def _run_authoritative_group(opts, sp, selected, songs, should_continue=None):
+    """Reconcile selected authorities into each other and destination mirrors."""
+    authorities = {part.strip() for part in (opts.authorities or "").split(",") if part.strip()}
+    return _run_peer_reconcile(
+        opts, sp, selected, songs, should_continue,
+        label="Authoritative group", authority_sources=authorities,
+    )
+
+
+def _run_peer_reconcile(opts, sp, selected, songs, should_continue=None, *,
+                        label, authority_sources):
+    """Shared ordered playlist loop for N-way and authoritative-group syncs."""
     peers = build_peers(opts, sp, songs=songs)
+    order_source = opts.sync_source if authority_sources is not None else "spotify"
+    peers.sort(key=lambda peer: (peer.source != order_source))
+    peer_sources = {peer.source for peer in peers}
+    if authority_sources is not None:
+        error = None
+        if len(authority_sources) < 2:
+            error = "an authoritative group needs at least two authorities"
+        elif order_source not in authority_sources:
+            error = "the order authority must belong to the authoritative group"
+        elif authority_sources - peer_sources:
+            missing = ", ".join(sorted(authority_sources - peer_sources))
+            error = f"authoritative providers are not connected: {missing}"
+        if error:
+            log_warn(error, indent="  ")
+            return [_summary_entry(label, {
+                "failed": 1,
+                "failures": [{"playlist": "Configuration", "error": error}],
+            })]
     if len(peers) < 2:
-        log_warn("N-way sync needs at least two configured music providers", indent="  ")
+        log_warn(f"{label} sync needs at least two configured music providers", indent="  ")
         return []
+    order_peer = next((peer for peer in peers if peer.source == order_source), None)
+    if order_peer is None:
+        error = f"order provider '{order_source}' is not connected"
+        log_warn(error, indent="  ")
+        return [_summary_entry(label, {
+            "failed": 1,
+            "failures": [{"playlist": "Configuration", "error": error}],
+        })]
     log(f"  peers: {paint(', '.join(p.name for p in peers), 'cyan')}"
         + (paint(f"   local downloads -> {opts.download_dir}", "grey") if opts.download_dir and opts.execute else ""))
 
@@ -437,12 +488,16 @@ def _run_nway(opts, sp, selected, songs, should_continue=None):
     change_diagnostics = []
     failures = []
     try:
-        for sp_playlist in selected:
+        for order_playlist in selected:
             if should_continue and should_continue() != "run":
                 break  # Stop/Pause requested — leave the rest for a re-run
-            name = sp_playlist["name"]
+            name = (order_peer.playlist_name(order_playlist)
+                    if hasattr(order_peer, "playlist_name") else order_playlist["name"])
             key = name.strip().casefold()
+            state_key = reconcile_state_key(
+                name, authority_sources=authority_sources)
             playlists = {}
+            authority_failure_recorded = False
             for p in peers:
                 pl = dirs[p.source].get(key)
                 if not pl:
@@ -450,32 +505,48 @@ def _run_nway(opts, sp, selected, songs, should_continue=None):
                         log_note(f"{name}: no {p.name} playlist yet - would create on --execute", tag=p.tag)
                         continue
                     try:
-                        pl = p.create(sp_playlist)
+                        pl = p.create(order_playlist)
                         # This physical playlist did not produce the provider's
                         # stored logical baseline. Reset that side immediately;
                         # if reconcile later fails, the next pass must still see
                         # a bootstrap peer rather than a collapsed old playlist.
-                        archive.reset_playlist_peer_state(songs, key, p.source)
+                        archive.reset_playlist_peer_state(songs, state_key, p.source)
                         log_note(f"created {p.name} playlist '{name}'", tag=p.tag)
                     except TargetAuthError:
                         raise
                     except Exception as e:
                         _collect_failure(total, failures, name, e)
+                        if authority_sources is not None and p.source in authority_sources:
+                            authority_failure_recorded = True
                         log_warn(f"create {p.name} '{name}' failed: {e!r}", tag=p.tag)
                         continue
                 if not p.is_editable(pl):
                     log_warn(f"{name}: {p.name} playlist not editable - skipped", tag=p.tag)
+                    if authority_sources is not None and p.source in authority_sources:
+                        error = RuntimeError(f"{p.name} authoritative playlist is not editable")
+                        _collect_failure(total, failures, name, error)
+                        authority_failure_recorded = True
                     continue
                 playlists[p.source] = pl
 
             active = [p for p in peers if p.source in playlists]
+            if authority_sources is not None and not authority_sources <= set(playlists):
+                missing = ", ".join(sorted(authority_sources - set(playlists)))
+                log_warn(f"{name}: authoritative playlist unavailable on {missing} - skipped", tag="sync")
+                if opts.execute and not authority_failure_recorded:
+                    _collect_failure(
+                        total, failures, name,
+                        RuntimeError(f"authoritative playlist unavailable on {missing}"),
+                    )
+                continue
             if len(active) < 2:
                 log_note(f"{name}: fewer than 2 providers have this playlist - skipped", tag="sync")
                 continue
             try:
                 stats = reconcile(active, name, playlists, caches, songs,
                                   execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
-                                  drain_removals=opts.apply_large_removals, should_continue=should_continue)
+                                  drain_removals=opts.apply_large_removals, should_continue=should_continue,
+                                  authority_sources=authority_sources)
                 for k in total:
                     total[k] += stats.get(k, 0)
                 _collect_held(held_detail, stats.get("held_removals", []))
@@ -494,4 +565,4 @@ def _run_nway(opts, sp, selected, songs, should_continue=None):
     # Drain any legacy explicit-ISRC caller residue. Cookie-only reconciliation
     # never enters that developer-catalog path.
     total["isrc_fallback"] = spotify_cookie.take_singles_used()
-    return [_summary_entry("N-way", total)]
+    return [_summary_entry(label, total)]

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -126,7 +126,8 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
     path (empty `links` => byte-for-byte unchanged when the source is Spotify)."""
     src_key = source.source
     agg = {"name": target.name, "pairs": 0, "added": 0, "removed": 0, "missing": 0,
-           "held": 0, "removals_skipped": 0, "skipped": 0, "created": 0, "failed": 0,
+           "held": 0, "deferred": 0, "removals_skipped": 0,
+           "skipped": 0, "created": 0, "failed": 0,
            "held_removals": [], "failures": []}
     cache = load_cache(target.cache_file)
     try:
@@ -154,6 +155,12 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                     continue
                 try:
                     tgt = target.create(sp_playlist)
+                    archive.reset_playlist_peer_state(songs, state_key, target.source)
+                    created_id = target.playlist_id(tgt)
+                    if created_id is not None:
+                        archive.invalidate_playlist_detail_cache(
+                            songs, target.source, created_id
+                        )
                     agg["created"] += 1
                     log_note(f"created {target.name} playlist '{name}' (name + description copied)", tag=target.tag)
                 except Exception as e:
@@ -182,7 +189,7 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                     source_key=src_key, source_name=source.name, name=name,
                 )
                 agg["pairs"] += 1
-                for k in ("added", "removed", "missing", "held", "removals_skipped"):
+                for k in ("added", "removed", "missing", "held", "deferred", "removals_skipped"):
                     agg[k] += res[k]
                 _collect_held(agg["held_removals"], res.get("held_removals", []))
                 if res["clean"] and snapshot:
@@ -444,6 +451,11 @@ def _run_nway(opts, sp, selected, songs, should_continue=None):
                         continue
                     try:
                         pl = p.create(sp_playlist)
+                        # This physical playlist did not produce the provider's
+                        # stored logical baseline. Reset that side immediately;
+                        # if reconcile later fails, the next pass must still see
+                        # a bootstrap peer rather than a collapsed old playlist.
+                        archive.reset_playlist_peer_state(songs, key, p.source)
                         log_note(f"created {p.name} playlist '{name}'", tag=p.tag)
                     except TargetAuthError:
                         raise

--- a/songmirror/engine/spotify.py
+++ b/songmirror/engine/spotify.py
@@ -275,14 +275,21 @@ def _playlist_tracks_api(sp, playlist_id):
             if not track:
                 continue
             artists = [a.get("name", "") for a in track.get("artists", []) if a.get("name")]
+            album = track.get("album") or {}
+            images = [image for image in album.get("images") or [] if image and image.get("url")]
+            image = min(
+                images,
+                key=lambda candidate: abs(int(candidate.get("width") or 96) - 96),
+            )["url"] if images else ""
             tracks.append({
                 "id": track.get("id"),
                 "isrc": (track.get("external_ids") or {}).get("isrc"),
                 "name": track.get("name", ""),
                 "artists": artists or [""],
-                "album": (track.get("album") or {}).get("name"),
+                "album": album.get("name"),
                 "duration_ms": track.get("duration_ms"),
                 "added_at": item.get("added_at") or "",
+                "image": image,
             })
         page = results
         results = _retry(lambda: sp.next(page), "tracks page") if results.get("next") else None

--- a/songmirror/engine/spotify_cookie.py
+++ b/songmirror/engine/spotify_cookie.py
@@ -518,14 +518,22 @@ def playlist_tracks(playlist, require_isrc=False, known_isrc=None):
         if not uri.startswith("spotify:track:"):
             continue  # local file / episode / unavailable — excluded like the official read
         artists = [(a.get("profile") or {}).get("name", "") for a in ((t.get("artists") or {}).get("items") or [])]
+        album = t.get("albumOfTrack") or {}
+        sources = [source for source in ((album.get("coverArt") or {}).get("sources") or [])
+                   if source and source.get("url")]
+        image = min(
+            sources,
+            key=lambda candidate: abs(int(candidate.get("width") or 96) - 96),
+        )["url"] if sources else ""
         out.append({
             "id": uri.rsplit(":", 1)[-1],
             "isrc": None,
             "name": t.get("name", "") or "",
             "artists": [a for a in artists if a] or [""],
-            "album": (t.get("albumOfTrack") or {}).get("name"),
+            "album": album.get("name"),
             "duration_ms": (t.get("trackDuration") or {}).get("totalMilliseconds"),
             "added_at": (it.get("addedAt") or {}).get("isoString") or "",
+            "image": image,
         })
     # Persisted ISRCs remain valuable in cookie-only mode, but a cache miss is
     # deliberately left blank for reconcile to infer from its ISRC-bearing peers.

--- a/songmirror/engine/spotify_web.py
+++ b/songmirror/engine/spotify_web.py
@@ -55,14 +55,22 @@ def playlist_tracks(playlist_id):
             continue  # local file / unavailable / ghost entry — excluded like the official read
         artists = [a.name for a in (getattr(t, "artists", ()) or ()) if getattr(a, "name", "")]
         added = getattr(pt, "added_at", None)
+        album = getattr(t, "album", None)
+        image = ""
+        for candidate in reversed(list(getattr(album, "images", ()) or ())):
+            url = candidate.get("url") if isinstance(candidate, dict) else getattr(candidate, "url", "")
+            if url:
+                image = url
+                break
         out.append({
             "id": tid,
             "isrc": None,  # the web payload omits ISRC; matching falls back to name/artist/duration
             "name": getattr(t, "name", "") or "",
             "artists": artists or [""],
-            "album": getattr(getattr(t, "album", None), "name", None),
+            "album": getattr(album, "name", None),
             "duration_ms": getattr(t, "duration_ms", None),
             # ISO-8601 string like the official API (the diff sorts oldest-first on it).
             "added_at": added.isoformat() if hasattr(added, "isoformat") else (added or ""),
+            "image": image,
         })
     return out

--- a/songmirror/engine/targets/__init__.py
+++ b/songmirror/engine/targets/__init__.py
@@ -11,7 +11,7 @@ caching, safety rails — is provider-agnostic and needs no change.
 
 from .apple import AppleMusicTarget
 from .amazon_music import AmazonMusicTarget
-from .base import MirrorTarget, TargetAuthError, mirror_pair, reconcile
+from .base import MirrorTarget, TargetAuthError, TargetTransientError, mirror_pair, reconcile
 from .deezer import DeezerTarget
 from .qobuz import QobuzTarget
 from .spotify_target import SpotifyTarget
@@ -19,7 +19,7 @@ from .tidal import TidalTarget
 from . import ytmusic
 
 __all__ = ["AppleMusicTarget", "AmazonMusicTarget", "DeezerTarget", "QobuzTarget",
-           "SpotifyTarget", "TidalTarget", "MirrorTarget", "TargetAuthError",
+           "SpotifyTarget", "TidalTarget", "MirrorTarget", "TargetAuthError", "TargetTransientError",
            "mirror_pair", "reconcile", "build_targets", "build_peers", "build_one", "is_peer"]
 
 

--- a/songmirror/engine/targets/amazon_music.py
+++ b/songmirror/engine/targets/amazon_music.py
@@ -69,6 +69,7 @@ query SongMirrorAmazonPlaylistTracks($id: String!, $cursor: String, $limit: Floa
           title
           isrc
           duration
+          images { url width height imageType aspectRatio }
           album { id title }
           contributingArtists { edges { role node { id name } } }
         }
@@ -88,6 +89,7 @@ query SongMirrorAmazonSearchTracks($query: String!) {
         title
         isrc
         duration
+        images { url width height imageType aspectRatio }
         album { id title }
         contributingArtists { edges { role node { id name } } }
       }
@@ -138,16 +140,24 @@ def _normalized_track(track, entry_id=None):
             if (edge.get("node") or {}).get("name")
         ]
     duration = track.get("duration")
+    album = track.get("album") or {}
+    images = track.get("images") or album.get("images") or []
+    usable_images = [item for item in images if isinstance(item, dict) and item.get("url")]
+    image = min(
+        usable_images,
+        key=lambda item: abs(int(item.get("width") or 160) - 160),
+    )["url"] if usable_images else ""
     return {
         "id": str(track.get("id")) if track.get("id") is not None else None,
         "relationship_id": entry_id,
         "name": track.get("title") or track.get("name") or "",
         "artist": ", ".join(artists),
         "artists": artists or [""],
-        "album": (track.get("album") or {}).get("title") or (track.get("album") or {}).get("name"),
+        "album": album.get("title") or album.get("name"),
         "duration_ms": int(duration * 1000) if isinstance(duration, (int, float)) else None,
         "isrc": track.get("isrc"),
         "added_at": "",
+        "image": image,
     }
 
 
@@ -155,6 +165,7 @@ class AmazonMusicTarget(MirrorTarget):
     name = "Amazon Music"
     tag = "amazon"
     source = "amazon"
+    stable_occurrence_ids = True
 
     def __init__(self):
         self.cache_file = os.getenv("AMAZON_MUSIC_CACHE_FILE", "amazon_music_resolve_cache.json")

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -10,13 +10,17 @@ import requests
 from ..config import AMP, REQUEST_TIMEOUT, polite_sleep, required_env
 from ..logs import log, log_warn
 from ..matching import normalize_text, romanized, score_candidate
-from .base import MirrorTarget, TargetAuthError
+from .base import MirrorTarget, TargetAuthError, TargetTransientError
 from .provider_utils import source_playlist_details
 
 # playlist_id -> (lastModifiedDate, track_count): in-process cache so the browse
 # doesn't re-issue a meta.total call for an unchanged Apple playlist (library
 # playlists carry no trackCount attribute, so each count is a live lookup).
 _COUNT_CACHE = {}
+_PUBLIC_SEARCH_URL = "https://itunes.apple.com/search"
+# Apple's documented public Search API is limited to roughly 20 calls/minute.
+# It is only a fallback after amp-api throttles, so pace it independently.
+_PUBLIC_SEARCH_INTERVAL_S = 3.1
 
 
 def _chunks(seq, size):
@@ -52,6 +56,11 @@ class AppleMusicTarget(MirrorTarget):
         self._session = requests.Session()
         self._session.headers.update(_headers())
         self._search_throttled = False  # set once catalog search rate-limits; defer the rest of the pass
+        self._write_not_before = 0.0
+        self._public_search_not_before = 0.0
+        self._validated_catalog_ids = {}
+        self._resolved_catalog_context = {}
+        self._added_catalog_ids = {}
 
     # -- HTTP ------------------------------------------------------------------
     def _rebuild_session(self):
@@ -92,13 +101,21 @@ class AppleMusicTarget(MirrorTarget):
                 )
             if r.status_code == 404 and ok404:
                 return None
-            if r.status_code == 429 and attempt < 1:
-                # One short retry for a transient blip; a sustained catalog-search
-                # limit is handled by the resolver deferring the rest of the pass.
-                wait = float(r.headers.get("Retry-After") or 10) + random.uniform(1, 4)
-                log(f"  rate-limited by Apple; waiting {int(wait)}s", tag=self.tag)
-                time.sleep(wait)
-                continue
+            if r.status_code == 429:
+                # 429 proves the mutation did not run, so a retry is safe. Give
+                # one blip an inline chance; callers then decide whether to hold
+                # an ordered queue or retry a known-safe singleton mutation.
+                retry_after = float(r.headers.get("Retry-After") or 10)
+                if attempt < 1:
+                    wait = retry_after + random.uniform(1, 4)
+                    log(f"  rate-limited by Apple; waiting {int(wait)}s", tag=self.tag)
+                    time.sleep(wait)
+                    continue
+                path = url.split("/v1/")[-1]
+                raise TargetTransientError(
+                    f"Apple kept returning HTTP 429 for {path}",
+                    retry_after=retry_after,
+                )
             if r.status_code >= 500 and method == "GET" and attempt < attempts - 1:
                 if attempt == 2:
                     self._rebuild_session()
@@ -107,7 +124,7 @@ class AppleMusicTarget(MirrorTarget):
                 continue
             if r.status_code >= 500 and method == "GET":
                 path = url.split("/v1/")[-1]
-                raise RuntimeError(
+                raise TargetTransientError(
                     f"Apple Music kept returning HTTP {r.status_code} while reading {path} "
                     f"after {attempts} attempts; this read was abandoned and the next pass will retry it"
                 )
@@ -161,6 +178,8 @@ class AppleMusicTarget(MirrorTarget):
             for t in rows:
                 attrs = t.get("attributes", {})
                 pp = attrs.get("playParams", {})
+                artwork = attrs.get("artwork") or {}
+                image = str(artwork.get("url") or "").replace("{w}", "128").replace("{h}", "128")
                 tracks.append({
                     "relationship_id": t.get("id"),
                     "catalog_id": pp.get("catalogId") or pp.get("id"),
@@ -168,6 +187,8 @@ class AppleMusicTarget(MirrorTarget):
                     "artist": attrs.get("artistName", ""),
                     "album": attrs.get("albumName"),
                     "duration_ms": attrs.get("durationInMillis"),
+                    "added_at": attrs.get("dateAdded") or "",
+                    "image": image,
                 })
             if not data.get("next"):
                 return tracks
@@ -240,11 +261,18 @@ class AppleMusicTarget(MirrorTarget):
         out = {}
         for t in sp_tracks:
             ids = set()
-            if links.get(t.get("id")):
-                ids.add(links[t["id"]])
-            for c in cache["isrc"].get(t.get("isrc") or "", []):
+            candidates = [
+                c for c in cache["isrc"].get(t.get("isrc") or "", [])
+                if c.get("id")
+            ]
+            for c in candidates:
                 if c.get("id"):
                     ids.add(c["id"])
+            # A current native ISRC result outranks an older archived link. If
+            # both are admitted, a stale/wrong linked release already present
+            # on Apple can suppress the correct recording forever.
+            if not candidates and links.get(t.get("id")):
+                ids.add(links[t["id"]])
             if ids:
                 out[t.get("id")] = ids
         return out
@@ -254,8 +282,60 @@ class AppleMusicTarget(MirrorTarget):
         if candidates and track["duration_ms"] is not None:
             candidates.sort(key=lambda c: abs((c.get("duration_ms") or 0) - track["duration_ms"]))
         if candidates:
-            return candidates[0]["id"], "isrc"
-        return self._search(track["name"], track["artists"], track["duration_ms"], cache), "search"
+            target_id = candidates[0]["id"]
+            self._remember_resolution(track, target_id, cache)
+            return target_id, "isrc"
+        target_id = self._search(
+            track["name"], track["artists"], track["duration_ms"], cache
+        )
+        if target_id:
+            self._remember_resolution(track, target_id, cache)
+        return target_id, "search"
+
+    def _remember_resolution(self, track, target_id, cache):
+        if target_id:
+            contexts = getattr(self, "_resolved_catalog_context", {})
+            contexts[str(target_id)] = (track, cache)
+            self._resolved_catalog_context = contexts
+
+    def validate_link(self, track, target_id, cache):
+        """Replace a stale historical catalog id with the current ISRC result.
+
+        Deleted Apple playlists can retain catalog ids that now 404 and produce
+        an opaque 500 when re-added. Once prefetch has checked this recording's
+        ISRC, that current catalog response outranks any older link/archive id.
+        """
+        isrc = track.get("isrc") or ""
+        if isrc not in cache["isrc"]:
+            return target_id, "link"
+        candidates = [candidate for candidate in cache["isrc"][isrc] if candidate.get("id")]
+        if candidates and track.get("duration_ms") is not None:
+            candidates.sort(
+                key=lambda candidate: abs(
+                    (candidate.get("duration_ms") or 0) - track["duration_ms"]
+                )
+            )
+        if candidates:
+            target_id = candidates[0]["id"]
+            self._remember_resolution(track, target_id, cache)
+            return target_id, "isrc"
+
+        # A source identity can point at a different release ISRC even when the
+        # archived Apple recording itself is still current. Prove the archived
+        # id directly before discarding it; a 404 falls through to live search.
+        validated = getattr(self, "_validated_catalog_ids", {})
+        if target_id not in validated:
+            response = self._request(
+                "GET",
+                f"{AMP}/catalog/{self.storefront}/songs/{target_id}",
+                ok404=True,
+            )
+            validated[target_id] = response is not None
+            self._validated_catalog_ids = validated
+        if validated[target_id]:
+            self._remember_resolution(track, target_id, cache)
+            return target_id, "link"
+        return None, None
 
     def _search_once(self, term, name, artists, duration_ms):
         r = self._request("GET", f"{AMP}/catalog/{self.storefront}/search",
@@ -270,15 +350,106 @@ class AppleMusicTarget(MirrorTarget):
                 best_id, best_score = song.get("id"), score
         return best_id
 
+    def _public_search_once(self, term, name, artists, duration_ms):
+        """Use Apple's unauthenticated Search API when amp-api is throttled.
+
+        This is a secondary read path only: no Apple credentials are sent to
+        the public host. A miss remains provisional and is never cached, while
+        a transient response still stops the ordered suffix for a later pass.
+        """
+        deadline = getattr(self, "_public_search_not_before", 0.0)
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(remaining)
+
+        try:
+            response = requests.get(
+                _PUBLIC_SEARCH_URL,
+                params={
+                    "term": term,
+                    "country": self.storefront.upper(),
+                    "media": "music",
+                    "entity": "song",
+                    "limit": 50,
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            raise TargetTransientError(
+                "Apple public catalog search was temporarily unreachable",
+                retry_after=10,
+            ) from exc
+        finally:
+            self._public_search_not_before = (
+                time.monotonic() + _PUBLIC_SEARCH_INTERVAL_S
+            )
+
+        if response.status_code == 429:
+            try:
+                retry_after = max(
+                    _PUBLIC_SEARCH_INTERVAL_S,
+                    float(response.headers.get("Retry-After") or 10),
+                )
+            except (TypeError, ValueError):
+                retry_after = 10
+            raise TargetTransientError(
+                "Apple public catalog search was rate-limited",
+                retry_after=retry_after,
+            )
+        if response.status_code >= 500:
+            raise TargetTransientError(
+                f"Apple public catalog search returned HTTP {response.status_code}",
+                retry_after=10,
+            )
+        try:
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise TargetTransientError(
+                f"Apple public catalog search returned HTTP {response.status_code}",
+                retry_after=10,
+            ) from exc
+
+        try:
+            results = response.json().get("results", [])
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise TargetTransientError(
+                "Apple public catalog search returned an invalid response",
+                retry_after=10,
+            ) from exc
+
+        best_id, best_score = None, -1.0
+        for song in results:
+            score, ok = score_candidate(
+                name,
+                artists,
+                duration_ms,
+                song.get("trackName", ""),
+                song.get("artistName", ""),
+                song.get("trackTimeMillis"),
+            )
+            if ok and score > best_score and song.get("trackId") is not None:
+                best_id, best_score = str(song["trackId"]), score
+        return best_id
+
     def _search(self, name, artists, duration_ms, cache):
         primary = artists[0] if artists else ""
+        public_term = f"{name} {' '.join(artists[:3])}".strip()
         if not f"{name} {primary}".strip():
             return None  # amp-api 400s on an empty term
         key = f"{name}|{primary}".casefold()
         if key in cache["search"]:
             return cache["search"][key]
         if self._search_throttled:
-            return None  # catalog search rate-limited earlier this pass; defer to the next (don't cache a miss)
+            # Keep the queue moving via Apple's separately rate-limited public
+            # catalog. A miss is deliberately not cached: the authenticated
+            # catalog gets another chance on the next pass.
+            best = self._public_search_once(
+                public_term, name, artists, duration_ms
+            )
+            if best:
+                cache["search"][key] = best
+                cache["dirty"] = True
+            return best
         try:
             best = self._search_once(f"{name} {primary}".strip(), name, artists, duration_ms)
             if not best:
@@ -286,25 +457,248 @@ class AppleMusicTarget(MirrorTarget):
                 if rom and rom != normalize_text(f"{name} {primary}"):
                     polite_sleep(0.3)
                     best = self._search_once(rom, name, artists, duration_ms)
-        except requests.HTTPError as e:
-            if "429" not in str(e):
-                raise
+        except TargetTransientError as e:
             self._search_throttled = True
-            log_warn("Apple Music search rate-limited — deferring the rest of the resolves to the next pass",
+            retry_after = e.retry_after or 10
+            # Catalog and library routes have separate budgets, but a sustained
+            # search throttle has repeatedly preceded library-write failures in
+            # practice. Keep a small safety margin before the ordered write queue.
+            self._write_not_before = max(
+                getattr(self, "_write_not_before", 0.0),
+                time.monotonic() + retry_after + 5,
+            )
+            log_warn("Apple Music search temporarily unavailable — switching to its public catalog fallback",
                      tag=self.tag)
-            return None
+            # amp-api and the public Search API have separate rate limits. The
+            # latter can resolve or provisionally skip this item so later
+            # source-ordered tracks still get a chance during the same pass.
+            best = self._public_search_once(
+                public_term, name, artists, duration_ms
+            )
+            if not best:
+                return None
         cache["search"][key] = best
         cache["dirty"] = True
         polite_sleep(0.3)
         return best
 
+    @staticmethod
+    def _error_status(exc):
+        response = getattr(exc, "response", None)
+        return getattr(response, "status_code", None) if response is not None else None
+
+    @staticmethod
+    def _retry_after(exc, fallback):
+        response = getattr(exc, "response", None)
+        value = response.headers.get("Retry-After") if response is not None else None
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            return float(fallback)
+
+    @staticmethod
+    def _error_detail(exc):
+        """A short credential-free Apple error description for diagnostics."""
+        response = getattr(exc, "response", None)
+        if response is None:
+            return ""
+        try:
+            error = (response.json().get("errors") or [])[0]
+        except (AttributeError, IndexError, TypeError, ValueError):
+            return ""
+        code = error.get("code")
+        message = " — ".join(
+            part for part in (error.get("title"), error.get("detail")) if part)
+        if code and message:
+            return f" ({code}: {message})"
+        if code:
+            return f" (code {code})"
+        return f" ({message})" if message else ""
+
+    def _wait_for_write_window(self):
+        deadline = getattr(self, "_write_not_before", 0.0)
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            log(f"  waiting {int(remaining) + 1}s for Apple's rate limit to clear before writes",
+                tag=self.tag)
+            time.sleep(remaining)
+            if getattr(self, "_write_not_before", 0.0) == deadline:
+                self._write_not_before = 0.0
+
+    def _repair_catalog_id(self, catalog_id):
+        """Find a current release id after Apple verifies an old id cannot add."""
+        context = getattr(self, "_resolved_catalog_context", {}).get(str(catalog_id))
+        if not context:
+            return None
+        track, cache = context
+        artists = track.get("artists") or []
+        replacement = self._public_search_once(
+            f"{track.get('name', '')} {' '.join(artists[:3])}".strip(),
+            track.get("name", ""),
+            artists,
+            track.get("duration_ms"),
+        )
+        if not replacement or str(replacement) == str(catalog_id):
+            # Do not persist a catalog id Apple has proven unwritable. This is
+            # especially important for fuzzy public-search hits: the next pass
+            # must search again under the current stricter recording-version
+            # rules instead of retrying a bad mapping forever.
+            isrc = track.get("isrc") or ""
+            candidates = cache.get("isrc", {}).get(isrc, [])
+            if candidates:
+                survivors = [
+                    candidate for candidate in candidates
+                    if str(candidate.get("id")) != str(catalog_id)
+                ]
+                if survivors:
+                    cache["isrc"][isrc] = survivors
+                else:
+                    cache["isrc"].pop(isrc, None)
+            search = cache.setdefault("search", {})
+            for key, value in list(search.items()):
+                if str(value) == str(catalog_id):
+                    del search[key]
+            cache["dirty"] = True
+            self._resolved_catalog_context.pop(str(catalog_id), None)
+            return None
+
+        replacement = str(replacement)
+        isrc = track.get("isrc") or ""
+        for candidate in cache.get("isrc", {}).get(isrc, []):
+            if str(candidate.get("id")) == str(catalog_id):
+                candidate["id"] = replacement
+        primary = artists[0] if artists else ""
+        cache.setdefault("search", {})[
+            f"{track.get('name', '')}|{primary}".casefold()
+        ] = replacement
+        cache["dirty"] = True
+        self._resolved_catalog_context[replacement] = (track, cache)
+        return replacement
+
+    def _verify_add_landed(self, playlist, catalog_id, before_count):
+        """True/False when a post-error read proves the outcome, None if reads fail.
+
+        Polling before retransmission covers Apple's short consistency lag and
+        prevents an ambiguous 5xx from creating a duplicate. Counts, rather
+        than mere membership, also keep duplicate-cleanup re-appends correct.
+        """
+        for check in range(3):
+            try:
+                actual = sum(
+                    1 for track in self.playlist_tracks(playlist)
+                    if self.track_id(track) == catalog_id
+                )
+            except TargetAuthError:
+                raise
+            except Exception as e:
+                if check == 2:
+                    log_warn(f"couldn't verify Apple add {catalog_id}: {e!r}", tag=self.tag)
+                    return None
+            else:
+                if actual > before_count:
+                    return True
+            if check < 2:
+                time.sleep(1 + check)
+        return False
+
+    def _add_one(self, playlist, catalog_id, before_count):
+        url = f"{AMP}/me/library/playlists/{playlist['id']}/tracks"
+        last_error = None
+        repaired = False
+        for attempt in range(6):
+            self._wait_for_write_window()
+            try:
+                self._request(
+                    "POST",
+                    url,
+                    json_body={"data": [{"id": catalog_id, "type": "songs"}]},
+                )
+                return catalog_id
+            except TargetAuthError:
+                raise
+            except TargetTransientError as e:
+                last_error = e
+                wait = float(e.retry_after or min(10 * (attempt + 1), 60)) + random.uniform(1, 3)
+                self._write_not_before = time.monotonic() + wait
+                log_warn(
+                    f"Apple rate-limited add {catalog_id}; preserving its queue position "
+                    f"and retrying after {int(wait)}s",
+                    tag=self.tag,
+                )
+                continue
+            except requests.RequestException as e:
+                status = self._error_status(e)
+                if status not in (408, 429) and status is not None and status < 500:
+                    raise
+                last_error = e
+
+                if status == 429:
+                    wait = self._retry_after(e, min(10 * (attempt + 1), 60)) + random.uniform(1, 3)
+                    self._write_not_before = time.monotonic() + wait
+                    log_warn(
+                        f"Apple rate-limited add {catalog_id}; preserving its queue position "
+                        f"and retrying after {int(wait)}s",
+                        tag=self.tag,
+                    )
+                    continue
+
+                # A connection loss or 5xx may be a committed write whose reply
+                # was lost. Reopen the connection, then prove the occurrence
+                # count before deciding whether retransmission is safe.
+                wait = min(2 ** attempt, 20) + random.uniform(0, 2)
+                detail = self._error_detail(e)
+                log_warn(
+                    f"Apple add {catalog_id} returned "
+                    f"{('HTTP ' + str(status)) if status else 'a network error'}{detail}; "
+                    f"verifying the playlist before retrying",
+                    tag=self.tag,
+                )
+                time.sleep(wait)
+                self._rebuild_session()
+                landed = self._verify_add_landed(playlist, catalog_id, before_count)
+                if landed is True:
+                    log(f"  Apple confirmed {catalog_id} was added despite the error", tag=self.tag)
+                    return catalog_id
+                if landed is None:
+                    raise RuntimeError(
+                        f"Apple add {catalog_id} had an ambiguous outcome and the playlist "
+                        "could not be verified; stopping this ordered queue until the next pass"
+                    ) from e
+                if not repaired:
+                    replacement = self._repair_catalog_id(catalog_id)
+                    repaired = True
+                    if replacement:
+                        log(
+                            f"  Apple replaced obsolete catalog id {catalog_id} with {replacement}",
+                            tag=self.tag,
+                        )
+                        catalog_id = replacement
+                        before_count = 0
+                        continue
+
+        raise RuntimeError(
+            f"Apple kept rejecting add {catalog_id} after 6 attempts; "
+            "stopping this ordered queue until the next pass"
+        ) from last_error
+
     def add(self, playlist, target_ids):
-        # One POST per track — batched arrays can land out of order, and append
-        # order is what keeps the playlist sorted by date added.
+        # One POST per track — batched arrays can land out of order. Never skip
+        # past a transiently failing id: later tracks would then receive earlier
+        # date-added stamps, and Apple offers no positional insert to repair it.
+        confirmed_counts = {}
+        added_catalog_ids = getattr(self, "_added_catalog_ids", {})
+        self._added_catalog_ids = added_catalog_ids
         for catalog_id in target_ids:
-            self._request("POST", f"{AMP}/me/library/playlists/{playlist['id']}/tracks",
-                         json_body={"data": [{"id": catalog_id, "type": "songs"}]})
-            polite_sleep(0.4)
+            requested_id = catalog_id
+            catalog_id = self.added_id(requested_id)
+            before_count = confirmed_counts.get(catalog_id, 0)
+            actual_id = self._add_one(playlist, catalog_id, before_count)
+            added_catalog_ids[str(requested_id)] = str(actual_id)
+            confirmed_counts[str(actual_id)] = before_count + 1
+            polite_sleep(1.0)
+
+    def added_id(self, target_id):
+        return getattr(self, "_added_catalog_ids", {}).get(str(target_id), target_id)
 
     def remove(self, playlist, track):
         self._request("DELETE", f"{AMP}/me/library/playlists/{playlist['id']}/tracks",

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -33,6 +33,14 @@ class TargetAuthError(RuntimeError):
     """Auth expired / rejected. Fatal for the pass — never a partial write."""
 
 
+class TargetTransientError(RuntimeError):
+    """A retryable provider failure that must not let later writes overtake it."""
+
+    def __init__(self, message, *, retry_after=None):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
 class MirrorTarget:
     """Interface a mirror destination implements. See apple.py / ytmusic.py."""
 
@@ -40,6 +48,10 @@ class MirrorTarget:
     tag = "target"        # short log tag, e.g. "apple"
     source = "target"     # archive source key, e.g. "apple"
     cache_file = None     # this target's own resolution cache path (ids differ per service)
+    # True only when the provider gives every physical playlist entry its own
+    # durable id. The manual editor can then delete that exact occurrence
+    # without rereading a thousand-track playlist to revalidate its position.
+    stable_occurrence_ids = False
 
     def list_playlists(self):
         """{casefolded name: playlist} of editable-or-not library playlists."""
@@ -60,6 +72,24 @@ class MirrorTarget:
         """Stable id of an existing target track (for diffing / linking)."""
         raise NotImplementedError
 
+    def occurrence_id(self, track):
+        """Provider id for one physical playlist entry, when available."""
+        for key in ("relationship_id", "playlistItemId", "setVideoId"):
+            value = track.get(key)
+            if value is not None and value != "":
+                return str(value)
+        return None
+
+    def remove_occurrence(self, playlist, track_id, occurrence_id):
+        """Delete one entry addressed by its provider-stable occurrence id."""
+        self.remove(playlist, {
+            "id": track_id,
+            "videoId": track_id,
+            "relationship_id": occurrence_id,
+            "playlistItemId": occurrence_id,
+            "setVideoId": occurrence_id,
+        })
+
     def playlist_count(self, playlist):
         """Current track count from list metadata (no API call), or None. Used
         to catch target-side edits when deciding a snapshot skip."""
@@ -78,8 +108,9 @@ class MirrorTarget:
         name-keyed list_playlists(); a provider whose list_playlists() dedupes by
         name (Spotify) overrides this to scan its full, un-deduped set so a followed
         playlist stays reachable by id."""
+        wanted = str(playlist_id)
         return next((pl for pl in self.browse_playlists()
-                     if self.playlist_id(pl) == playlist_id), None)
+                     if str(self.playlist_id(pl)) == wanted), None)
 
     def browse_playlists(self):
         """All library playlists for the browse / transfer pickers, as a flat list
@@ -114,9 +145,27 @@ class MirrorTarget:
         """(target_id, method) for an unlinked track, or (None, None)."""
         raise NotImplementedError
 
+    def validate_link(self, sp_track, target_id, cache):
+        """Return a still-addable linked id, or None to fall through to resolve.
+
+        Most provider ids are durable and use this default unchanged. A provider
+        whose catalog ids expire can override it using freshly prefetched data.
+        """
+        return target_id, "link"
+
     def add(self, playlist, target_ids):
         """Append target_ids IN ORDER, one request per id (never batch)."""
         raise NotImplementedError
+
+    def added_id(self, target_id):
+        """Catalog id actually written for a resolved id.
+
+        Most providers write the resolved id unchanged. A provider with
+        replaceable catalog releases may repair an obsolete id during the
+        mutation and report the replacement so the durable crosswalk follows
+        what really landed.
+        """
+        return target_id
 
     def remove(self, playlist, track):
         """Remove one existing target track."""
@@ -157,6 +206,65 @@ def held_removals(target_name, playlist, tracks, max_removals, reason=None, *,
     return out
 
 
+def _recover_archived_links(songs, source_key, target, source_tracks, known):
+    """Recover addable target ids from durable identity and recording history.
+
+    A destination playlist can be deleted while the catalog entries SongMirror
+    previously proved remain valid. Reusing those mappings avoids unnecessary
+    provider search traffic (and is especially important while a catalog search
+    route is throttled). Direct links supplied by the caller remain authoritative.
+    """
+    source_ids = [track.get("id") for track in source_tracks if track.get("id")]
+    recovered = archive.get_identity_crosswalk(
+        songs, source_key, target.source, source_ids)
+    recovered = {source_id: target_id for source_id, target_id in recovered.items()
+                 if source_id not in known and target_id}
+
+    by_name = {}
+    for candidate in archive.get_song_history(songs, target.source):
+        target_id = target.track_id(candidate) or candidate.get("_archive_id")
+        if target_id:
+            by_name.setdefault(catalog_name(candidate.get("name", "")), []).append(
+                (target_id, candidate))
+
+    for track in source_tracks:
+        if not track.get("id"):
+            continue
+        matches = [
+            (target_id, candidate)
+            for target_id, candidate in by_name.get(catalog_name(track.get("name", "")), [])
+            if same_catalog_recording(track, candidate)
+        ]
+        if matches:
+            # get_song_history is newest-first. same_catalog_recording is a
+            # conservative title/artist/duration gate, so the freshest proven
+            # catalog id is the best replacement-playlist candidate.
+            # Fresh, conservative metadata evidence also repairs a stale direct
+            # link or hard-identity candidate left by a deleted playlist.
+            recovered[track["id"]] = matches[0][0]
+    return recovered
+
+
+def _enrich_hard_isrcs(songs, source_key, source_tracks):
+    """Fill missing source ISRCs from identities proven on earlier N-way reads."""
+    identities = archive.get_identities(
+        songs, source_key, [track.get("id") for track in source_tracks])
+    enriched = []
+    for track in source_tracks:
+        if normalize_isrc(track.get("isrc")):
+            enriched.append(track)
+            continue
+        canonical_id = identities.get(track.get("id"), "")
+        isrc = normalize_isrc(canonical_id[2:]) if canonical_id.startswith("i:") else ""
+        if not isrc:
+            enriched.append(track)
+            continue
+        copy = dict(track)
+        copy["isrc"] = isrc
+        enriched.append(copy)
+    return enriched
+
+
 def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, execute, max_removals,
                 max_adds, drain_removals=False, should_continue=None, source_key="spotify", source_name="Spotify", name=None):
     """Reconcile one source→target playlist pair. Returns a stats dict; `clean`
@@ -170,6 +278,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     tag = target.tag
     name = name or sp_playlist.get("name", "?")
     started = time.monotonic()
+    sp_tracks = _enrich_hard_isrcs(songs, source_key, sp_tracks)
     tgt_tracks = target.playlist_tracks(tgt_playlist)
     log_section(name, f"{source_name} {len(sp_tracks)} tracks - {target.name} {len(tgt_tracks)} tracks", tag=tag)
 
@@ -180,6 +289,9 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
 
     links = (archive.get_links(songs, target.source, [t.get("id") for t in sp_tracks])
              if source_key == "spotify" else {})
+    recovered_links = _recover_archived_links(
+        songs, source_key, target, sp_tracks, links)
+    links = {**links, **recovered_links}  # fresh conservative archive evidence repairs stale links
     target.prefetch(sp_tracks, cache)
     to_add, to_remove = compute_diff(
         sp_tracks, tgt_tracks, target.expected_ids(sp_tracks, links, cache), target.track_id
@@ -191,6 +303,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     present = {target.track_id(t) for t in tgt_tracks if target.track_id(t)}
     additions, not_found, new_links, methods = [], [], {}, {}
     stopped_early = False
+    deferred = 0
     for i, track in enumerate(to_add, 1):
         if should_continue and should_continue() != "run":
             stopped_early = True  # Pause/Stop — defer the rest; keep the pass "not clean" below
@@ -198,14 +311,31 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         label = f"{track['name']} - {', '.join(track['artists'])}"
         tid = links.get(track.get("id"))
         method = "link" if tid else None
-        if not tid:
-            try:
+        try:
+            if tid:
+                validator = getattr(target, "validate_link", None)
+                if validator:
+                    tid, method = validator(track, tid, cache)
+            if not tid:
                 tid, method = target.resolve(track, cache)
-            except TargetAuthError:
-                raise
-            except Exception as e:
-                log_warn(f"resolve failed: {label}: {e!r}", tag=tag)
-                tid, method = None, None
+        except TargetAuthError:
+            raise
+        except TargetTransientError as e:
+            # The destination appends, so allowing a later source track to
+            # pass a throttled one would permanently invert date-added
+            # order. Apply only the resolved prefix and resume here later.
+            stopped_early = True
+            deferred += len(to_add) - i + 1
+            retry = (f"; provider requested about {e.retry_after:g}s" if e.retry_after is not None else "")
+            log_warn(
+                f"resolve temporarily blocked at {label}: {e}{retry}; "
+                f"deferring this track and {len(to_add) - i} later track(s) to preserve order",
+                tag=tag,
+            )
+            break
+        except Exception as e:
+            log_warn(f"resolve failed: {label}: {e!r}", tag=tag)
+            tid, method = None, None
         if len(to_add) > 25 and i % 25 == 0:
             log_note(f"  ...resolved {i}/{len(to_add)}", tag=tag)
         if not tid:
@@ -218,14 +348,15 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
             additions.append((tid, label, method))
             present.add(tid)
             methods[method] = methods.get(method, 0) + 1
-    if source_key == "spotify":
-        archive.set_links(songs, target.source, new_links)  # keep the shared table Spotify-anchored
-
-    guard = stopped_early  # a pause mid-resolve must not advance the snapshot (a re-run finishes it)
-    deferred = 0
+    # A provider miss can be provisional (catalog throttling, regional indexing,
+    # or a temporarily stale search result). Do not mark the source snapshot
+    # complete while anything is unresolved; a later scheduled pass must get a
+    # chance to fill it even when Spotify itself has not changed.
+    guard = stopped_early or bool(not_found)
     if len(additions) > max_adds:
-        deferred = len(additions) - max_adds
-        log_warn(f"{len(additions)} additions exceed --max-adds={max_adds}; deferring {deferred} to next pass", tag=tag)
+        cap_deferred = len(additions) - max_adds
+        deferred += cap_deferred
+        log_warn(f"{len(additions)} additions exceed --max-adds={max_adds}; deferring {cap_deferred} to next pass", tag=tag)
         additions, guard = additions[:max_adds], True
 
     removals, held = protect_removals(to_remove, not_found)
@@ -258,10 +389,33 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         log_miss(f"not on {target.name}: {track['name']} - {', '.join(track['artists'])}", tag=tag)
 
     if execute:
+        if additions or removals:
+            # Invalidate before the first provider write: a batched/ordered add
+            # can partially land before a transient exception. A cached ledger
+            # must never survive with the pre-write contents in that case.
+            playlist_id = getattr(
+                target, "playlist_id", lambda playlist: playlist.get("id")
+            )(tgt_playlist)
+            if playlist_id is not None:
+                archive.invalidate_playlist_detail_cache(
+                    songs, target.source, playlist_id
+                )
         if additions:
             target.add(tgt_playlist, [tid for tid, _, _ in additions])
+        if source_key == "spotify":
+            actual_id = getattr(target, "added_id", lambda target_id: target_id)
+            archive.set_links(
+                songs,
+                target.source,
+                {source_id: actual_id(target_id)
+                 for source_id, target_id in new_links.items()},
+            )
         for track in removals:
             target.remove(tgt_playlist, track)
+    elif source_key == "spotify":
+        # A dry run may still warm proven cross-provider mappings, but there is
+        # no write-time provider repair to account for.
+        archive.set_links(songs, target.source, new_links)
 
     via = ", ".join(f"{n} {m}" for m, n in sorted(methods.items(), key=lambda kv: -kv[1]))
     counts = fmt_counts(len(additions), len(removals), len(not_found), len(held), deferred)
@@ -838,7 +992,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         except Exception as e:
             log_warn(f"{p.name} prefetch failed: {e!r}", tag=p.tag)
         additions, not_found = [], []
-        for cid, norm in add_items:
+        deferred = 0
+        for add_index, (cid, norm) in enumerate(add_items, 1):
             if should_continue and should_continue() != "run":
                 interrupted = True  # Pause/Stop — defer this provider's remaining adds
                 add_blockers.add("the sync was interrupted")
@@ -865,6 +1020,17 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 tid, method = p.resolve(norm, cache)
             except TargetAuthError:
                 raise
+            except TargetTransientError as e:
+                deferred += len(add_items) - add_index + 1
+                add_blockers.add("the provider temporarily blocked ordered resolution")
+                retry = (f"; provider requested about {e.retry_after:g}s"
+                         if e.retry_after is not None else "")
+                log_warn(
+                    f"{p.name}/{name}: resolve temporarily blocked at {norm['name']}: {e}{retry}; "
+                    f"deferring it and {len(add_items) - add_index} later track(s) to preserve order",
+                    tag=p.tag,
+                )
+                break
             except Exception as e:
                 log_warn(f"resolve failed on {p.name}: {norm['name']}: {e!r}", tag=p.tag)
                 tid, method = None, None
@@ -892,11 +1058,11 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             present_recordings[p.source].setdefault(catalog_name(norm["name"]), []).append((None, norm))
             additions.append((cid, tid, method or "search", norm))
 
-        deferred = 0
         if len(additions) > max_adds:
-            deferred = len(additions) - max_adds
+            cap_deferred = len(additions) - max_adds
+            deferred += cap_deferred
             log_warn(f"{p.name}/{name}: {len(additions)} additions exceed --max-adds={max_adds}; "
-                     f"deferring {deferred}", tag=p.tag)
+                     f"deferring {cap_deferred}", tag=p.tag)
             additions = additions[:max_adds]
             add_blockers.add("replacement additions exceeded the add cap")
         for _, tid, _, norm in additions:

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -613,11 +613,13 @@ def _unify_aliases(canon):
     return alias
 
 
-def _merge(prev, cur, collapsed):
+def _merge(prev, cur, collapsed, authority_sources=None):
     """Pure delta merge over PER-PROVIDER state. prev, cur: {source:
     set(canonical_id)} — each provider's membership after the last clean pass
     and now. collapsed: sources whose read is untrusted (skipped this pass).
-    Returns (desired, {source: (add_ids, remove_ids)}).
+    Returns (desired, {source: (add_ids, remove_ids)}). When
+    ``authority_sources`` is supplied, only those providers may change desired
+    membership; every other current set is a destination-only mirror.
 
     A canonical is REMOVED only when it leaves a provider that actually had it
     (prev[src] - cur[src]) — so a track that merely can't be matched on a
@@ -625,9 +627,10 @@ def _merge(prev, cur, collapsed):
     Concurrent additions on initialized peers win over removals. Membership on
     a peer absent from `prev` is bootstrap state, not a user addition, so it
     joins the initial union but cannot resurrect an established removal."""
+    contributors = set(cur) if authority_sources is None else set(authority_sources)
     adds, bootstrap, removes = set(), set(), set()
     for src, ids in cur.items():
-        if src in collapsed:
+        if src in collapsed or src not in contributors:
             continue  # untrusted read contributes neither adds nor removes
         if src not in prev:
             bootstrap |= ids
@@ -635,13 +638,15 @@ def _merge(prev, cur, collapsed):
         adds |= ids - prev[src]
         removes |= prev[src] - ids
     removes -= adds
-    union_prev = set().union(*prev.values()) if prev else set()
+    previous_authority_sets = [ids for src, ids in prev.items() if src in contributors]
+    union_prev = set().union(*previous_authority_sets) if previous_authority_sets else set()
     desired = (union_prev | adds | bootstrap) - removes
     plan = {src: (desired - ids, ids - desired) for src, ids in cur.items()}
     return desired, plan
 
 
-def _addition_order_by_cid(peers, per_entry, prev, cur, collapsed, alias):
+def _addition_order_by_cid(peers, per_entry, prev, cur, collapsed, alias,
+                           authority_sources=None):
     """Choose deterministic ordering evidence from each track's origin peer.
 
     Reconcile membership is intentionally set-based, so plan iteration cannot
@@ -650,6 +655,8 @@ def _addition_order_by_cid(peers, per_entry, prev, cur, collapsed, alias):
     trusted current peer. Date-added wins when present, otherwise peer rank and
     the entry's source-playlist position preserve a stable order.
     """
+    contributors = ({peer.source for peer in peers} if authority_sources is None
+                    else set(authority_sources))
     source_rank = {peer.source: rank for rank, peer in enumerate(peers)}
     all_evidence, origin_evidence = {}, {}
     for peer in peers:
@@ -665,7 +672,7 @@ def _addition_order_by_cid(peers, per_entry, prev, cur, collapsed, alias):
                 playlist_position=norm.get("_playlist_position", 0),
             )
             all_evidence.setdefault(cid, []).append(order)
-            if cid in introduced:
+            if source in contributors and cid in introduced:
                 origin_evidence.setdefault(cid, []).append(order)
     return {
         cid: min(origin_evidence.get(cid) or evidence)
@@ -673,23 +680,74 @@ def _addition_order_by_cid(peers, per_entry, prev, cur, collapsed, alias):
     }
 
 
+def reconcile_state_key(name, *, link_key=None, authority_sources=None):
+    """Stable baseline namespace for one logical reconciliation policy."""
+    logical_key = link_key or name.casefold()
+    if authority_sources is None:
+        return logical_key
+    authority_key = ",".join(sorted(set(authority_sources)))
+    return f"group:{authority_key}:{logical_key}"
+
+
 def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, max_adds,
-              drain_removals=False, should_continue=None, link_key=None):
-    """Reconcile one logical playlist across N provider peers, bidirectionally.
+              drain_removals=False, should_continue=None, link_key=None,
+              authority_sources=None):
+    """Reconcile one logical playlist across provider peers.
 
     playlists: {source: playlist dict}; caches: {source: resolution cache}.
+    With ``authority_sources=None``, every peer contributes changes (N-way).
+    Otherwise only those providers contribute membership and all remaining
+    peers are mirrors. The first pass under a new authority set establishes a
+    separate baseline and refuses destructive writes.
     `link_key`, when given (explicit pairing), addresses the canonical snapshot
     state so differently-named paired playlists share one logical identity;
     otherwise the casefolded display name is used (implicit same-name pairing).
     Returns a stats dict; `clean` is True when every side applied with no guard
     tripped (only then is the canonical snapshot advanced)."""
-    key = link_key or name.casefold()
+    authorities = None if authority_sources is None else frozenset(authority_sources)
+    peer_sources = {p.source for p in peers}
+    if authorities is not None:
+        if len(authorities) < 2:
+            raise ValueError("authoritative reconciliation needs at least two authorities")
+        missing_authorities = authorities - peer_sources
+        if missing_authorities:
+            raise ValueError(
+                "authoritative reconciliation is missing peers: "
+                + ", ".join(sorted(missing_authorities))
+            )
+    key = reconcile_state_key(name, link_key=link_key, authority_sources=authorities)
     started = time.monotonic()
     peer_names = {p.source: p.name for p in peers}
     diagnostics = []
     identity_changes = 0
     read_anomalies = 0
     initialized = {p.source for p in peers if archive.has_playlist_state(songs, key, p.source)}
+    physical_playlist_ids = {}
+    replaced_sources = set()
+    for p in peers:
+        playlist_id_getter = getattr(p, "playlist_id", lambda playlist: playlist.get("id"))
+        physical_id = playlist_id_getter(playlists[p.source])
+        if physical_id is None:
+            continue
+        physical_id = str(physical_id)
+        physical_playlist_ids[p.source] = physical_id
+        previous_physical_id = archive.get_playlist_physical_id(songs, key, p.source)
+        if p.source in initialized and previous_physical_id and previous_physical_id != physical_id:
+            replaced_sources.add(p.source)
+            diagnostics.append({
+                "category": "playlist_recreated", "playlist": name, "provider": p.name,
+                "count": 1,
+                "evidence": (
+                    f"provider playlist id changed from {previous_physical_id} to {physical_id}; "
+                    "this side is re-establishing its baseline"
+                ),
+            })
+            log_note(
+                f"{name}: {p.name} playlist was recreated ({previous_physical_id} -> {physical_id}); "
+                "re-establishing that baseline",
+                tag=p.tag,
+            )
+    initialized -= replaced_sources
     # Missing keys deliberately mean "bootstrap peer" to _merge. Keeping an
     # initialized empty set in the mapping is why playlist_state_meta exists.
     prev = {p.source: {normalize_canonical_id(cid) for cid in
@@ -704,7 +762,18 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     key2isrc = {}      # track_key -> ISRC, seeded by every ISRC-bearing provider before canonicalization
     raw_by_source = {}
     for p in peers:
-        raw = p.playlist_tracks(playlists[p.source])
+        provider_rows = p.playlist_tracks(playlists[p.source])
+        raw = [
+            track for track in provider_rows
+            if isinstance(track, dict) and str(track.get("name") or "").strip()
+        ]
+        ignored = len(provider_rows) - len(raw)
+        if ignored:
+            log_warn(
+                f"{p.name}/{name}: ignored {ignored} malformed playlist "
+                f"entr{'y' if ignored == 1 else 'ies'} without a usable title",
+                tag=p.tag,
+            )
         raw_by_source[p.source] = raw
         archive.upsert_many(songs, p.source, raw)
         archive.record_order(songs, key, p.source,
@@ -859,7 +928,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     # source-local absence retained from a prior executing pass is confirmed.
     missing_by_source, first_seen_removals, confirmed_removals = {}, {}, {}
     effective_cur = {src: set(ids) for src, ids in cur.items()}
-    for src in initialized:
+    confirmation_sources = initialized if authorities is None else initialized & authorities
+    for src in confirmation_sources:
         if src in collapsed or src not in cur:
             continue
         pending = {
@@ -886,10 +956,10 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 "evidence": "missing from two consecutive trusted snapshots on this provider",
             })
 
-    _, unconfirmed_plan = _merge(prev, cur, collapsed)
-    desired, plan = _merge(prev, effective_cur, collapsed)
+    _, unconfirmed_plan = _merge(prev, cur, collapsed, authorities)
+    desired, plan = _merge(prev, effective_cur, collapsed, authorities)
     addition_order = _addition_order_by_cid(
-        peers, per_entry, prev, cur, collapsed, alias)
+        peers, per_entry, prev, cur, collapsed, alias, authorities)
     desired_recordings = {}
     for cid in desired:
         norm = repr_.get(cid)
@@ -899,7 +969,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
 
     awaiting_confirmation = sum(len(ids) for ids in first_seen_removals.values())
     confirmed_absence_count = sum(len(ids) for ids in confirmed_removals.values())
-    stats = {"clean": execute and not collapsed and not awaiting_confirmation,
+    authority_bootstrap = authorities is not None and bool(authorities - initialized)
+    stats = {"clean": execute and not collapsed and not awaiting_confirmation and not authority_bootstrap,
              "added": 0, "removed": 0, "missing": 0,
              "held": 0, "deferred": 0, "removals_skipped": 0, "held_removals": [],
              "identity_changes": identity_changes,
@@ -907,7 +978,18 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
              "confirmed_absences": confirmed_absence_count,
              "read_anomalies": read_anomalies,
              "change_diagnostics": diagnostics}
-    baseline_blocked = bool(awaiting_confirmation)
+    baseline_blocked = bool(awaiting_confirmation or authority_bootstrap)
+    if authority_bootstrap:
+        initializing = ", ".join(sorted(peer_names.get(src, src) for src in authorities - initialized))
+        diagnostics.append({
+            "category": "authority_baseline", "playlist": name,
+            "provider": initializing, "count": len(authorities - initialized),
+            "evidence": "the authority set has no trusted baseline yet; destructive writes wait for the next pass",
+        })
+        log_note(
+            f"{name}: establishing authoritative baseline for {initializing}; removals are held this pass",
+            tag="sync",
+        )
     if awaiting_confirmation:
         # Report actual destination removals held, deduplicated when several
         # sources first report the same absence. The detail is what lets the UI
@@ -1092,7 +1174,23 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 continue
             remove_pairs.append((cid, norm))
         safe, held = protect_removals([n for _, n in remove_pairs], not_found)
-        if provider_add_incomplete:
+        if authority_bootstrap:
+            held = [norm for _, norm in remove_pairs]
+            safe = []
+            if held:
+                stats["removals_skipped"] += len(held)
+                stats["held_removals"] += held_removals(
+                    p.name, name, held, max_removals,
+                    reason="the authoritative group is establishing its first trusted baseline",
+                    category="authority_baseline",
+                    source=", ".join(sorted(peer_names.get(src, src) for src in authorities)),
+                    evidence="destructive writes begin only after every authority has one complete baseline",
+                )
+                log_warn(
+                    f"{p.name}/{name}: held {len(held)} removals while the authoritative baseline is established",
+                    tag=p.tag,
+                )
+        elif provider_add_incomplete:
             # Removals are the destructive half of a replacement transaction.
             # If any desired addition is unresolved, deferred, or interrupted,
             # keep every current entry until the complete add plan can succeed.
@@ -1169,9 +1267,10 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                     dry=not execute, tag=p.tag)
         for norm in safe:
             log_remove(f"{p.name}: {norm['name']} - {norm['artist']}", dry=not execute, tag=p.tag)
-        hold_reason = ("replacement additions incomplete" if provider_add_incomplete
-                       else "no re-add match")
-        if held and not provider_add_incomplete:
+        hold_reason = ("authoritative baseline" if authority_bootstrap else
+                       "replacement additions incomplete" if provider_add_incomplete else
+                       "no re-add match")
+        if held and not provider_add_incomplete and not authority_bootstrap:
             diagnostics.append({
                 "category": "uncertain_match", "playlist": name,
                 "provider": p.name, "count": len(held),
@@ -1180,8 +1279,9 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         for norm in held:
             log_protected(
                 f"{p.name}: kept ({hold_reason}): {norm['name']} - {norm['artist']}", tag=p.tag,
-                data={"classification": ("replacement_blocked" if provider_add_incomplete
-                                         else "uncertain_match"),
+                data={"classification": ("authority_baseline" if authority_bootstrap else
+                                         "replacement_blocked" if provider_add_incomplete else
+                                         "uncertain_match"),
                       "count": 1, "playlist": name, "provider": p.source},
             )
         for norm in not_found:
@@ -1217,14 +1317,15 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         if not collapsed and not interrupted:
             persist = new_state if not baseline_blocked else {
                 src: ids for src, ids in new_state.items() if src not in initialized}
+            pending_sources = initialized if authorities is None else initialized & authorities
             pending_updates = (
                 {src: missing_by_source.get(src, set()) | applied_removals.get(src, set())
-                 for src in initialized}
+                 for src in pending_sources}
                 if baseline_blocked else
-                {src: set() for src in initialized}
+                {src: set() for src in pending_sources}
             )
             archive.commit_reconcile_membership(
-                songs, key, persist, pending_updates)
+                songs, key, persist, pending_updates, physical_playlist_ids)
             if baseline_blocked:
                 for src in persist:
                     label = next((p.name for p in peers if p.source == src), src)

--- a/songmirror/engine/targets/deezer.py
+++ b/songmirror/engine/targets/deezer.py
@@ -30,15 +30,23 @@ def _normalized_track(track):
     primary = (track.get("artist") or {}).get("name", "")
     artists = contributors or ([primary] if primary else [""])
     duration = track.get("duration")
+    album = track.get("album") or {}
+    cover = album.get("cover")
+    if isinstance(cover, dict):
+        image = next((url for url in reversed(cover.get("urls") or []) if url), "")
+    else:
+        image = next((album.get(key) for key in ("cover_medium", "cover_big", "cover_xl", "cover")
+                      if isinstance(album.get(key), str) and album.get(key)), "")
     return {
         "id": str(track.get("id")) if track.get("id") is not None else None,
         "name": track.get("title", ""),
         "artist": ", ".join(artists),
         "artists": artists,
-        "album": (track.get("album") or {}).get("title") or (track.get("album") or {}).get("displayTitle"),
+        "album": album.get("title") or album.get("displayTitle"),
         "duration_ms": int(duration * 1000) if isinstance(duration, (int, float)) else None,
         "isrc": track.get("isrc"),
         "added_at": str(track.get("time_add") or ""),
+        "image": image,
     }
 
 

--- a/songmirror/engine/targets/qobuz.py
+++ b/songmirror/engine/targets/qobuz.py
@@ -32,16 +32,23 @@ def _artist_name(track):
 def _normalized_track(track):
     artist = _artist_name(track)
     duration = track.get("duration")
+    album = track.get("album") or {}
+    album_image = album.get("image") or {}
+    if isinstance(album_image, dict):
+        image = album_image.get("small") or album_image.get("thumbnail") or album_image.get("large") or ""
+    else:
+        image = album_image if isinstance(album_image, str) else ""
     return {
         "id": str(track.get("id")) if track.get("id") is not None else None,
         "relationship_id": track.get("playlist_track_id"),
         "name": track.get("title", ""),
         "artist": artist,
         "artists": [artist] if artist else [""],
-        "album": (track.get("album") or {}).get("title"),
+        "album": album.get("title"),
         "duration_ms": int(duration * 1000) if isinstance(duration, (int, float)) else None,
         "isrc": track.get("isrc"),
         "added_at": str(track.get("created_at") or ""),
+        "image": image,
     }
 
 
@@ -49,6 +56,7 @@ class QobuzTarget(MirrorTarget):
     name = "Qobuz"
     tag = "qobuz"
     source = "qobuz"
+    stable_occurrence_ids = True
 
     def __init__(self):
         self.cache_file = os.getenv("QOBUZ_CACHE_FILE", "qobuz_resolve_cache.json")

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -30,6 +30,7 @@ class TidalTarget(MirrorTarget):
     name = "TIDAL"
     tag = "tidal"
     source = "tidal"
+    stable_occurrence_ids = True
 
     def __init__(self):
         self.cache_file = os.getenv("TIDAL_CACHE_FILE", "tidal_resolve_cache.json")
@@ -172,8 +173,26 @@ class TidalTarget(MirrorTarget):
             artists = [a for a in artists if a]
             album_ids = [str(a.get("id")) for a in ((relationships.get("albums") or {}).get("data") or [])]
             album = ""
+            image = ""
             if album_ids:
-                album = (resources.get(("albums", album_ids[0]), {}).get("attributes") or {}).get("title", "")
+                album_resource = resources.get(("albums", album_ids[0]), {})
+                album = (album_resource.get("attributes") or {}).get("title", "")
+                cover_ids = [
+                    str(item.get("id"))
+                    for item in (((album_resource.get("relationships") or {}).get("coverArt") or {}).get("data") or [])
+                    if item.get("id") is not None
+                ]
+                files = [
+                    file
+                    for cover_id in cover_ids
+                    for file in ((resources.get(("artworks", cover_id), {}).get("attributes") or {}).get("files") or [])
+                    if file.get("href")
+                ]
+                if files:
+                    image = min(
+                        files,
+                        key=lambda file: abs(int((file.get("meta") or {}).get("width") or 160) - 160),
+                    )["href"]
             meta = identifier.get("meta") or {}
             tracks.append(
                 {
@@ -183,6 +202,7 @@ class TidalTarget(MirrorTarget):
                     "artist": ", ".join(artists),
                     "artists": artists or [""],
                     "album": album or None,
+                    "image": image,
                     "duration_ms": iso_duration_ms(attrs.get("duration")),
                     "isrc": attrs.get("isrc"),
                     "added_at": meta.get("addedAt") or "",
@@ -269,7 +289,7 @@ class TidalTarget(MirrorTarget):
                 "tracks",
                 params={
                     "filter[id]": group,
-                    "include": ["artists", "albums"],
+                    "include": ["artists", "albums", "albums.coverArt"],
                     "countryCode": self.country,
                 },
             ).json()

--- a/songmirror/engine/targets/ytmusic.py
+++ b/songmirror/engine/targets/ytmusic.py
@@ -160,6 +160,7 @@ class YTMusicTarget(MirrorTarget):
     name = "YouTube Music"
     tag = "yt"
     source = "ytmusic"
+    stable_occurrence_ids = True
 
     def __init__(self, auth_file, creds):
         self._auth_file = auth_file
@@ -274,10 +275,17 @@ class YTMusicTarget(MirrorTarget):
                 continue
             sn = item.get("snippet", {})
             artist = _artist_from_channel(sn.get("videoOwnerChannelTitle", ""))
+            thumbnails = sn.get("thumbnails") or {}
+            image = next((
+                (thumbnails.get(size) or {}).get("url")
+                for size in ("medium", "high", "default")
+                if (thumbnails.get(size) or {}).get("url")
+            ), "")
             tracks.append({
                 "id": vid, "videoId": vid, "playlistItemId": item.get("id"),
                 "name": sn.get("title", ""), "artist": artist, "artists": [artist] if artist else [""],
                 "album": None, "duration_ms": None,
+                "added_at": sn.get("publishedAt") or "", "image": image,
             })
         return tracks
 
@@ -412,11 +420,15 @@ class YTMusicBrowserTarget(YTMusicTarget):
                                    for x in (t.get("artists") or [])) if a]
             album = t.get("album")
             ds = t.get("duration_seconds")
+            thumbnails = t.get("thumbnails") or []
+            image = next((thumb.get("url") for thumb in reversed(thumbnails)
+                          if isinstance(thumb, dict) and thumb.get("url")), "")
             tracks.append({
                 "id": vid, "videoId": vid, "setVideoId": t.get("setVideoId"),
                 "name": t.get("title", ""), "artist": ", ".join(artists), "artists": artists or [""],
                 "album": album.get("name") if isinstance(album, dict) else None,
                 "duration_ms": ds * 1000 if ds else None,
+                "added_at": t.get("dateAdded") or "", "image": image,
             })
         return tracks
 

--- a/songmirror/services/playlists.py
+++ b/songmirror/services/playlists.py
@@ -6,14 +6,68 @@ same-name matching. Services tier — drives the engine (build_one), never the w
 """
 
 import json
+import os
 import uuid
 from dataclasses import asdict, dataclass, field
+from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import quote
 
-from ..engine import spotify, spotify_cookie
+from ..engine import archive, spotify, spotify_cookie
 from ..engine.config import parse_args, spotify_write_backend
+from ..engine.logs import log_warn
 from ..engine.targets import build_one
 from .settings import _open_private
+
+
+_PROVIDER_NAMES = {
+    "spotify": "Spotify",
+    "tidal": "TIDAL",
+    "qobuz": "Qobuz",
+    "deezer": "Deezer",
+    "amazon": "Amazon Music",
+    "apple": "Apple Music",
+    "ytmusic": "YouTube Music",
+    "jellyfin": "Jellyfin",
+}
+
+
+class PlaylistServiceError(RuntimeError):
+    status_code = 502
+
+
+class PlaylistBrowseError(PlaylistServiceError):
+    pass
+
+
+class PlaylistNotFoundError(PlaylistServiceError):
+    status_code = 404
+
+
+class PlaylistReadOnlyError(PlaylistServiceError):
+    status_code = 403
+
+
+class PlaylistChangedError(PlaylistServiceError):
+    status_code = 409
+
+
+class _PlainTextParser(HTMLParser):
+    """Extract provider-authored description text without rendering markup."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.parts = []
+
+    def handle_data(self, data):
+        self.parts.append(data)
+
+
+def _plain_text(value):
+    parser = _PlainTextParser()
+    parser.feed(str(value or ""))
+    parser.close()
+    return " ".join("".join(parser.parts).split())
 
 
 # ponytail: provider playlist dicts store name/id differently (Spotify `name`,
@@ -90,9 +144,122 @@ def _pl_image(pl):
     return ""
 
 
+def _external_url(provider_id, kind, item_id):
+    """Stable first-party web URL for a provider playlist or track."""
+    item_id = quote(str(item_id), safe="")
+    routes = {
+        "spotify": f"https://open.spotify.com/{kind}/{item_id}",
+        "tidal": f"https://listen.tidal.com/{kind}/{item_id}",
+        "qobuz": f"https://open.qobuz.com/{kind}/{item_id}",
+        "deezer": f"https://www.deezer.com/{kind}/{item_id}",
+        "amazon": f"https://music.amazon.com/{kind}s/{item_id}",
+        "apple": (
+            f"https://music.apple.com/library/playlist/{item_id}"
+            if kind == "playlist"
+            else f"https://music.apple.com/song/{item_id}"
+        ),
+        "ytmusic": (
+            f"https://music.youtube.com/playlist?list={item_id}"
+            if kind == "playlist"
+            else f"https://music.youtube.com/watch?v={item_id}"
+        ),
+    }
+    return routes.get(provider_id, "")
+
+
+def _track_artist(track):
+    if track.get("artist"):
+        return str(track["artist"])
+    artists = track.get("artists") or []
+    names = []
+    for artist in artists:
+        name = artist.get("name") if isinstance(artist, dict) else artist
+        if name:
+            names.append(str(name))
+    if names:
+        return ", ".join(names)
+    return str((track.get("attributes") or {}).get("artistName") or "")
+
+
 class PlaylistService:
     def __init__(self, settings):
         self._settings = settings
+
+    def _failure(self, provider_id, action, exc):
+        label = _PROVIDER_NAMES.get(provider_id, provider_id)
+        log_warn(f"{action} failed: {exc!r}", tag=provider_id)
+        raise PlaylistBrowseError(
+            f"{label} could not {action} right now. Retry; if it continues, reconnect the account."
+        ) from exc
+
+    def _target(self, provider_id):
+        self._settings.apply_to_env()
+        opts = parse_args([])
+        try:
+            cookie = (
+                provider_id == "spotify"
+                and spotify_write_backend() == "cookie"
+                and spotify_cookie.configured()
+            )
+            sp = spotify.client() if provider_id == "spotify" and not cookie else None
+            target = build_one(provider_id, opts, sp)
+        except Exception as exc:
+            self._failure(provider_id, "load playlists", exc)
+        if target is None:
+            label = _PROVIDER_NAMES.get(provider_id, provider_id)
+            raise PlaylistBrowseError(
+                f"{label} is not available. Connect or reconnect the account and retry."
+            )
+        return target
+
+    def _with_cache(self, callback):
+        """Run a short operation against the configured persistent song DB."""
+        self._settings.apply_to_env()
+        cache_file = os.getenv("SONG_CACHE_FILE") or str(
+            self._settings.data_dir / "song_cache.db"
+        )
+        conn = archive.connect(cache_file)
+        try:
+            return callback(conn)
+        finally:
+            conn.close()
+
+    def _cached_detail(self, provider_id, playlist_id):
+        try:
+            return self._with_cache(
+                lambda conn: archive.get_playlist_detail_cache(
+                    conn, provider_id, playlist_id
+                )
+            )
+        except Exception as exc:
+            log_warn(f"playlist cache read failed: {exc!r}", tag="cache")
+            return None
+
+    def _cache_detail(self, detail):
+        try:
+            self._with_cache(lambda conn: archive.set_playlist_detail_cache(conn, detail))
+        except Exception as exc:
+            log_warn(f"playlist cache write failed: {exc!r}", tag="cache")
+
+    def _invalidate_detail(self, provider_id, playlist_id):
+        try:
+            self._with_cache(
+                lambda conn: archive.invalidate_playlist_detail_cache(
+                    conn, provider_id, playlist_id
+                )
+            )
+        except Exception as exc:
+            log_warn(f"playlist cache invalidation failed: {exc!r}", tag="cache")
+
+    def _prune_details(self, provider_id, playlist_ids):
+        try:
+            self._with_cache(
+                lambda conn: archive.prune_playlist_detail_cache(
+                    conn, provider_id, playlist_ids
+                )
+            )
+        except Exception as exc:
+            log_warn(f"playlist cache pruning failed: {exc!r}", tag="cache")
 
     def browse(self, provider_id):
         """[{id, name, count, image, owned}] for one connected provider (empty if
@@ -101,31 +268,163 @@ class PlaylistService:
         change here. `owned` is False only for a followed (non-owned) playlist — a
         provider surfaces those by overriding browse_playlists (Spotify does today).
         Jellyfin is browse-only and lists via its own API."""
-        self._settings.apply_to_env()
         if provider_id == "jellyfin":
             from ..engine import jellyfin
-            rows = [{**r, "owned": True} for r in jellyfin.list_playlists()]
+            self._settings.apply_to_env()
+            server = (os.getenv("JELLYFIN_URL") or "").rstrip("/")
+            rows = [{
+                **row,
+                "owned": True,
+                "external_url": (
+                    f"{server}/web/#/details?id={quote(str(row['id']), safe='')}"
+                    if server else ""
+                ),
+            } for row in jellyfin.list_playlists()]
             return sorted(rows, key=lambda r: (r["name"] or "").casefold())
-        opts = parse_args([])
-        try:
-            cookie = (provider_id == "spotify" and spotify_write_backend() == "cookie"
-                      and spotify_cookie.configured())
-            sp = spotify.client() if provider_id == "spotify" and not cookie else None
-            target = build_one(provider_id, opts, sp)
-        except Exception:
-            return []  # e.g. Spotify not authorized yet -> nothing to browse
-        if target is None:
-            return []
+        target = self._target(provider_id)
         try:
             playlists = list(target.browse_playlists())
             hydrate_counts = getattr(target, "hydrate_playlist_counts", None)
             if hydrate_counts:
                 playlists = hydrate_counts(playlists) or playlists
-        except Exception:
-            return []
+        except Exception as exc:
+            self._failure(provider_id, "load playlists", exc)
         rows = [{"id": _pl_id(pl), "name": _pl_name(pl), "count": target.playlist_count(pl),
-                 "image": _pl_image(pl), "owned": bool(pl.get("_owned", True))} for pl in playlists]
+                 "image": _pl_image(pl), "owned": bool(pl.get("_owned", True)),
+                 "external_url": _external_url(provider_id, "playlist", _pl_id(pl))}
+                for pl in playlists]
+        self._prune_details(provider_id, [row["id"] for row in rows])
         return sorted(rows, key=lambda r: (r["name"] or "").casefold())
+
+    def detail(self, provider_id, playlist_id, *, refresh=False, expected_count=None):
+        cached = self._cached_detail(provider_id, playlist_id)
+        if (
+            cached is not None
+            and not refresh
+            and (expected_count is None or cached["count"] == expected_count)
+        ):
+            return cached
+        if provider_id == "jellyfin":
+            raise PlaylistReadOnlyError(
+                "Jellyfin playlist tracks are managed in Jellyfin. Open the service to edit them."
+            )
+        target = self._target(provider_id)
+        try:
+            playlist = target.find_playlist(str(playlist_id))
+            if playlist is None:
+                self._invalidate_detail(provider_id, playlist_id)
+                raise PlaylistNotFoundError(
+                    f"That {_PROVIDER_NAMES.get(provider_id, provider_id)} playlist no longer exists. Refresh Browse."
+                )
+            tracks = target.playlist_tracks(playlist)
+        except PlaylistServiceError:
+            raise
+        except Exception as exc:
+            self._failure(provider_id, "open that playlist", exc)
+
+        normalized = []
+        occurrence_id_getter = getattr(target, "occurrence_id", lambda track: None)
+        for position, track in enumerate(tracks):
+            track_id = target.track_id(track)
+            if track_id is None:
+                continue
+            normalized.append({
+                "position": position,
+                "id": str(track_id),
+                "isrc": str(track.get("isrc") or ""),
+                "occurrence_id": str(occurrence_id_getter(track) or ""),
+                "name": str(track.get("name") or track.get("title") or "Unknown track"),
+                "artist": _track_artist(track),
+                "album": track.get("album") or track.get("albumName"),
+                "duration_ms": track.get("duration_ms") or track.get("durationInMillis"),
+                "image": str(track.get("image") or _pl_image(track) or ""),
+                "added_at": str(
+                    track.get("added_at")
+                    or track.get("addedAt")
+                    or (track.get("attributes") or {}).get("dateAdded")
+                    or ""
+                ),
+                "external_url": _external_url(provider_id, "track", track_id),
+            })
+
+        playlist_id_getter = getattr(target, "playlist_id", _pl_id)
+        playlist_id = str(playlist_id_getter(playlist) or playlist_id)
+        detail = {
+            "provider": provider_id,
+            "id": playlist_id,
+            "name": target.playlist_name(playlist),
+            "description": _plain_text(target.playlist_description(playlist)),
+            "count": len(normalized),
+            "image": _pl_image(playlist),
+            "owned": bool(playlist.get("_owned", True)),
+            "editable": bool(target.is_editable(playlist)),
+            "external_url": _external_url(provider_id, "playlist", playlist_id),
+            "tracks": normalized,
+        }
+        self._cache_detail(detail)
+        return detail
+
+    def remove_track(self, provider_id, playlist_id, *, position, track_id, occurrence_id=""):
+        self.remove_tracks(provider_id, playlist_id, selections=[{
+            "position": position,
+            "track_id": track_id,
+            "occurrence_id": occurrence_id,
+        }])
+        return {"ok": True}
+
+    def remove_tracks(self, provider_id, playlist_id, *, selections):
+        """Remove one or more explicitly selected physical playlist entries.
+
+        Providers with durable occurrence ids can address each selected entry
+        directly. Position-only providers are reread once and every selection
+        is validated before the first mutation, so drift never turns a range
+        selection into deletion of unrelated tracks.
+        """
+        target = self._target(provider_id)
+        try:
+            playlist = target.find_playlist(str(playlist_id))
+            if playlist is None:
+                raise PlaylistNotFoundError(
+                    "That playlist no longer exists. Refresh Browse."
+                )
+            if not target.is_editable(playlist):
+                raise PlaylistReadOnlyError(
+                    "This playlist is read-only on the provider and cannot be edited here."
+                )
+            stable = bool(getattr(target, "stable_occurrence_ids", False))
+            if stable and all(selection.get("occurrence_id") for selection in selections):
+                # Invalidate before the first provider write: a later transient
+                # failure can leave a valid partial result that must be reread.
+                self._invalidate_detail(provider_id, playlist_id)
+                for selection in selections:
+                    target.remove_occurrence(
+                        playlist,
+                        str(selection["track_id"]),
+                        str(selection["occurrence_id"]),
+                    )
+                return {"ok": True, "removed": len(selections)}
+
+            tracks = target.playlist_tracks(playlist)
+            positioned = []
+            for selection in selections:
+                position = int(selection["position"])
+                if position < 0 or position >= len(tracks):
+                    raise PlaylistChangedError(
+                        "The playlist changed since it was opened. Refresh it before editing."
+                    )
+                track = tracks[position]
+                if str(target.track_id(track)) != str(selection["track_id"]):
+                    raise PlaylistChangedError(
+                        "The playlist changed since it was opened. Refresh it before editing."
+                    )
+                positioned.append((position, track))
+            self._invalidate_detail(provider_id, playlist_id)
+            target.remove_occurrences(playlist, positioned)
+            return {"ok": True, "removed": len(positioned)}
+        except PlaylistServiceError:
+            raise
+        except Exception as exc:
+            self._failure(provider_id, "remove the selected tracks", exc)
 
 
 @dataclass

--- a/songmirror/services/settings.py
+++ b/songmirror/services/settings.py
@@ -49,6 +49,11 @@ class SettingsStore:
         self.env_path = str(self._dir / "app.env")
         self._data = self._read()
 
+    @property
+    def data_dir(self):
+        """Persistent application-data directory for sibling service caches."""
+        return self._dir
+
     def _read(self):
         try:
             with open(self._json, encoding="utf-8") as f:

--- a/songmirror/services/sync_service.py
+++ b/songmirror/services/sync_service.py
@@ -60,6 +60,7 @@ class SyncService:
         opts.execute = execute
         opts.sync_mode = job.mode
         opts.sync_source = job.source
+        opts.authorities = job.authorities
         opts.providers = job.providers
         opts.playlists = job.playlists
         opts.max_adds = job.max_adds

--- a/songmirror/services/syncs.py
+++ b/songmirror/services/syncs.py
@@ -33,8 +33,9 @@ LEGACY_NAMED_JOB_PROVIDERS = "spotify,apple,ytmusic"
 class SyncJob:
     name: str = "Sync"
     enabled: bool = True                      # participates in scheduled auto-sync
-    mode: str = DEFAULT_SYNC_MODE             # oneway | nway
-    source: str = DEFAULT_SYNC_SOURCE         # one-way source of truth
+    mode: str = DEFAULT_SYNC_MODE             # oneway | group | nway
+    source: str = DEFAULT_SYNC_SOURCE         # one-way source / group order authority
+    authorities: str = ""                    # group membership authorities, comma-separated
     providers: str = DEFAULT_PROVIDERS        # comma-separated participating providers
     playlists: str = ""                       # comma-separated names (empty = every same-named pair)
     interval: str = DEFAULT_INTERVAL          # this job's own auto-sync cadence
@@ -43,6 +44,43 @@ class SyncJob:
     apply_large_removals: bool = False        # drain removals over max_removals across passes (default: hold back)
     download: bool = False                    # opt into the global download mirror
     id: str = ""
+
+
+VALID_SYNC_MODES = {"oneway", "group", "nway"}
+
+
+def _provider_ids(value):
+    return {part.strip() for part in str(value or "").split(",") if part.strip()}
+
+
+def validate_sync_job(job):
+    """Reject configurations whose direction cannot be reconciled safely.
+
+    Existing one-way and N-way jobs do not need an ``authorities`` value. An
+    authoritative group does: every authority must participate, and the
+    provider whose playlist supplies names/order must itself be authoritative.
+    """
+    if job.mode not in VALID_SYNC_MODES:
+        raise ValueError(f"mode must be one of: {', '.join(sorted(VALID_SYNC_MODES))}")
+    if job.max_adds < 1:
+        raise ValueError("max_adds must be at least 1")
+    if job.max_removals < 0:
+        raise ValueError("max_removals must be at least 0")
+    if job.mode != "group":
+        return job
+
+    providers = _provider_ids(job.providers)
+    authorities = _provider_ids(job.authorities)
+    if len(authorities) < 2:
+        raise ValueError("an authoritative group needs at least two authorities")
+    if job.source not in authorities:
+        raise ValueError("the order authority must belong to the authoritative group")
+    missing = authorities - providers
+    if missing:
+        raise ValueError(
+            "every authority must be a selected provider; missing: " + ", ".join(sorted(missing))
+        )
+    return job
 
 
 class SyncStore:
@@ -70,6 +108,7 @@ class SyncStore:
         return next((j for j in self.list() if j.id == job_id), None)
 
     def upsert(self, job):
+        validate_sync_job(job)
         if not job.id:
             job.id = uuid.uuid4().hex[:8]
         jobs = [j for j in self.list() if j.id != job.id]

--- a/songmirror/web/routers/playlists.py
+++ b/songmirror/web/routers/playlists.py
@@ -2,16 +2,113 @@
 
 from dataclasses import asdict
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 
-from ...services.playlists import PlaylistLink, PlaylistService
+from ...services.playlists import (
+    PlaylistLink, PlaylistService, PlaylistServiceError,
+)
 
 router = APIRouter()
 
 
 @router.get("/api/playlists")
 def playlists(request: Request, provider: str):
-    return PlaylistService(request.app.state.settings).browse(provider)
+    try:
+        return PlaylistService(request.app.state.settings).browse(provider)
+    except PlaylistServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
+@router.get("/api/playlists/{provider}/{playlist_id}")
+def playlist_detail(
+    request: Request,
+    provider: str,
+    playlist_id: str,
+    refresh: bool = False,
+    expected_count: int | None = None,
+):
+    try:
+        return PlaylistService(request.app.state.settings).detail(
+            provider,
+            playlist_id,
+            refresh=refresh,
+            expected_count=expected_count,
+        )
+    except PlaylistServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
+@router.delete("/api/playlists/{provider}/{playlist_id}/tracks")
+async def remove_playlist_track(
+    request: Request,
+    provider: str,
+    playlist_id: str,
+    body: dict = Body(...),
+):
+    raw_tracks = body.get("tracks")
+    if raw_tracks is not None:
+        if not isinstance(raw_tracks, list) or not raw_tracks or len(raw_tracks) > 1000:
+            raise HTTPException(
+                status_code=422,
+                detail="tracks must contain between 1 and 1000 selections",
+            )
+        selections = []
+        seen = set()
+        try:
+            for raw in raw_tracks:
+                position = int(raw["position"])
+                track_id = str(raw["track_id"])
+                occurrence_id = str(raw.get("occurrence_id") or "")
+                if position < 0 or not track_id:
+                    raise ValueError
+                key = (position, track_id, occurrence_id)
+                if key not in seen:
+                    seen.add(key)
+                    selections.append({
+                        "position": position,
+                        "track_id": track_id,
+                        "occurrence_id": occurrence_id,
+                    })
+        except (KeyError, TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=422,
+                detail="every selected track needs a non-negative position and track_id",
+            ) from exc
+
+        service = PlaylistService(request.app.state.settings)
+        try:
+            return await request.app.state.sync.run_exclusive(
+                lambda: service.remove_tracks(
+                    provider,
+                    playlist_id,
+                    selections=selections,
+                )
+            )
+        except PlaylistServiceError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+    try:
+        position = int(body["position"])
+        track_id = str(body["track_id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="position and track_id are required",
+        ) from exc
+
+    service = PlaylistService(request.app.state.settings)
+    try:
+        return await request.app.state.sync.run_exclusive(
+            lambda: service.remove_track(
+                provider,
+                playlist_id,
+                position=position,
+                track_id=track_id,
+                occurrence_id=str(body.get("occurrence_id") or ""),
+            )
+        )
+    except PlaylistServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 @router.get("/api/links")

--- a/songmirror/web/routers/syncs.py
+++ b/songmirror/web/routers/syncs.py
@@ -7,14 +7,14 @@ stay in step with the store.
 import asyncio
 from dataclasses import asdict
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from ...services.syncs import SyncJob
+from ...services.syncs import SyncJob, validate_sync_job
 
 router = APIRouter()
 
-_FIELDS = {"name", "enabled", "mode", "source", "providers", "playlists",
+_FIELDS = {"name", "enabled", "mode", "source", "authorities", "providers", "playlists",
            "interval", "max_adds", "max_removals", "apply_large_removals", "download", "id"}
 
 
@@ -27,7 +27,10 @@ def _job_from(values):
     for k in ("enabled", "download", "apply_large_removals"):
         if k in data:
             data[k] = bool(data[k])
-    return SyncJob(**data)
+    try:
+        return validate_sync_job(SyncJob(**data))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.get("/api/syncs")

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -70,6 +70,50 @@ def test_compute_diff_preserves_playlist_position_without_timestamps():
     assert [track["name"] for track in to_add] == ["First", "Second", "Third"]
 
 
+def test_fuzzy_match_rejects_a_different_creative_version():
+    assert not accepts(
+        "Post Break-Up Sex",
+        ["The Vaccines"],
+        174000,
+        "Post Break-Up Sex (Live in Brighton)",
+        "The Vaccines",
+        174000,
+    )
+    assert not accepts(
+        "Runaway",
+        ["AURORA"],
+        243000,
+        "Runaway (Acoustic)",
+        "AURORA",
+        243000,
+    )
+    assert accepts(
+        "Runaway - Piano Version",
+        ["AURORA"],
+        243000,
+        "Runaway (Piano)",
+        "AURORA",
+        243500,
+    )
+
+
+def test_diff_replaces_a_wrong_live_variant_instead_of_fuzzy_protecting_it():
+    source = [sp("Post Break-Up Sex", "The Vaccines", None, "", dur=174000)]
+    live = ap(
+        "Post Break-Up Sex (Live in Brighton)",
+        "The Vaccines",
+        "live-id",
+    )
+    live["duration_ms"] = 174000
+
+    to_add, to_remove = compute_diff(source, [live], {}, cid_of)
+    safe, held = protect_removals(to_remove, source)
+
+    assert to_add == source
+    assert safe == [live]
+    assert held == []
+
+
 def run():
     assert parse_interval("900") == 900 and parse_interval("15m") == 900 and parse_interval("1h") == 3600
 

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -23,7 +23,20 @@ def test_tidal_jsonapi_track_shape_carries_isrc_artist_and_entry_id():
                 },
             },
             {"type": "artists", "id": "a1", "attributes": {"name": "Artist"}},
-            {"type": "albums", "id": "al1", "attributes": {"title": "Album"}},
+            {
+                "type": "albums",
+                "id": "al1",
+                "attributes": {"title": "Album"},
+                "relationships": {"coverArt": {"data": [{"type": "artworks", "id": "art1"}]}},
+            },
+            {
+                "type": "artworks",
+                "id": "art1",
+                "attributes": {"files": [
+                    {"href": "https://tidal/1280.jpg", "meta": {"width": 1280}},
+                    {"href": "https://tidal/160.jpg", "meta": {"width": 160}},
+                ]},
+            },
         ],
     }
     track = TidalTarget._tracks_from_body(body)[0]
@@ -34,6 +47,7 @@ def test_tidal_jsonapi_track_shape_carries_isrc_artist_and_entry_id():
         "artist": "Artist",
         "artists": ["Artist"],
         "album": "Album",
+        "image": "https://tidal/160.jpg",
         "duration_ms": 182500,
         "isrc": "USAAA2600001",
         "added_at": "2026-01-01",
@@ -416,12 +430,16 @@ def test_deezer_track_shape_and_browser_header_minimization(tmp_path, monkeypatc
             "duration": 123,
             "isrc": "FRCCC2600003",
             "contributors": [{"name": "One"}, {"name": "Two"}],
-            "album": {"title": "World"},
+            "album": {
+                "title": "World",
+                "cover": {"urls": ["https://deezer/64.jpg", "https://deezer/128.jpg"]},
+            },
         }
     )
     assert (track["id"], track["artist"], track["duration_ms"], track["isrc"]) == (
         "12", "One, Two", 123000, "FRCCC2600003"
     )
+    assert track["image"] == "https://deezer/128.jpg"
 
     monkeypatch.setenv("DEEZER_WEB_HEADERS", "")
     monkeypatch.setenv("DEEZER_REFRESH_TOKEN", "")
@@ -908,6 +926,10 @@ def test_amazon_web_backend_maps_playlists_tracks_and_mutations():
                                         "title": "Song",
                                         "isrc": "USWEB2600001",
                                         "duration": 202,
+                                        "images": [
+                                            {"url": "https://amazon/160.jpg", "width": 160},
+                                            {"url": "https://amazon/1280.jpg", "width": 1280},
+                                        ],
                                         "album": {"title": "Album"},
                                         "contributingArtists": {
                                             "edges": [{"node": {"name": "Artist"}, "role": "PRIMARY"}]
@@ -930,6 +952,7 @@ def test_amazon_web_backend_maps_playlists_tracks_and_mutations():
     assert (track["relationship_id"], track["artist"], track["album"], track["isrc"]) == (
         "entry-1", "Artist", "Album", "USWEB2600001"
     )
+    assert track["image"] == "https://amazon/160.jpg"
     target.add(playlist, ["asin-1", "asin-2"])
     append_calls = [variables for operation, variables, _ in target._web.calls
                     if operation == "SongMirrorAmazonAppendTracks"]

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -1,5 +1,7 @@
 """build_one registry helper + PlaylistService."""
 
+import pytest
+
 from songmirror.engine import targets
 from songmirror.engine.config import parse_args
 
@@ -12,6 +14,16 @@ def test_build_one_known_dispatches(monkeypatch):
     sentinel = object()
     monkeypatch.setitem(targets._REGISTRY, "spotify", lambda o, sp: sentinel)
     assert targets.build_one("spotify", parse_args([])) is sentinel
+
+
+def test_find_playlist_normalizes_numeric_provider_ids():
+    from songmirror.engine.targets.base import MirrorTarget
+
+    class Target(MirrorTarget):
+        def browse_playlists(self):
+            return [{"id": 68684835, "name": "Argonaut"}]
+
+    assert Target().find_playlist("68684835")["name"] == "Argonaut"
 
 
 def test_is_peer_excludes_browse_only():
@@ -72,7 +84,14 @@ def test_browse_normalizes_rows(monkeypatch, tmp_path):
 
     monkeypatch.setattr("songmirror.services.playlists.build_one", lambda pid, opts, sp=None: FakeTarget())
     rows = PlaylistService(SettingsStore(dir=tmp_path)).browse("apple")
-    assert rows == [{"id": "1", "name": "Chill", "count": 5, "image": "", "owned": True}]
+    assert rows == [{
+        "id": "1",
+        "name": "Chill",
+        "count": 5,
+        "image": "",
+        "owned": True,
+        "external_url": "https://music.apple.com/library/playlist/1",
+    }]
 
 
 def test_browse_hydrates_counts_before_normalizing_rows(monkeypatch, tmp_path):
@@ -112,6 +131,347 @@ def test_browse_lists_followed_spotify_playlists(monkeypatch, tmp_path):
     )
     rows = PlaylistService(SettingsStore(dir=tmp_path)).browse("spotify")
     assert {r["name"]: r["owned"] for r in rows} == {"Mine": True, "Theirs": False}
+
+
+def test_browse_failure_is_not_reported_as_an_empty_library(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistBrowseError, PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    class BrokenTarget:
+        name = "Spotify"
+
+        def browse_playlists(self):
+            raise RuntimeError("temporary upstream failure")
+
+    monkeypatch.setattr(
+        "songmirror.services.playlists.build_one",
+        lambda provider, opts, sp=None: BrokenTarget(),
+    )
+    monkeypatch.setattr("songmirror.services.playlists.spotify.client", lambda: object())
+
+    with pytest.raises(PlaylistBrowseError, match="could not load playlists"):
+        PlaylistService(SettingsStore(dir=tmp_path)).browse("spotify")
+
+
+def test_playlist_detail_normalizes_tracks_and_external_links(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    class Target:
+        name = "Spotify"
+
+        def find_playlist(self, playlist_id):
+            assert playlist_id == "playlist-1"
+            return {
+                "id": playlist_id,
+                "name": "Aurora",
+                "images": [{"url": "https://img.test/aurora.jpg"}],
+                "_owned": True,
+            }
+
+        def playlist_tracks(self, playlist):
+            return [{
+                "id": "track-1",
+                "name": "Song",
+                "artists": ["Artist", "Guest"],
+                "album": "Album",
+                "duration_ms": 183000,
+                "image": "https://img.test/song.jpg",
+                "added_at": "2026-08-15T12:34:56Z",
+            }]
+
+        def track_id(self, track):
+            return track["id"]
+
+        def playlist_count(self, playlist):
+            return 1
+
+        def playlist_name(self, playlist):
+            return playlist["name"]
+
+        def playlist_description(self, playlist):
+            return 'A description with <a href="spotify:playlist:other">another mix</a>.'
+
+        def is_editable(self, playlist):
+            return True
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    detail = service.detail("spotify", "playlist-1")
+
+    assert detail == {
+        "provider": "spotify",
+        "id": "playlist-1",
+        "name": "Aurora",
+        "description": "A description with another mix.",
+        "count": 1,
+        "image": "https://img.test/aurora.jpg",
+        "owned": True,
+        "editable": True,
+        "external_url": "https://open.spotify.com/playlist/playlist-1",
+        "tracks": [{
+            "position": 0,
+            "id": "track-1",
+            "isrc": "",
+            "occurrence_id": "",
+            "name": "Song",
+            "artist": "Artist, Guest",
+            "album": "Album",
+            "duration_ms": 183000,
+            "image": "https://img.test/song.jpg",
+            "added_at": "2026-08-15T12:34:56Z",
+            "external_url": "https://open.spotify.com/track/track-1",
+        }],
+    }
+
+
+def test_playlist_detail_cache_is_ordered_persistent_and_archives_songs(tmp_path):
+    from songmirror.engine import archive
+
+    conn = archive.connect(str(tmp_path / "songs.db"))
+    detail = {
+        "provider": "deezer",
+        "id": "playlist-1",
+        "name": "Argonaut",
+        "description": "Mirror",
+        "count": 2,
+        "image": "https://img.test/playlist.jpg",
+        "owned": True,
+        "editable": True,
+        "external_url": "https://www.deezer.com/playlist/playlist-1",
+        "tracks": [
+            {
+                "position": 0,
+                "id": "track-1",
+                "isrc": "USAAA2600001",
+                "occurrence_id": "",
+                "name": "First",
+                "artist": "Artist",
+                "album": "Album",
+                "duration_ms": 180000,
+                "image": "https://img.test/first.jpg",
+                "added_at": "",
+                "external_url": "https://www.deezer.com/track/track-1",
+            },
+            {
+                "position": 1,
+                "id": "track-2",
+                "isrc": "",
+                "occurrence_id": "entry-2",
+                "name": "Second",
+                "artist": "Artist",
+                "album": None,
+                "duration_ms": None,
+                "image": "",
+                "added_at": "2026-08-16T12:00:00Z",
+                "external_url": "https://www.deezer.com/track/track-2",
+            },
+        ],
+    }
+
+    archive.set_playlist_detail_cache(conn, detail)
+
+    assert archive.get_playlist_detail_cache(conn, "deezer", "playlist-1") == detail
+    assert conn.execute(
+        "SELECT name, isrc FROM songs WHERE source = 'deezer' ORDER BY id"
+    ).fetchall() == [("First", "USAAA2600001"), ("Second", "")]
+
+    archive.invalidate_playlist_detail_cache(conn, "deezer", "playlist-1")
+    assert archive.get_playlist_detail_cache(conn, "deezer", "playlist-1") is None
+
+
+def test_playlist_detail_reuses_cache_until_explicit_refresh(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    reads = []
+
+    class Target:
+        def find_playlist(self, playlist_id):
+            return {"id": playlist_id, "name": "Aurora"}
+
+        def playlist_tracks(self, playlist):
+            reads.append(playlist["id"])
+            return [{"id": "track-1", "name": f"Read {len(reads)}", "artist": "Artist"}]
+
+        def track_id(self, track):
+            return track["id"]
+
+        def playlist_id(self, playlist):
+            return playlist["id"]
+
+        def playlist_name(self, playlist):
+            return playlist["name"]
+
+        def playlist_description(self, playlist):
+            return ""
+
+        def is_editable(self, playlist):
+            return True
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    first = service.detail("spotify", "playlist-1")
+    cached = service.detail("spotify", "playlist-1")
+    refreshed = service.detail("spotify", "playlist-1", refresh=True)
+
+    assert first["tracks"][0]["name"] == "Read 1"
+    assert cached["tracks"][0]["name"] == "Read 1"
+    assert refreshed["tracks"][0]["name"] == "Read 2"
+    assert reads == ["playlist-1", "playlist-1"]
+
+
+def test_browse_prunes_cache_for_a_deleted_or_recreated_playlist(monkeypatch, tmp_path):
+    from songmirror.engine import archive
+    from songmirror.services.playlists import PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    conn = archive.connect(str(tmp_path / "song_cache.db"))
+    archive.set_playlist_detail_cache(conn, {
+        "provider": "apple",
+        "id": "deleted-id",
+        "name": "Aurora",
+        "description": "",
+        "image": "",
+        "owned": True,
+        "editable": True,
+        "external_url": "",
+        "tracks": [],
+    })
+    conn.close()
+
+    class Target:
+        def browse_playlists(self):
+            return [{"id": "replacement-id", "attributes": {"name": "Aurora"}}]
+
+        def playlist_count(self, playlist):
+            return None
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    assert service.browse("apple")[0]["id"] == "replacement-id"
+    conn = archive.connect(str(tmp_path / "song_cache.db"))
+    assert archive.get_playlist_detail_cache(conn, "apple", "deleted-id") is None
+    conn.close()
+
+
+def test_remove_track_checks_the_read_position_before_mutating(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistChangedError, PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    removed = []
+
+    class Target:
+        name = "Spotify"
+
+        def find_playlist(self, playlist_id):
+            return {"id": playlist_id, "name": "Aurora", "_editable": True}
+
+        def playlist_tracks(self, playlist):
+            return [{"id": "first", "name": "First"}, {"id": "second", "name": "Second"}]
+
+        def track_id(self, track):
+            return track["id"]
+
+        def is_editable(self, playlist):
+            return True
+
+        def remove_occurrences(self, playlist, positioned):
+            removed.extend(positioned)
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    with pytest.raises(PlaylistChangedError, match="changed since it was opened"):
+        service.remove_track("spotify", "playlist-1", position=1, track_id="stale")
+    assert removed == []
+
+    result = service.remove_track(
+        "spotify", "playlist-1", position=1, track_id="second"
+    )
+    assert result == {"ok": True}
+    assert removed == [(1, {"id": "second", "name": "Second"})]
+
+
+def test_remove_track_uses_stable_occurrence_without_full_reread(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    removed = []
+
+    class Target:
+        stable_occurrence_ids = True
+
+        def find_playlist(self, playlist_id):
+            return {"id": playlist_id, "name": "Argonaut"}
+
+        def is_editable(self, playlist):
+            return True
+
+        def playlist_tracks(self, playlist):
+            raise AssertionError("stable occurrence removal must not reread every track")
+
+        def remove_occurrence(self, playlist, track_id, occurrence_id):
+            removed.append((playlist["id"], track_id, occurrence_id))
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    result = service.remove_track(
+        "tidal",
+        "playlist-1",
+        position=271,
+        track_id="track-1",
+        occurrence_id="entry-271",
+    )
+
+    assert result == {"ok": True}
+    assert removed == [("playlist-1", "track-1", "entry-271")]
+
+
+def test_bulk_remove_validates_every_position_before_mutating(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistChangedError, PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    removed = []
+
+    class Target:
+        stable_occurrence_ids = False
+
+        def find_playlist(self, playlist_id):
+            return {"id": playlist_id, "name": "Aurora"}
+
+        def is_editable(self, playlist):
+            return True
+
+        def playlist_tracks(self, playlist):
+            return [{"id": "first"}, {"id": "second"}, {"id": "third"}]
+
+        def track_id(self, track):
+            return track["id"]
+
+        def remove_occurrences(self, playlist, positioned):
+            removed.extend(positioned)
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    with pytest.raises(PlaylistChangedError, match="changed since it was opened"):
+        service.remove_tracks("spotify", "playlist-1", selections=[
+            {"position": 0, "track_id": "first", "occurrence_id": ""},
+            {"position": 2, "track_id": "stale", "occurrence_id": ""},
+        ])
+    assert removed == []
+
+    result = service.remove_tracks("spotify", "playlist-1", selections=[
+        {"position": 0, "track_id": "first", "occurrence_id": ""},
+        {"position": 2, "track_id": "third", "occurrence_id": ""},
+    ])
+    assert result == {"ok": True, "removed": 2}
+    assert removed == [(0, {"id": "first"}), (2, {"id": "third"})]
 
 
 def test_track_total_reads_both_shapes():

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -195,6 +195,61 @@ def test_adds_and_removes_always_disjoint():
         assert not (add_ids & rem_ids), f"{src}: add/remove overlap"
 
 
+def test_authoritative_group_ignores_mirror_additions_and_repairs_mirror_deletions():
+    prev = {
+        "spotify": {"a", "b"},
+        "apple": {"a", "b"},
+        "ytmusic": {"a", "b"},
+    }
+    cur = {
+        "spotify": {"a", "b"},
+        "apple": {"a", "b"},
+        "ytmusic": {"a", "mirror-only"},
+    }
+
+    desired, plan = _merge(prev, cur, set(), {"spotify", "apple"})
+
+    assert desired == {"a", "b"}
+    assert plan["spotify"] == (set(), set())
+    assert plan["apple"] == (set(), set())
+    assert plan["ytmusic"] == ({"b"}, {"mirror-only"})
+
+
+def test_authoritative_group_accepts_additions_from_either_authority():
+    prev = {"spotify": {"a"}, "apple": {"a"}, "tidal": {"a"}}
+    cur = {
+        "spotify": {"a", "from-spotify"},
+        "apple": {"a", "from-apple"},
+        "tidal": {"a"},
+    }
+
+    desired, plan = _merge(prev, cur, set(), {"spotify", "apple"})
+
+    assert desired == {"a", "from-spotify", "from-apple"}
+    assert plan["spotify"][0] == {"from-apple"}
+    assert plan["apple"][0] == {"from-spotify"}
+    assert plan["tidal"][0] == {"from-spotify", "from-apple"}
+
+
+def test_authoritative_group_removal_does_not_need_a_mirror_vote():
+    prev = {
+        "spotify": {"a", "removed"},
+        "apple": {"a", "removed"},
+        "deezer": {"a", "removed"},
+    }
+    cur = {
+        "spotify": {"a"},
+        "apple": {"a", "removed"},
+        "deezer": {"a", "removed", "mirror-only"},
+    }
+
+    desired, plan = _merge(prev, cur, set(), {"spotify", "apple"})
+
+    assert desired == {"a"}
+    assert plan["apple"][1] == {"removed"}
+    assert plan["deezer"][1] == {"removed", "mirror-only"}
+
+
 # --- archive: the per-provider persistence helpers ---------------------------
 def test_playlist_state_roundtrip_per_source():
     conn = archive.connect(os.path.join(tempfile.mkdtemp(), "s.db"))
@@ -234,6 +289,32 @@ def test_existing_nonempty_baseline_is_marked_initialized_on_connect(tmp_path):
 
     assert archive.has_playlist_state(conn, "mix", "spotify")
     assert archive.get_playlist_state(conn, "mix", "spotify") == {"i:A"}
+    conn.close()
+
+
+def test_playlist_state_meta_migrates_and_preserves_physical_id(tmp_path):
+    path = str(tmp_path / "physical-id-migration.db")
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE playlist_state_meta ("
+        "playlist TEXT NOT NULL, source TEXT NOT NULL, initialized_at TEXT NOT NULL, "
+        "PRIMARY KEY (playlist, source))"
+    )
+    conn.commit()
+    conn.close()
+
+    conn = archive.connect(path)
+    assert "physical_playlist_id" in {
+        row[1] for row in conn.execute("PRAGMA table_info(playlist_state_meta)")
+    }
+    archive.commit_reconcile_membership(
+        conn, "mix", {"apple": {"i:A"}}, {"apple": set()},
+        {"apple": "apple-playlist-v1"},
+    )
+    assert archive.get_playlist_physical_id(conn, "mix", "apple") == "apple-playlist-v1"
+
+    archive.set_reconcile_identities(conn, "mix", {"apple": {"i:A"}}, {})
+    assert archive.get_playlist_physical_id(conn, "mix", "apple") == "apple-playlist-v1"
     conn.close()
 
 
@@ -434,6 +515,124 @@ def test_reconcile_saves_baseline_when_only_adds_deferred(tmp_path):
                       _caches("spotify", "apple"), conn, execute=True, max_removals=25, max_adds=1)
     assert stats["deferred"] >= 1 and stats["clean"] is False   # add backlog deferred
     assert archive.get_playlist_state(conn, "mix", "spotify") == {"i:A", "i:B", "i:C"}  # baseline still saved
+    conn.close()
+
+
+def test_authoritative_group_bootstrap_is_scoped_and_non_destructive(tmp_path):
+    conn = archive.connect(str(tmp_path / "group-baseline.db"))
+    spotify = _P("spotify", ["A", "SPOTIFY"])
+    apple = _P("apple", ["A", "APPLE"])
+    mirror = _P("ytmusic", ["A", "MIRROR_ONLY"])
+    peers = [spotify, apple, mirror]
+    playlists = {p.source: {"id": p.source} for p in peers}
+    caches = _caches(*(p.source for p in peers))
+    kwargs = dict(
+        execute=True, max_removals=25, max_adds=200,
+        authority_sources={"spotify", "apple"},
+    )
+
+    first = reconcile(peers, "Mix", playlists, caches, conn, **kwargs)
+
+    assert first["clean"] is False
+    assert first["removed"] == 0
+    assert first["removals_skipped"] == 1
+    assert "authority_baseline" in {d["category"] for d in first["change_diagnostics"]}
+    assert spotify.added == ["APPLE"]
+    assert apple.added == ["SPOTIFY"]
+    assert set(mirror.added) == {"APPLE", "SPOTIFY"}
+    assert mirror.removed == []
+    key = "group:apple,spotify:mix"
+    assert archive.has_playlist_state(conn, key, "spotify")
+    assert not archive.has_playlist_state(conn, "mix", "spotify")
+
+    second = reconcile(peers, "Mix", playlists, caches, conn, **kwargs)
+
+    assert second["removed"] == 1
+    assert mirror.removed == ["MIRROR_ONLY"]
+    assert "MIRROR_ONLY" not in spotify.added
+    assert "MIRROR_ONLY" not in apple.added
+    conn.close()
+
+
+def test_authoritative_group_recognizes_a_same_name_recreated_playlist(tmp_path):
+    conn = archive.connect(str(tmp_path / "group-recreated.db"))
+    key = "group:apple,spotify:aurora"
+    baseline = {"i:A", "i:B", "i:C"}
+    archive.commit_reconcile_membership(
+        conn,
+        key,
+        {"spotify": baseline, "apple": baseline},
+        {"spotify": set(), "apple": set()},
+        {"spotify": "spotify-aurora", "apple": "deleted-apple-aurora"},
+    )
+    spotify = _P("spotify", ["A", "B", "C"])
+    apple = _P("apple", ["A"])
+
+    stats = reconcile(
+        [spotify, apple],
+        "Aurora",
+        {
+            "spotify": {"id": "spotify-aurora"},
+            "apple": {"id": "replacement-apple-aurora"},
+        },
+        _caches("spotify", "apple"),
+        conn,
+        execute=True,
+        max_removals=25,
+        max_adds=200,
+        authority_sources={"spotify", "apple"},
+    )
+
+    assert stats["read_anomalies"] == 0
+    assert stats["removed"] == 0
+    assert apple.added == ["B", "C"]
+    assert {d["category"] for d in stats["change_diagnostics"]} >= {
+        "playlist_recreated", "authority_baseline",
+    }
+    assert archive.get_playlist_physical_id(conn, key, "apple") == "replacement-apple-aurora"
+    conn.close()
+
+
+def test_reconcile_does_not_search_for_blank_catalog_entries(tmp_path):
+    """Provider tombstones/placeholder rows must never become empty searches."""
+
+    class BlankAuthority(_P):
+        def playlist_tracks(self, pl):
+            return [{
+                "id": "blank-row",
+                "name": "",
+                "artists": [],
+                "artist": "",
+                "duration_ms": 0,
+                "isrc": None,
+                "added_at": "2020",
+            }]
+
+    class QueryRecordingMirror(_P):
+        def __init__(self):
+            super().__init__("tidal", [])
+            self.resolve_queries = []
+
+        def resolve(self, norm, cache):
+            self.resolve_queries.append((norm["name"], norm["artist"]))
+            return None, None
+
+    conn = archive.connect(str(tmp_path / "blank-catalog-entry.db"))
+    authority = BlankAuthority("spotify", [])
+    mirror = QueryRecordingMirror()
+
+    reconcile(
+        [authority, mirror],
+        "Mix",
+        {"spotify": {"id": "s"}, "tidal": {"id": "t"}},
+        _caches("spotify", "tidal"),
+        conn,
+        execute=False,
+        max_removals=25,
+        max_adds=200,
+    )
+
+    assert mirror.resolve_queries == []
     conn.close()
 
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -10,7 +10,7 @@ import pytest
 
 from songmirror.engine import archive
 from songmirror.engine.matching import spotify_track_keys, track_key
-from songmirror.engine.targets.base import _entry_cids, _merge, reconcile
+from songmirror.engine.targets.base import TargetTransientError, _entry_cids, _merge, reconcile
 
 
 # --- merge: the safety-critical set logic (per-provider prev + cur) ----------
@@ -477,6 +477,38 @@ def test_reconcile_adds_in_origin_playlist_order_even_if_plan_set_is_scrambled(t
     )
 
     assert apple.added == ["A", "B", "C"]
+    conn.close()
+
+
+def test_reconcile_stops_ordered_adds_at_a_transient_resolution_error(tmp_path):
+    """A later song must not leapfrog a rate-limited earlier source entry."""
+
+    class RateLimitedPeer(_P):
+        def resolve(self, norm, cache):
+            if norm["isrc"] == "B":
+                raise TargetTransientError("catalog search returned 429", retry_after=10)
+            return super().resolve(norm, cache)
+
+    conn = archive.connect(str(tmp_path / "rate-limited-order.db"))
+    for source in ("spotify", "apple"):
+        archive.set_playlist_state(conn, "mix", source, set())
+    spotify = _P("spotify", ["A", "B", "C"])
+    apple = RateLimitedPeer("apple", [])
+
+    stats = reconcile(
+        [spotify, apple],
+        "Mix",
+        {"spotify": {"id": "s"}, "apple": {"id": "a"}},
+        _caches("spotify", "apple"),
+        conn,
+        execute=True,
+        max_removals=0,
+        max_adds=200,
+    )
+
+    assert apple.added == ["A"]
+    assert stats["deferred"] == 2
+    assert stats["clean"] is False
     conn.close()
 
 

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -191,6 +191,37 @@ def test_nway_wraps_accumulated_summary(monkeypatch):
     assert s["per_target"][0]["skipped"] == 0  # defaulted keys always present
 
 
+def test_authoritative_group_routes_with_writable_spotify(monkeypatch):
+    writable_requests = []
+    monkeypatch.setattr(
+        runner.spotify, "client",
+        lambda writable=False: writable_requests.append(writable) or object(),
+    )
+    monkeypatch.setattr(runner, "build_one", lambda *args, **kwargs: type("Source", (), {
+        "source": "spotify", "name": "Spotify", "list_playlists": lambda self: {},
+    })())
+    monkeypatch.setattr(runner.archive, "connect", lambda f: _FakeSongs())
+    monkeypatch.setattr(runner, "_post_sync", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner, "_run_authoritative_group",
+        lambda opts, sp, selected, songs, should_continue=None: [
+            runner._summary_entry("Authoritative group", {"added": 2})
+        ],
+    )
+
+    summary = runner.run_pass(_opts(
+        execute=True,
+        sync_mode="group",
+        authorities="spotify,apple",
+        providers="spotify,apple,ytmusic",
+    ))
+
+    assert writable_requests == [True]
+    assert summary["mode"] == "group"
+    assert summary["per_target"][0]["name"] == "Authoritative group"
+    assert summary["per_target"][0]["added"] == 2
+
+
 def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
     from songmirror.engine import archive
     from songmirror.services.playlists import PlaylistLink
@@ -705,6 +736,51 @@ class _RecreatedPeer(_Peer):
 
     def remove(self, playlist, track):
         self._isrcs.remove(track["isrc"])
+
+
+def test_authoritative_group_forwards_only_its_authority_sources(monkeypatch):
+    peers = [_Peer("spotify"), _Peer("apple"), _Peer("ytmusic")]
+    seen = []
+    monkeypatch.setattr(runner, "build_peers", lambda opts, sp, songs=None: peers)
+    monkeypatch.setattr(runner, "load_cache", lambda path: {})
+    monkeypatch.setattr(runner, "save_cache", lambda path, cache: None)
+
+    def capture(*args, **kwargs):
+        seen.append((args[0][0].source, kwargs["authority_sources"]))
+        return {}
+
+    monkeypatch.setattr(runner, "reconcile", capture)
+
+    entry = runner._run_authoritative_group(
+        _opts(
+            sync_mode="group", sync_source="spotify",
+            authorities="spotify,apple", providers="spotify,apple,ytmusic",
+        ),
+        object(), [{"name": "Aurora"}], _FakeSongs(),
+    )[0]
+
+    assert seen == [("spotify", {"spotify", "apple"})]
+    assert entry["name"] == "Authoritative group"
+
+
+def test_authoritative_group_reports_a_disconnected_authority(monkeypatch):
+    monkeypatch.setattr(
+        runner, "build_peers", lambda opts, sp, songs=None: [_Peer("spotify")],
+    )
+
+    entry = runner._run_authoritative_group(
+        _opts(
+            sync_mode="group", sync_source="spotify",
+            authorities="spotify,apple", providers="spotify,apple",
+        ),
+        object(), [], _FakeSongs(),
+    )[0]
+
+    assert entry["failed"] == 1
+    assert entry["failures"] == [{
+        "playlist": "Configuration",
+        "error": "authoritative providers are not connected: apple",
+    }]
 
 
 def test_nway_created_replacement_discards_the_deleted_playlists_baseline(monkeypatch, tmp_path):

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -2,6 +2,7 @@
 
 import threading
 
+from songmirror.engine import archive
 import songmirror.engine.runner as runner
 from songmirror.engine.config import Options
 
@@ -224,7 +225,7 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
                          source_key="spotify", source_name="Spotify", name=None):
         captured["tgt_id"] = tgt_playlist["id"]
         return {"clean": True, "added": 1, "removed": 0, "missing": 0, "held": 0,
-                "deferred": 0, "removals_skipped": 0, "target_count": 1}
+                "deferred": 2, "removals_skipped": 0, "target_count": 1}
 
     monkeypatch.setattr(runner, "mirror_pair", fake_mirror_pair)
 
@@ -235,6 +236,7 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
 
     assert captured["tgt_id"] == "t99"          # paired target used, not same-name match
     assert agg["added"] == 1
+    assert agg["deferred"] == 2
     assert archive.get_state(songs, "LINK1", "apple") is not None  # state keyed by the link id
     songs.close()
 
@@ -319,6 +321,276 @@ def test_mirror_pair_non_spotify_source_never_writes_links(tmp_path):
     songs.close()
 
 
+def test_one_way_mirror_defers_the_ordered_suffix_after_a_transient_resolve(tmp_path):
+    from songmirror.engine.targets.base import TargetTransientError, mirror_pair
+
+    songs = archive.connect(str(tmp_path / "ordered-one-way.db"))
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def track_id(self, track):
+            return track.get("catalog_id")
+
+        def expected_ids(self, tracks, links, cache):
+            return {}
+
+        def prefetch(self, tracks, cache):
+            pass
+
+        def resolve(self, track, cache):
+            if track["name"] == "Middle":
+                raise TargetTransientError("HTTP 429", retry_after=10)
+            return track["name"].casefold(), "search"
+
+        def add(self, playlist, ids):
+            self.added = list(ids)
+
+        def remove(self, playlist, track):
+            pass
+
+    target = Target()
+    source_tracks = [
+        {"id": "a", "name": "Oldest", "artists": ["Artist"], "duration_ms": 1},
+        {"id": "b", "name": "Middle", "artists": ["Artist"], "duration_ms": 1},
+        {"id": "c", "name": "Newest", "artists": ["Artist"], "duration_ms": 1},
+    ]
+
+    stats = mirror_pair(
+        target,
+        source_tracks,
+        {"name": "Aurora"},
+        {"id": "apple-aurora"},
+        {"isrc": {}, "search": {}, "dirty": False},
+        songs,
+        execute=True,
+        max_removals=200,
+        max_adds=200,
+    )
+
+    assert target.added == ["oldest"]
+    assert stats["deferred"] == 2
+    assert stats["clean"] is False
+    songs.close()
+
+
+def test_one_way_unresolved_track_keeps_snapshot_retryable(tmp_path):
+    from songmirror.engine.targets.base import mirror_pair
+
+    songs = archive.connect(str(tmp_path / "unresolved-one-way.db"))
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def track_id(self, track):
+            return track.get("catalog_id")
+
+        def expected_ids(self, tracks, links, cache):
+            return {}
+
+        def prefetch(self, tracks, cache):
+            pass
+
+        def resolve(self, track, cache):
+            return None, None
+
+        def add(self, playlist, ids):
+            raise AssertionError("an unresolved track cannot be added")
+
+        def remove(self, playlist, track):
+            pass
+
+    stats = mirror_pair(
+        Target(),
+        [{"id": "missing", "name": "Missing", "artists": ["Artist"]}],
+        {"name": "Drive"},
+        {"id": "apple-drive"},
+        {"isrc": {}, "search": {}, "dirty": False},
+        songs,
+        execute=True,
+        max_removals=200,
+        max_adds=200,
+    )
+
+    assert stats["missing"] == 1
+    assert stats["clean"] is False
+    songs.close()
+
+
+def test_one_way_reuses_cross_provider_identity_for_a_recreated_playlist(tmp_path):
+    """A deleted destination playlist must not force known songs through search."""
+    from songmirror.engine.targets.base import mirror_pair
+
+    songs = archive.connect(str(tmp_path / "identity-crosswalk.db"))
+    archive.set_identities(songs, "spotify", {"sp-a": "i:ISRC-A"})
+    archive.set_identities(songs, "apple", {"apple-stale": "i:ISRC-A"})
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def track_id(self, track):
+            return track.get("catalog_id")
+
+        def expected_ids(self, tracks, links, cache):
+            return {track["id"]: {links[track["id"]]} for track in tracks if track["id"] in links}
+
+        def prefetch(self, tracks, cache):
+            assert tracks[0]["isrc"] == "ISRCA"
+            cache["isrc"]["ISRCA"] = [{
+                "id": "apple-current", "name": "Known",
+                "artist": "Artist", "duration_ms": 1000,
+            }]
+
+        def validate_link(self, track, target_id, cache):
+            assert target_id == "apple-stale"
+            return cache["isrc"][track["isrc"]][0]["id"], "isrc"
+
+        def resolve(self, track, cache):
+            raise AssertionError("a durable hard-identity crosswalk should avoid catalog search")
+
+        def add(self, playlist, ids):
+            self.added = list(ids)
+
+        def remove(self, playlist, track):
+            pass
+
+    target = Target()
+    source_tracks = [
+        {"id": "sp-a", "name": "Known", "artists": ["Artist"], "duration_ms": 1000},
+    ]
+    stats = mirror_pair(
+        target, source_tracks, {"name": "Aurora"}, {"id": "new-apple-aurora"},
+        {"isrc": {}, "search": {}, "dirty": False}, songs,
+        execute=True, max_removals=200, max_adds=200,
+    )
+
+    assert target.added == ["apple-current"]
+    assert stats["added"] == 1
+    assert archive.get_links(songs, "apple", ["sp-a"]) == {"sp-a": "apple-current"}
+    songs.close()
+
+
+def test_one_way_records_the_catalog_id_that_the_target_actually_added(tmp_path):
+    """A provider may repair an obsolete resolved id during the write itself."""
+    from songmirror.engine.targets.base import mirror_pair
+
+    songs = archive.connect(str(tmp_path / "write-time-repair.db"))
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def track_id(self, track):
+            return track.get("catalog_id")
+
+        def expected_ids(self, tracks, links, cache):
+            return {}
+
+        def prefetch(self, tracks, cache):
+            pass
+
+        def resolve(self, track, cache):
+            return "obsolete", "isrc"
+
+        def add(self, playlist, ids):
+            assert ids == ["obsolete"]
+
+        def added_id(self, target_id):
+            return "current" if target_id == "obsolete" else target_id
+
+        def remove(self, playlist, track):
+            pass
+
+    stats = mirror_pair(
+        Target(),
+        [{
+            "id": "spotify-id",
+            "isrc": "ISRC",
+            "name": "Song",
+            "artists": ["Artist"],
+            "duration_ms": 1000,
+        }],
+        {"name": "Aurora"},
+        {"id": "apple-aurora"},
+        {"isrc": {}, "search": {}, "dirty": False},
+        songs,
+        execute=True,
+        max_removals=200,
+        max_adds=200,
+    )
+
+    assert stats["added"] == 1
+    assert archive.get_links(songs, "apple", ["spotify-id"]) == {
+        "spotify-id": "current"
+    }
+    songs.close()
+
+
+def test_one_way_reuses_a_conservative_archived_recording_match(tmp_path):
+    from songmirror.engine.targets.base import mirror_pair
+
+    songs = archive.connect(str(tmp_path / "recording-history.db"))
+    archive.upsert_many(songs, "apple", [{
+        "catalog_id": "apple-drowning",
+        "name": "Drowning (feat. Kodak Black)",
+        "artist": "A Boogie wit da Hoodie",
+        "duration_ms": 209_269,
+    }])
+    archive.set_links(songs, "apple", {"sp-drowning": "apple-stale"})
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def track_id(self, track):
+            return track.get("catalog_id")
+
+        def expected_ids(self, tracks, links, cache):
+            return {track["id"]: {links[track["id"]]} for track in tracks if track["id"] in links}
+
+        def prefetch(self, tracks, cache):
+            pass
+
+        def resolve(self, track, cache):
+            raise AssertionError("the conservative archive match should avoid throttled search")
+
+        def add(self, playlist, ids):
+            self.added = list(ids)
+
+        def remove(self, playlist, track):
+            pass
+
+    target = Target()
+    source_tracks = [{
+        "id": "sp-drowning",
+        "name": "Drowning (feat. Kodak Black)",
+        "artists": ["A Boogie Wit da Hoodie", "Kodak Black"],
+        "duration_ms": 209_269,
+    }]
+    stats = mirror_pair(
+        target, source_tracks, {"name": "Aurora"}, {"id": "new-apple-aurora"},
+        {"isrc": {}, "search": {}, "dirty": False}, songs,
+        execute=True, max_removals=200, max_adds=200,
+    )
+
+    assert target.added == ["apple-drowning"]
+    assert stats["added"] == 1
+    songs.close()
+
+
 def test_held_removals_name_the_track_playlist_service_and_reason():
     from songmirror.engine.targets.base import held_removals
 
@@ -378,6 +650,87 @@ class _Peer:
 
     def is_editable(self, pl):
         return True
+
+
+class _RecreatedPeer(_Peer):
+    """N-way peer whose membership reflects writes to a newly created playlist."""
+
+    def __init__(self, source, isrcs, *, missing=False):
+        super().__init__(source)
+        self._isrcs = list(isrcs)
+        self._missing = missing
+        self.added = []
+
+    def list_playlists(self):
+        if self._missing:
+            return {}
+        return {"aurora": {"id": f"{self.source}-aurora", "name": "Aurora"}}
+
+    def create(self, playlist):
+        self._missing = False
+        return {"id": f"{self.source}-replacement", "name": playlist["name"]}
+
+    def playlist_tracks(self, playlist):
+        return [
+            {
+                "id": f"{self.source}-{isrc}",
+                "name": f"Song {isrc}",
+                "artists": ["Artist"],
+                "artist": "Artist",
+                "duration_ms": 180_000,
+                "isrc": isrc,
+                "added_at": "2026-01-01",
+            }
+            for isrc in self._isrcs
+        ]
+
+    def track_id(self, track):
+        return track["id"]
+
+    def prefetch(self, tracks, cache):
+        pass
+
+    def native_isrc_map(self, cache):
+        return {}
+
+    def resolve(self, track, cache):
+        return f"{self.source}-{track['isrc']}", "isrc"
+
+    def add(self, playlist, ids):
+        for track_id in ids:
+            isrc = track_id.removeprefix(f"{self.source}-")
+            self.added.append(isrc)
+            if isrc not in self._isrcs:
+                self._isrcs.append(isrc)
+
+    def remove(self, playlist, track):
+        self._isrcs.remove(track["isrc"])
+
+
+def test_nway_created_replacement_discards_the_deleted_playlists_baseline(monkeypatch, tmp_path):
+    songs = archive.connect(str(tmp_path / "songs.db"))
+    for source in ("spotify", "apple"):
+        archive.set_playlist_state(songs, "aurora", source, {"i:A", "i:B"})
+
+    spotify = _RecreatedPeer("spotify", ["A", "B"])
+    apple = _RecreatedPeer("apple", [], missing=True)
+    monkeypatch.setattr(runner, "build_peers", lambda opts, sp, songs=None: [spotify, apple])
+    monkeypatch.setattr(runner, "load_cache", lambda path: {"isrc": {}, "search": {}, "dirty": False})
+    monkeypatch.setattr(runner, "save_cache", lambda path, cache: None)
+
+    runner._run_nway(
+        _opts(sync_mode="nway", execute=True),
+        object(),
+        [{"id": "spotify-aurora", "name": "Aurora"}],
+        songs,
+    )
+
+    assert apple.added == ["A", "B"]
+    # Additions enter the baseline on the next read, after the provider proves
+    # they landed; this pass still marks the replacement as initialized-empty.
+    assert archive.has_playlist_state(songs, "aurora", "apple")
+    assert archive.get_playlist_state(songs, "aurora", "apple") == set()
+    songs.close()
 
 
 def test_nway_counts_and_names_a_playlist_it_could_not_sync(monkeypatch):

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -15,6 +15,22 @@ def _svc(tmp_path, bus):
     return m.SyncService(SettingsStore(dir=tmp_path), bus, store), job.id
 
 
+def test_group_authorities_reach_engine_options(tmp_path):
+    from songmirror.services.sync_service import SyncService
+
+    service = SyncService(SettingsStore(dir=tmp_path), EventBus(), SyncStore(dir=tmp_path))
+    job = SyncJob(
+        name="Group", mode="group", source="spotify",
+        authorities="spotify,apple", providers="spotify,apple,tidal",
+    )
+
+    opts = service._opts_for(job, execute=False)
+
+    assert opts.sync_mode == "group"
+    assert opts.sync_source == "spotify"
+    assert opts.authorities == "spotify,apple"
+
+
 def test_run_job_coalesces(monkeypatch, tmp_path):
     calls = []
 

--- a/tests/test_targets_accessors.py
+++ b/tests/test_targets_accessors.py
@@ -3,7 +3,7 @@
 import pytest
 
 from songmirror.engine.targets.apple import AppleMusicTarget
-from songmirror.engine.targets.base import MirrorTarget
+from songmirror.engine.targets.base import MirrorTarget, TargetTransientError
 from songmirror.engine.targets.ytmusic import YTMusicTarget
 
 
@@ -221,6 +221,343 @@ def test_apple_get_exhausted_5xx_explains_safe_next_pass_retry(monkeypatch):
 
     with pytest.raises(RuntimeError, match=r"after 5 attempts;.*next pass will retry"):
         target._request("GET", "https://amp-api.music.apple.com/v1/me/library/playlists/p1/tracks")
+
+
+def test_apple_add_verifies_an_ambiguous_500_and_keeps_source_order(monkeypatch):
+    """A server error can arrive after Apple committed the singleton append.
+
+    The write queue must prove that outcome before retrying: a blind retry makes
+    a duplicate, while aborting loses the rest of the source-ordered queue.
+    """
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    landed, calls = [], []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        landed.append(catalog_id)
+        if catalog_id == "middle":
+            response = requests.Response()
+            response.status_code = 500
+            raise requests.HTTPError("500 Server Error", response=response)
+        return object()
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: [
+        {"catalog_id": catalog_id} for catalog_id in landed
+    ]
+    target._rebuild_session = lambda: None
+    monkeypatch.setattr(apple, "polite_sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+
+    target.add({"id": "aurora"}, ["oldest", "middle", "newest"])
+
+    assert landed == ["oldest", "middle", "newest"]
+    assert calls == ["oldest", "middle", "newest"]  # no duplicate retry
+
+
+def test_apple_add_waits_and_retries_a_429_without_skipping_a_track(monkeypatch):
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    landed, calls = [], []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        if catalog_id == "middle" and calls.count("middle") == 1:
+            response = requests.Response()
+            response.status_code = 429
+            response.headers["Retry-After"] = "3"
+            raise requests.HTTPError("429 Too Many Requests", response=response)
+        landed.append(catalog_id)
+        return object()
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: [
+        {"catalog_id": catalog_id} for catalog_id in landed
+    ]
+    target._rebuild_session = lambda: None
+    waits = []
+    monkeypatch.setattr(apple, "polite_sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.time, "sleep", waits.append)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+
+    target.add({"id": "aurora"}, ["oldest", "middle", "newest"])
+
+    assert landed == ["oldest", "middle", "newest"]
+    assert calls == ["oldest", "middle", "middle", "newest"]
+    assert waits and waits[0] >= 2.9
+
+
+def test_apple_add_repairs_a_stale_catalog_id_before_continuing(monkeypatch):
+    """A verified 500 can mean an obsolete Apple catalog release.
+
+    Re-resolve the same source recording through Apple's public catalog, retry
+    that replacement at the same queue position, and only then append later
+    tracks.
+    """
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target._write_not_before = 0.0
+    target._public_search_not_before = 0.0
+    target._resolved_catalog_context = {}
+    target._added_catalog_ids = {}
+    cache = {
+        "isrc": {
+            "QZEQU2502334": [{
+                "id": "1848462301",
+                "name": "It Ain't Nothing",
+                "artist": "Scout Willis",
+                "duration_ms": 191363,
+            }]
+        },
+        "search": {},
+        "dirty": False,
+    }
+    track = {
+        "id": "spotify-track",
+        "isrc": "QZEQU2502334",
+        "name": "It Ain't Nothing",
+        "artists": ["Scout Willis"],
+        "duration_ms": 191363,
+    }
+    target._remember_resolution(track, "1848462301", cache)
+
+    calls, landed = [], []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        if catalog_id == "1848462301":
+            response = requests.Response()
+            response.status_code = 500
+            raise requests.HTTPError("500 Server Error", response=response)
+        landed.append(catalog_id)
+        return object()
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: [
+        {"catalog_id": catalog_id} for catalog_id in landed
+    ]
+    target._rebuild_session = lambda: None
+    target._public_search_once = lambda *_args: "6791344492"
+    monkeypatch.setattr(apple, "polite_sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+
+    target.add({"id": "aurora"}, ["1848462301", "later"])
+
+    assert calls == ["1848462301", "6791344492", "later"]
+    assert landed == ["6791344492", "later"]
+    assert target.added_id("1848462301") == "6791344492"
+    assert cache["isrc"]["QZEQU2502334"][0]["id"] == "6791344492"
+    assert cache["dirty"] is True
+
+
+def test_apple_current_isrc_candidate_outranks_an_archived_link():
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    track = {"id": "spotify-1", "isrc": "USAAA2600001"}
+    cache = {
+        "isrc": {"USAAA2600001": [{"id": "current-release"}]},
+        "search": {},
+    }
+
+    assert target.expected_ids(
+        [track], {"spotify-1": "stale-linked-release"}, cache
+    ) == {"spotify-1": {"current-release"}}
+
+
+def test_apple_rejected_unrepairable_catalog_id_is_evicted():
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    track = {
+        "id": "spotify-1",
+        "isrc": "USAAA2600001",
+        "name": "Post Break-Up Sex",
+        "artists": ["The Vaccines"],
+        "duration_ms": 174000,
+    }
+    cache = {
+        "isrc": {"USAAA2600001": [{"id": "bad-id"}]},
+        "search": {"post break-up sex|the vaccines": "bad-id"},
+        "dirty": False,
+    }
+    target._resolved_catalog_context = {"bad-id": (track, cache)}
+    target._public_search_once = lambda *_args: None
+
+    assert target._repair_catalog_id("bad-id") is None
+    assert "USAAA2600001" not in cache["isrc"]
+    assert cache["search"] == {}
+    assert cache["dirty"] is True
+
+
+def test_apple_empty_isrc_result_keeps_only_a_live_archived_catalog_id():
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target.storefront = "us"
+    target._validated_catalog_ids = {}
+    track = {"isrc": "WRONGEDITION", "duration_ms": 1000}
+    cache = {"isrc": {"WRONGEDITION": []}}
+
+    target._request = lambda *args, **kwargs: object()
+    assert target.validate_link(track, "still-live", cache) == ("still-live", "link")
+
+    target._validated_catalog_ids.clear()
+    target._request = lambda *args, **kwargs: None
+    assert target.validate_link(track, "delisted", cache) == (None, None)
+
+
+def test_apple_search_falls_back_to_public_catalog_after_amp_429(monkeypatch):
+    """A throttled authenticated search must not block the ordered suffix.
+
+    Apple's public search is a read-only second route. A proven match may be
+    cached normally; it lets the queue keep moving without sending credentials
+    to a different host.
+    """
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target.storefront = "us"
+    target._search_throttled = False
+    target._write_not_before = 0.0
+    target._public_search_not_before = 0.0
+    target._search_once = lambda *_args: (_ for _ in ()).throw(
+        TargetTransientError("Apple search throttled", retry_after=4)
+    )
+    calls = []
+
+    class Response:
+        status_code = 200
+        headers = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "results": [{
+                    "trackId": 1892105071,
+                    "trackName": "seaside_demo",
+                    "artistName": "SEB",
+                    "trackTimeMillis": 120000,
+                }]
+            }
+
+    def public_get(url, *, params, timeout):
+        calls.append((url, params, timeout))
+        return Response()
+
+    monkeypatch.setattr(apple.requests, "get", public_get)
+    monkeypatch.setattr(apple.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    cache = {"search": {}, "dirty": False}
+
+    result = target._search("seaside_demo", ["SEB"], 120000, cache)
+
+    assert result == "1892105071"
+    assert cache["search"]["seaside_demo|seb"] == "1892105071"
+    assert target._search_throttled is True
+    assert calls[0][0] == "https://itunes.apple.com/search"
+    assert calls[0][1] == {
+        "term": "seaside_demo SEB",
+        "country": "US",
+        "media": "music",
+        "entity": "song",
+        "limit": 50,
+    }
+
+
+def test_apple_public_search_miss_is_not_cached(monkeypatch):
+    """A secondary-catalog miss is provisional, not a permanent mapping."""
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target.storefront = "us"
+    target._search_throttled = True
+    target._public_search_not_before = 0.0
+
+    class Response:
+        status_code = 200
+        headers = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"resultCount": 0, "results": []}
+
+    monkeypatch.setattr(apple.requests, "get", lambda *_args, **_kwargs: Response())
+    monkeypatch.setattr(apple.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    cache = {"search": {}, "dirty": False}
+
+    assert target._search("unavailable", ["artist"], 100000, cache) is None
+    assert cache == {"search": {}, "dirty": False}
+
+
+def test_apple_public_search_rejects_a_live_substitute(monkeypatch):
+    """A fuzzy fallback must not turn a studio song into a live recording."""
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target.storefront = "us"
+    target._public_search_not_before = 0.0
+
+    class Response:
+        status_code = 200
+        headers = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"results": [{
+                "trackId": 542407156,
+                "trackName": "Post Break-Up Sex (Live in Brighton)",
+                "artistName": "The Vaccines",
+                "trackTimeMillis": 174000,
+            }]}
+
+    monkeypatch.setattr(apple.requests, "get", lambda *_args, **_kwargs: Response())
+    monkeypatch.setattr(apple.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+
+    assert target._public_search_once(
+        "Post Break-Up Sex The Vaccines",
+        "Post Break-Up Sex",
+        ["The Vaccines"],
+        174000,
+    ) is None
+
+
+def test_apple_public_search_429_preserves_order_for_a_later_pass(monkeypatch):
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target.storefront = "us"
+    target._search_throttled = True
+    target._public_search_not_before = 0.0
+
+    class Response:
+        status_code = 429
+        headers = {"Retry-After": "12"}
+
+    monkeypatch.setattr(apple.requests, "get", lambda *_args, **_kwargs: Response())
+    monkeypatch.setattr(apple.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(TargetTransientError) as exc_info:
+        target._search("later", ["artist"], 100000, {"search": {}, "dirty": False})
+    assert exc_info.value.retry_after == 12
 
 
 def test_jellyfin_list_playlists_fills_counts(monkeypatch):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -356,6 +356,34 @@ def test_syncs_crud(tmp_path):
         assert jid not in [j["id"] for j in client.get("/api/syncs").json()]
 
 
+def test_syncs_validate_authoritative_groups(tmp_path):
+    store = SyncStore(dir=tmp_path)
+    with TestClient(create_app(settings=SettingsStore(dir=tmp_path), syncs=store)) as client:
+        created = client.post("/api/syncs", json={
+            "name": "Two authorities",
+            "mode": "group",
+            "source": "spotify",
+            "authorities": "spotify,apple",
+            "providers": "spotify,apple,tidal",
+        })
+        assert created.status_code == 200
+        assert created.json()["authorities"] == "spotify,apple"
+
+        too_small = client.post("/api/syncs", json={
+            "name": "Unsafe", "mode": "group", "source": "spotify",
+            "authorities": "spotify", "providers": "spotify,apple",
+        })
+        assert too_small.status_code == 422
+        assert "at least two" in too_small.json()["detail"]
+
+        missing_provider = client.post("/api/syncs", json={
+            "name": "Unsafe", "mode": "group", "source": "spotify",
+            "authorities": "spotify,apple", "providers": "spotify,tidal",
+        })
+        assert missing_provider.status_code == 422
+        assert "missing: apple" in missing_provider.json()["detail"]
+
+
 def test_download_dir_prefers_container_override(tmp_path, monkeypatch):
     # In Docker the download path is a container bind-mount (/music). An
     # SONGMIRROR_DOWNLOAD_DIR override must win over a UI-saved DOWNLOAD_DIR — inside

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -248,6 +248,99 @@ def test_links_crud(tmp_path):
         assert client.get("/api/links").json() == []
 
 
+def test_playlist_browse_failure_is_a_retryable_http_error(tmp_path, monkeypatch):
+    from songmirror.services.playlists import PlaylistBrowseError, PlaylistService
+
+    monkeypatch.setattr(
+        PlaylistService,
+        "browse",
+        lambda self, provider: (_ for _ in ()).throw(
+            PlaylistBrowseError("Spotify could not load playlists right now. Retry.")
+        ),
+    )
+    with TestClient(_app(tmp_path)) as client:
+        response = client.get("/api/playlists?provider=spotify")
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Spotify could not load playlists right now. Retry."
+
+
+def test_playlist_detail_and_serialized_remove_routes(tmp_path, monkeypatch):
+    from songmirror.services.playlists import PlaylistService
+
+    detail_calls = []
+
+    def playlist_detail(self, provider, playlist_id, **kwargs):
+        detail_calls.append((provider, playlist_id, kwargs))
+        return {
+            "provider": provider,
+            "id": playlist_id,
+            "name": "Aurora",
+            "tracks": [],
+        }
+
+    monkeypatch.setattr(
+        PlaylistService,
+        "detail",
+        playlist_detail,
+    )
+    seen = []
+
+    def remove(self, provider, playlist_id, *, position, track_id, occurrence_id=""):
+        seen.append((provider, playlist_id, position, track_id, occurrence_id))
+        return {"ok": True}
+
+    monkeypatch.setattr(PlaylistService, "remove_track", remove)
+
+    with TestClient(_app(tmp_path)) as client:
+        detail = client.get(
+            "/api/playlists/spotify/playlist-1?refresh=true&expected_count=12"
+        )
+        removed = client.request(
+            "DELETE",
+            "/api/playlists/spotify/playlist-1/tracks",
+            json={"position": 4, "track_id": "track-5"},
+        )
+
+    assert detail.status_code == 200
+    assert detail.json()["name"] == "Aurora"
+    assert detail_calls == [(
+        "spotify",
+        "playlist-1",
+        {"refresh": True, "expected_count": 12},
+    )]
+    assert removed.json() == {"ok": True}
+    assert seen == [("spotify", "playlist-1", 4, "track-5", "")]
+
+
+def test_playlist_bulk_remove_route(tmp_path, monkeypatch):
+    from songmirror.services.playlists import PlaylistService
+
+    seen = []
+
+    def remove_many(self, provider, playlist_id, *, selections):
+        seen.extend(selections)
+        return {"ok": True, "removed": len(selections)}
+
+    monkeypatch.setattr(PlaylistService, "remove_tracks", remove_many)
+
+    with TestClient(_app(tmp_path)) as client:
+        response = client.request(
+            "DELETE",
+            "/api/playlists/tidal/playlist-1/tracks",
+            json={"tracks": [
+                {"position": 3, "track_id": "track-4", "occurrence_id": "entry-4"},
+                {"position": 7, "track_id": "track-8", "occurrence_id": "entry-8"},
+            ]},
+        )
+
+    assert response.json() == {"ok": True, "removed": 2}
+    assert seen == [
+        {"position": 3, "track_id": "track-4", "occurrence_id": "entry-4"},
+        {"position": 7, "track_id": "track-8", "occurrence_id": "entry-8"},
+    ]
+
+
 def test_syncs_crud(tmp_path):
     # Fresh installs start with NO syncs (no auto-seeded "Default"); jobs are
     # created, merge-updated, and deleted via CRUD.


### PR DESCRIPTION
## What changed

SongMirror now supports an **authoritative group** sync mode. Two or more trusted services contribute playlist membership, one of them is the **order authority**, and every other selected service is a mirror that cannot feed drift back into the authorities.

For the requested setup, Spotify remains the order authority while Spotify and Apple Music jointly define membership. The mode is persisted and validated across the CLI, environment configuration, API, sync scheduler, React wizard, job summaries, live-feed diagnostics, README, and the new domain glossary.

Reconciliation now:

- namespaces baselines by authority set so old N-way history cannot leak into a group
- requires every configured authority to be present and readable instead of silently degrading
- propagates additions from either authority and makes concurrent additions win
- requires two trusted executing snapshots before authority removals propagate
- treats mirror-only additions as drift while repairing mirror deletions
- holds every destructive write on a new authority baseline or when replacement matching is incomplete
- records physical playlist IDs so deleted/recreated same-name playlists (including Apple Music Aurora) establish a safe fresh baseline
- ignores titleless provider placeholder rows before caching/canonicalization, preventing bogus membership and empty TIDAL/Qobuz/Deezer searches

The earlier changes in this PR also preserve provider playlist order, add 429/5xx backoff and ordered deferral, harden Spotify playlist loading, retain stale browse data on refresh errors, cache playlist tracks across all providers, restore artwork/service links, add the in-app playlist inspector/editor, paginate 50 tracks at a time, support provider-correct latest-added sorting, and add click/shift-click bulk removal.

## Root cause

The prior baseline represented sync history rather than an explicit authority boundary. In N-way mode every participant could therefore reintroduce tracks, while one-way mode could not express Spotify and Apple Music as joint sources. Recreated playlists also inherited stale logical state because only the playlist name was tracked.

Separately, a Spotify placeholder row with no title, artist, or ISRC canonicalized as `k:|`. That phantom member was sent to every destination resolver as an empty search. Filtering malformed rows at the shared reconciliation boundary fixes the membership model itself instead of adding provider-specific HTTP guards.

## Safety and compatibility

Existing one-way and N-way jobs retain their behavior. Group jobs fail closed if an authority is disconnected, missing, or unreadable. The first executing pass may apply safe additions but cannot remove anything; incomplete replacements keep both the old entry and the desired replacement visible for later retries.

## Live migration

The deployed **Default** job is now:

- mode: authoritative group
- order authority: Spotify
- membership authorities: Spotify + Apple Music
- mirrors: YouTube Music, TIDAL, Deezer, Amazon Music, and Qobuz

The separate **Drive** job remains one-way from Spotify.

A non-writing preview completed with no failures or read anomalies. The first guarded execute added 16 tracks, removed 0, and held 15 removal candidates while establishing 49 physical-ID-backed state rows (7 playlists × 7 providers). A second execute added 1 track, removed 0, and kept all 15 ambiguous replacements protected. After the malformed-row fix, a live preview logged the one ignored Spotify/Sleep placeholder, issued zero empty searches, and reduced unresolved matches from 1,539 to 1,538.

## Validation

- `uv run pytest -q`: 291 passed, 1 skipped
- `npm run lint`: passed
- `npm run build`: passed
- `npm run test:e2e:ci`: 118 checks, 0 horizontal-overflow failures
- deployed Docker image `sha256:bdf634473c5e5b927769ffc76bad2cfeadf8781e418fd51974d976c0f7d39832`: healthy
