### PR TITLE
fix(sync): isolate mirror read failures

### DIFF
--- a/frontend/src/components/dashboard/NeedsALook.tsx
+++ b/frontend/src/components/dashboard/NeedsALook.tsx
@@ -174,7 +174,7 @@ function buildItems(accounts: Account[] | null, status: SyncStatus | null): Need
     })
   }
 
-  const readAnomalyRows = diagnosticsByCategory(diagnostics, 'incomplete_read', 'ambiguous_identity')
+  const readAnomalyRows = diagnosticsByCategory(diagnostics, 'incomplete_read', 'mirror_read_failed', 'ambiguous_identity')
   const readAnomalyTotal = Math.max(
     diagnosticCount(readAnomalyRows),
     targets.reduce((sum, target) => sum + (target.read_anomalies ?? 0), 0),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -135,6 +135,7 @@ export type ChangeDiagnosticCategory =
   | 'unconfirmed_absence'
   | 'confirmed_absence'
   | 'incomplete_read'
+  | 'mirror_read_failed'
   | 'ambiguous_identity'
   | 'replacement_blocked'
   | 'confirmed_removal_disabled'

--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -328,6 +328,27 @@ def get_isrcs(conn, source, ids):
     return {k: v for k, v in got.items() if v}
 
 
+def get_snapshots(conn, source, ids):
+    """{id: last archived snapshot dict} for a source's tracks.
+
+    `meta` holds the provider row exactly as a previous read returned it, so a
+    catalog entry the provider can no longer describe is still identifiable by
+    what it was. Rows without a usable title are dropped: reconcile ignores
+    them anyway, and an unnamed entry cannot carry a canonical identity."""
+    rows = _in_chunks(
+        conn, "SELECT id, meta FROM songs WHERE source = ? AND meta IS NOT NULL "
+              "AND id IN ({marks})", [source], ids)
+    out = {}
+    for song_id, meta in rows.items():
+        try:
+            snapshot = json.loads(meta)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(snapshot, dict) and str(snapshot.get("name") or "").strip():
+            out[song_id] = snapshot
+    return out
+
+
 def get_identities(conn, source, track_ids):
     """{track_id: canonical_id} recorded for this provider's existing tracks."""
     return _in_chunks(

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -551,6 +551,10 @@ def _run_peer_reconcile(opts, sp, selected, songs, should_continue=None, *,
                     total[k] += stats.get(k, 0)
                 _collect_held(held_detail, stats.get("held_removals", []))
                 _collect_diagnostics(change_diagnostics, stats.get("change_diagnostics", []))
+                # Reconcile reports a skipped mirror itself: it keeps the other
+                # providers in sync, so the pass survives, but the summary must
+                # still name what did not get read.
+                failures.extend(stats.get("failures", [])[:max(0, FAILURE_DETAIL - len(failures))])
             except TargetAuthError:
                 raise
             except Exception as e:

--- a/songmirror/engine/targets/__init__.py
+++ b/songmirror/engine/targets/__init__.py
@@ -35,11 +35,11 @@ def _apple(opts):
         return None
 
 
-def _rest_provider(target_cls, label):
+def _rest_provider(target_cls, label, **kwargs):
     """Build an env-configured REST peer, logging a clean skip when absent."""
     from ..logs import log_note
     try:
-        return target_cls()
+        return target_cls(**kwargs)
     except RuntimeError as e:
         log_note(f"{label} skipped: {e}", tag=target_cls.tag)
         return None
@@ -63,7 +63,8 @@ def _spotify(opts, sp, *, sync_peer=False, songs=None):
 _REGISTRY = {
     "spotify": lambda opts, sp, sync_peer=False, songs=None: _spotify(
         opts, sp, sync_peer=sync_peer, songs=songs),
-    "tidal": lambda opts, sp, sync_peer=False, songs=None: _rest_provider(TidalTarget, "TIDAL"),
+    "tidal": lambda opts, sp, sync_peer=False, songs=None: _rest_provider(
+        TidalTarget, "TIDAL", songs=songs),
     "qobuz": lambda opts, sp, sync_peer=False, songs=None: _rest_provider(QobuzTarget, "Qobuz"),
     "deezer": lambda opts, sp, sync_peer=False, songs=None: _rest_provider(DeezerTarget, "Deezer"),
     "amazon": lambda opts, sp, sync_peer=False, songs=None: _rest_provider(AmazonMusicTarget, "Amazon Music"),

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -761,8 +761,24 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     present = {}       # source -> set of ALL current target ids (not canonical-deduped)
     key2isrc = {}      # track_key -> ISRC, seeded by every ISRC-bearing provider before canonicalization
     raw_by_source = {}
+    unreadable = {}
     for p in peers:
-        provider_rows = p.playlist_tracks(playlists[p.source])
+        try:
+            provider_rows = p.playlist_tracks(playlists[p.source])
+        except TargetAuthError:
+            raise
+        except Exception as e:
+            # Only a mirror can be skipped. Every N-way peer contributes
+            # membership, as does an authority, so losing one of those reads
+            # loses information the pass needs and must still fail closed.
+            if authorities is None or p.source in authorities:
+                raise
+            unreadable[p.source] = f"{p.name} mirror read failed: {e}"
+            raw_by_source[p.source] = []
+            present[p.source] = set()
+            log_warn(f"{p.name}/{name}: playlist read failed ({e!r}); "
+                     "syncing the other providers without it", tag=p.tag)
+            continue
         raw = [
             track for track in provider_rows
             if isinstance(track, dict) and str(track.get("name") or "").strip()
@@ -848,8 +864,19 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         for cid, norm in canon[p.source].items():
             repr_.setdefault(cid, norm)
 
-    collapsed = set()
+    collapsed = set(unreadable)
+    read_failures = []
+    for source, reason in unreadable.items():
+        read_anomalies += 1
+        read_failures.append({"playlist": name, "error": reason})
+        diagnostics.append({
+            "category": "mirror_read_failed", "playlist": name,
+            "provider": peer_names.get(source, source), "count": 1,
+            "evidence": "the provider playlist could not be read; changes ignored",
+        })
     for p in peers:
+        if p.source in collapsed:
+            continue
         base = prev.get(p.source, set())
         if base and (not cur[p.source] or len(cur[p.source]) < COLLAPSE_FRACTION * len(base)):
             collapsed.add(p.source)
@@ -977,6 +1004,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
              "unconfirmed_absences": awaiting_confirmation,
              "confirmed_absences": confirmed_absence_count,
              "read_anomalies": read_anomalies,
+             "failed": len(read_failures), "failures": read_failures,
              "change_diagnostics": diagnostics}
     baseline_blocked = bool(awaiting_confirmation or authority_bootstrap)
     if authority_bootstrap:

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -15,7 +15,9 @@ import requests
 from ...browser_session import jwt_expiry
 from ...oauth import merge_refresh, read_token, token_is_live, token_path, write_token
 from ...tidal_web import parse_web_headers
+from .. import archive
 from ..config import REQUEST_TIMEOUT, polite_sleep, required_env
+from ..logs import log_note, log_warn
 from ..matching import normalize_text, romanized, track_key
 from .base import MirrorTarget, TargetAuthError
 from .provider_utils import best_candidate, chunks, iso_duration_ms, source_playlist_details
@@ -32,8 +34,11 @@ class TidalTarget(MirrorTarget):
     source = "tidal"
     stable_occurrence_ids = True
 
-    def __init__(self):
+    def __init__(self, songs=None):
         self.cache_file = os.getenv("TIDAL_CACHE_FILE", "tidal_resolve_cache.json")
+        # The songs archive (sqlite conn) supplies last-known metadata for
+        # catalog entries TIDAL has since delisted (see playlist_tracks).
+        self._songs = songs
         web_headers = (os.getenv("TIDAL_WEB_HEADERS") or "").strip()
         self._browser_mode = bool(web_headers)
         self._token_file = token_path("TIDAL_TOKEN_FILE", DEFAULT_TOKEN_FILE)
@@ -266,6 +271,14 @@ class TidalTarget(MirrorTarget):
             details = self._tracks_by_id(requested_ids)
             missing = [track_id for track_id in requested_ids if track_id not in details]
             if missing:
+                # The relationship listing is the membership authority; /tracks
+                # only hydrates metadata. TIDAL keeps serving a relationship
+                # after the catalog entry behind it disappears, so falling back
+                # to what that id last was keeps the entry a member instead of
+                # turning a delisting into a removal everywhere it is mirrored.
+                details = {**details, **self._archived_details(missing)}
+                missing = [track_id for track_id in missing if track_id not in details]
+            if missing:
                 preview = ", ".join(missing[:5])
                 suffix = "..." if len(missing) > 5 else ""
                 raise RuntimeError(
@@ -278,6 +291,23 @@ class TidalTarget(MirrorTarget):
                 tracks.append({**track, "relationship_id": meta.get("itemId"),
                                "added_at": meta.get("addedAt") or ""})
         return tracks
+
+    def _archived_details(self, ids):
+        """Last-known metadata for track ids the catalog no longer describes."""
+        if self._songs is None:
+            return {}
+        try:
+            found = archive.get_snapshots(self._songs, self.source, ids)
+        except Exception as e:
+            log_warn(f"archive lookup failed for {len(ids)} delisted track(s): {e!r}", tag=self.tag)
+            return {}
+        if found:
+            log_note(
+                f"{len(found)} playlist entr{'y' if len(found) == 1 else 'ies'} no longer in the "
+                "TIDAL catalog; using their last known details",
+                tag=self.tag,
+            )
+        return found
 
     def _tracks_by_id(self, ids):
         out = {}

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -59,6 +59,7 @@ def test_tidal_playlist_read_fails_closed_when_catalog_detail_is_missing(monkeyp
 
     target = TidalTarget.__new__(TidalTarget)
     target.country = "US"
+    target._songs = None
     page = {
         "data": [
             {"type": "tracks", "id": "t1", "meta": {"itemId": "entry-1"}},
@@ -73,6 +74,56 @@ def test_tidal_playlist_read_fails_closed_when_catalog_detail_is_missing(monkeyp
 
     with pytest.raises(RuntimeError, match=r"incomplete.*t2"):
         target.playlist_tracks({"id": "playlist"})
+
+
+def test_tidal_playlist_read_keeps_a_delisted_entry_from_the_archive(tmp_path):
+    # TIDAL keeps serving a playlist relationship after the catalog entry behind
+    # it disappears. Dropping the entry would read as a user deletion and
+    # propagate everywhere it is mirrored, so the last known details stand in.
+    from songmirror.engine import archive
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    conn = archive.connect(str(tmp_path / "delisted.db"))
+    archive.upsert_many(conn, "tidal", [{
+        "id": "t2", "name": "Delisted", "artist": "Artist", "artists": ["Artist"],
+        "album": "Album", "duration_ms": 2000, "isrc": "TWO", "added_at": "2020",
+    }])
+    target = TidalTarget.__new__(TidalTarget)
+    target.country = "US"
+    target._songs = conn
+    page = {"data": [
+        {"type": "tracks", "id": "t1", "meta": {"itemId": "entry-1", "addedAt": "2026"}},
+        {"type": "tracks", "id": "t2", "meta": {"itemId": "entry-2", "addedAt": "2026"}},
+    ]}
+    target._pages = lambda path, params: iter([page])
+    target._tracks_by_id = lambda ids: {
+        "t1": {"id": "t1", "name": "Available", "artist": "Artist",
+               "artists": ["Artist"], "duration_ms": 1000, "isrc": "ONE"}
+    }
+
+    tracks = target.playlist_tracks({"id": "playlist"})
+
+    assert [t["id"] for t in tracks] == ["t1", "t2"]
+    assert tracks[1]["name"] == "Delisted" and tracks[1]["isrc"] == "TWO"
+    assert tracks[1]["relationship_id"] == "entry-2"   # this pass's entry, not the archived one
+    conn.close()
+
+
+def test_tidal_playlist_read_fails_closed_when_the_archive_cannot_identify_it(tmp_path):
+    from songmirror.engine import archive
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    conn = archive.connect(str(tmp_path / "unknown.db"))
+    target = TidalTarget.__new__(TidalTarget)
+    target.country = "US"
+    target._songs = conn
+    target._pages = lambda path, params: iter(
+        [{"data": [{"type": "tracks", "id": "t9", "meta": {"itemId": "entry-9"}}]}])
+    target._tracks_by_id = lambda ids: {}
+
+    with pytest.raises(RuntimeError, match=r"incomplete.*t9"):
+        target.playlist_tracks({"id": "playlist"})
+    conn.close()
 
 
 def test_tidal_connector_accepts_minimized_browser_headers(tmp_path, monkeypatch):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -554,6 +554,87 @@ def test_authoritative_group_bootstrap_is_scoped_and_non_destructive(tmp_path):
     conn.close()
 
 
+def test_authoritative_group_skips_an_unreadable_mirror_without_blocking_authorities(tmp_path):
+    class UnreadableMirror(_P):
+        def playlist_tracks(self, pl):
+            raise RuntimeError("incomplete TIDAL relationship 305553517")
+
+    conn = archive.connect(str(tmp_path / "unreadable-mirror.db"))
+    key = "group:apple,spotify:aurora"
+    baseline = {"i:A"}
+    archive.commit_reconcile_membership(
+        conn,
+        key,
+        {source: baseline for source in ("spotify", "apple", "tidal", "ytmusic")},
+        {source: set() for source in ("spotify", "apple", "tidal", "ytmusic")},
+        {source: source for source in ("spotify", "apple", "tidal", "ytmusic")},
+    )
+    spotify = _P("spotify", ["A"])
+    apple = _P("apple", ["A", "NEW"])
+    tidal = UnreadableMirror("tidal", ["A"])
+    tidal.name = "TIDAL"
+    ytmusic = _P("ytmusic", ["A"])
+    peers = [spotify, apple, tidal, ytmusic]
+
+    stats = reconcile(
+        peers,
+        "Aurora",
+        {p.source: {"id": p.source} for p in peers},
+        _caches(*(p.source for p in peers)),
+        conn,
+        execute=True,
+        max_removals=25,
+        max_adds=200,
+        authority_sources={"spotify", "apple"},
+    )
+
+    assert spotify.added == ["NEW"]
+    assert apple.added == []
+    assert ytmusic.added == ["NEW"]
+    assert tidal.added == []
+    assert stats["added"] == 2
+    assert stats["failed"] == 1
+    assert stats["failures"] == [{
+        "playlist": "Aurora",
+        "error": "TIDAL mirror read failed: incomplete TIDAL relationship 305553517",
+    }]
+    assert "mirror_read_failed" in {
+        diagnostic["category"] for diagnostic in stats["change_diagnostics"]
+    }
+    assert stats["clean"] is False
+    assert archive.get_playlist_state(conn, key, "tidal") == baseline
+    conn.close()
+
+
+def test_authoritative_group_still_fails_closed_when_an_authority_is_unreadable(tmp_path):
+    class UnreadableAuthority(_P):
+        def playlist_tracks(self, pl):
+            raise RuntimeError("Apple Music snapshot unavailable")
+
+    conn = archive.connect(str(tmp_path / "unreadable-authority.db"))
+    spotify = _P("spotify", ["A"])
+    apple = UnreadableAuthority("apple", ["A", "NEW"])
+    mirror = _P("ytmusic", ["A"])
+    peers = [spotify, apple, mirror]
+
+    with pytest.raises(RuntimeError, match="Apple Music snapshot unavailable"):
+        reconcile(
+            peers,
+            "Aurora",
+            {p.source: {"id": p.source} for p in peers},
+            _caches(*(p.source for p in peers)),
+            conn,
+            execute=True,
+            max_removals=25,
+            max_adds=200,
+            authority_sources={"spotify", "apple"},
+        )
+
+    assert spotify.added == []
+    assert mirror.added == []
+    conn.close()
+
+
 def test_authoritative_group_recognizes_a_same_name_recreated_playlist(tmp_path):
     conn = archive.connect(str(tmp_path / "group-recreated.db"))
     key = "group:apple,spotify:aurora"

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -763,6 +763,33 @@ def test_authoritative_group_forwards_only_its_authority_sources(monkeypatch):
     assert entry["name"] == "Authoritative group"
 
 
+def test_authoritative_group_preserves_a_skipped_mirror_read_failure(monkeypatch):
+    peers = [_Peer("spotify"), _Peer("apple"), _Peer("tidal")]
+    monkeypatch.setattr(runner, "build_peers", lambda opts, sp, songs=None: peers)
+    monkeypatch.setattr(runner, "load_cache", lambda path: {})
+    monkeypatch.setattr(runner, "save_cache", lambda path, cache: None)
+    failure = {
+        "playlist": "Aurora",
+        "error": "TIDAL mirror read failed: incomplete relationship 305553517",
+    }
+    monkeypatch.setattr(
+        runner,
+        "reconcile",
+        lambda *args, **kwargs: {"failed": 1, "failures": [failure]},
+    )
+
+    entry = runner._run_authoritative_group(
+        _opts(
+            sync_mode="group", sync_source="spotify",
+            authorities="spotify,apple", providers="spotify,apple,tidal",
+        ),
+        object(), [{"name": "Aurora"}], _FakeSongs(),
+    )[0]
+
+    assert entry["failed"] == 1
+    assert entry["failures"] == [failure]
+
+
 def test_authoritative_group_reports_a_disconnected_authority(monkeypatch):
     monkeypatch.setattr(
         runner, "build_peers", lambda opts, sp, songs=None: [_Peer("spotify")],


### PR DESCRIPTION
## What changed

- keep Spotify and Apple Music fail-closed as authoritative providers
- isolate an unreadable non-authoritative mirror so healthy providers can still reconcile
- reuse archived TIDAL metadata when a playlist relationship points to a delisted catalog item
- report skipped mirror reads in sync summaries and the dashboard's read-anomaly section

## Root cause

Authoritative-group reconciliation read every selected provider before planning any changes, but a single mirror exception aborted the whole playlist. TIDAL still exposed Aurora relationship `305553517` while its catalog-details endpoint no longer returned that track, so the Apple Music additions were never planned for Spotify.

The authority snapshots remain mandatory. Only destination-only mirrors may be skipped, and their prior baseline is preserved so they retry and rejoin on a later pass.

## Verification

- `.venv\Scripts\python.exe -m pytest -q` — 296 passed, 1 skipped
- `npm run lint` — passed
- `npm run build` — passed
- `npm run test:e2e` — 118 browser checks passed with no horizontal overflow
- live preview — 13 additions, 0 failed playlists
- live execute — 13 additions, 0 removals, 0 failed playlists
- fresh Spotify read — Aurora has 749 tracks; “Take Me Back To LA” and “Figure 8” are appended at positions 747 and 748
