### PR TITLE
ci: publish cache-isolated Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,84 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  schedule:
+    # Rebuild weekly so the published image picks up patched base images.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          # Do not restore or save the binfmt image through the Actions cache.
+          cache-image: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          # Release tooling must come from the pinned action, never a shared cache.
+          cache-binary: false
+          keep-state: false
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          # Release builds deliberately consume and produce no BuildKit cache.
+          # This trades build speed for isolation from all cross-run cache state.
+          no-cache: true
+          pull: true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest image provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ SongMirror keeps your playlists identical everywhere without manual re-adding, o
 
 ## 🚀 Quick Start
 
-The fastest way to run it is Docker — the container serves the web UI and runs your syncs on schedule.
+The fastest way to run it is Docker — Compose pulls the published image, serves the web UI, and runs your syncs on schedule.
 
 ```bash
 git clone https://github.com/ahnafnafee/songmirror.git
@@ -160,13 +160,15 @@ uv run uvicorn songmirror.web:app --host 0.0.0.0 --port 8080   # then open http:
 
 ## 🐳 Always running: Docker
 
-The Docker container is the recommended deployment: it serves the web UI, runs your syncs on their schedules, and restarts with the host. It runs as **`songmirror`** and persists all auth + caches in `./data`.
+The Docker container is the recommended deployment: it serves the web UI, runs your syncs on their schedules, and restarts with the host. Compose pulls **`ghcr.io/ahnafnafee/songmirror:latest`**, runs it as **`songmirror`**, and persists all auth + caches in `./data`.
 
 ```bash
-docker compose up -d --build     # build + start in the background
+docker compose up -d             # pull the published image + start in the background
 # open http://<host>:8888 and connect your services + create syncs in the browser
 docker compose logs -f           # watch it work
 ```
+
+To update, run `docker compose up -d --pull always`. To build the current checkout instead, run `docker compose up -d --build`. See the **[container image guide](docs/docker-image.md)** for tags, digest pinning, direct pulls, verification, updates, and rollback.
 
 **No `.env` is needed to start** — everything is configured in the browser and saved under `./data`. OAuth, partner-token, and API-key setup all live on the Accounts page; each wizard explains the service-specific prerequisites and exact callback URI. Then build your syncs on the Sync page.
 
@@ -183,6 +185,7 @@ SongMirror will then advertise `https://music.example.com/oauth/spotify/callback
 
 | | |
 | --- | --- |
+| **Image** | `ghcr.io/ahnafnafee/songmirror:latest` supports AMD64 and ARM64. Each build is also published with a commit-specific `sha-...` tag; Git tags such as `v1.2.3` additionally publish `1.2.3`, `1.2`, and `1`. Use the [container image guide](docs/docker-image.md) to pin an immutable digest. |
 | **Port** | The UI is published on host **8888** (the `8888:8080` mapping in `docker-compose.yml`; change the host side if it clashes). **LAN-only** — don't port-forward it to the internet; the UI has no login yet. |
 | **Persistence** | `./data` holds credentials, tokens, caches, and the song archive. Back it up to keep your setup across rebuilds. |
 | **Downloads** | Set `DOWNLOAD_DIR` (in `.env` or your shell) to your host music dir (e.g. `F:\Torrent\Music`); compose bind-mounts it to `/music`. From Docker, set `JELLYFIN_URL` to `http://host.docker.internal:8096`. |
@@ -480,7 +483,7 @@ This project is [MIT](./LICENSE) licensed.
 [python-shield]: https://img.shields.io/badge/python-3.13%2B-F2601A?labelColor=black&logo=python&logoColor=white&style=flat-square
 [python-link]: https://www.python.org/
 [docker-shield]: https://img.shields.io/badge/docker-ready-F2601A?labelColor=black&logo=docker&logoColor=white&style=flat-square
-[docker-link]: https://github.com/ahnafnafee/songmirror/blob/main/docker-compose.yml
+[docker-link]: https://github.com/ahnafnafee/songmirror/pkgs/container/songmirror
 [stars-shield]: https://img.shields.io/github/stars/ahnafnafee/songmirror?color=F2601A&labelColor=black&logo=github&logoColor=white&style=flat-square
 [stars-link]: https://github.com/ahnafnafee/songmirror/stargazers
 [forks-shield]: https://img.shields.io/github/forks/ahnafnafee/songmirror?color=F2601A&labelColor=black&logo=github&logoColor=white&style=flat-square

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ name: songmirror   # compose project (group) name
 
 services:
   web:
+    # Pull the official image by default; `docker compose up --build` still
+    # builds this checkout locally and tags it with the same image name.
+    image: "${SONGMIRROR_IMAGE:-ghcr.io/ahnafnafee/songmirror:latest}"
     build: .
     container_name: songmirror
     # A .env is OPTIONAL — every service is configured in the browser and saved

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -1,0 +1,131 @@
+# SongMirror container image
+
+The official image is published to `ghcr.io/ahnafnafee/songmirror` for
+`linux/amd64` and `linux/arm64`. The package is public, so normal pulls do not
+require a GitHub login.
+
+## Recommended: Docker Compose
+
+The repository's Compose file declares every persistent token, cache, database,
+and download path. Use it for a durable installation:
+
+```bash
+git clone https://github.com/ahnafnafee/songmirror.git
+cd songmirror
+docker compose pull
+docker compose up -d
+docker compose ps
+```
+
+Open `http://localhost:8888`. Configuration entered in the browser is stored in
+`./data`; downloaded music is stored in `./downloads` unless `DOWNLOAD_DIR` is
+set in `.env`. Back up those directories before upgrades. The web UI has no
+login, so keep port 8888 on a trusted LAN and do not expose it directly to the
+internet.
+
+To follow the newest default-branch image:
+
+```bash
+docker compose up -d --pull always
+docker compose logs -f
+```
+
+To build the checked-out source instead of pulling GHCR, leave
+`SONGMIRROR_IMAGE` unset and run:
+
+```bash
+docker compose up -d --build
+```
+
+## Tags and immutable digests
+
+The publisher creates these references:
+
+| Reference | Meaning |
+| --- | --- |
+| `latest` | Current default-branch build; also refreshed by the weekly rebuild. |
+| `sha-<short-commit>` | Build associated with a Git commit. A scheduled rebuild can update this tag when upstream base images change. |
+| `1.2.3` | Image built from Git tag `v1.2.3`. |
+| `1.2` and `1` | Moving aliases for the newest matching release. |
+| `@sha256:<digest>` | Exact image bytes; this is the immutable form. |
+
+Inspect a tag to obtain the multi-platform digest:
+
+```bash
+docker buildx imagetools inspect ghcr.io/ahnafnafee/songmirror:latest
+```
+
+For repeatable deployments, put the digest from that output in `.env`:
+
+```dotenv
+SONGMIRROR_IMAGE=ghcr.io/ahnafnafee/songmirror@sha256:REPLACE_WITH_DIGEST
+```
+
+Then recreate the service:
+
+```bash
+docker compose up -d --pull always --force-recreate
+```
+
+`SONGMIRROR_IMAGE` is consumed by Compose. Do not set it to a digest when using
+`docker compose ... --build`, because a local build needs a taggable image name.
+
+## Pull or inspect the image directly
+
+You can pull the image without Compose:
+
+```bash
+docker pull ghcr.io/ahnafnafee/songmirror:latest
+docker image inspect ghcr.io/ahnafnafee/songmirror:latest
+```
+
+A disposable smoke test is also possible:
+
+```bash
+docker run --rm -p 8888:8080 ghcr.io/ahnafnafee/songmirror:latest
+```
+
+That command intentionally has no persistent volumes. Use the Compose setup for
+a real installation so account tokens, provider caches, the song database, and
+downloads survive container replacement.
+
+## Verify provenance
+
+Published images receive a GitHub artifact attestation bound to the exact pushed
+digest. With GitHub CLI installed and authenticated to GHCR, verify it with:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/ahnafnafee/songmirror:latest \
+  --repo ahnafnafee/songmirror \
+  --signer-workflow ahnafnafee/songmirror/.github/workflows/docker-publish.yml
+```
+
+Verification proves which repository workflow attested the image. For a stable
+deployment reference, still use the verified digest rather than a moving tag.
+
+## Roll back
+
+Replace `SONGMIRROR_IMAGE` in `.env` with a previously working digest, then run:
+
+```bash
+docker compose up -d --pull always --force-recreate
+docker compose logs -f
+```
+
+Rolling back the container does not roll back `./data`. Make a data backup before
+upgrading when application-level storage compatibility matters.
+
+## Cache-isolation policy
+
+Release builds intentionally disable all persistent caches exposed by the Docker
+publishing toolchain:
+
+- the QEMU setup action does not cache its binfmt image;
+- the Buildx setup action does not cache its binary or retain builder state; and
+- BuildKit runs with `no-cache` and has no cache import or export destination.
+
+This prevents cross-run cache state from becoming an input to a published image.
+It deliberately makes releases slower. It does not make moving tags immutable or
+remove external registry and dependency trust, which is why digest pinning and
+attestation verification remain useful.


### PR DESCRIPTION
## Summary

- publish linux/amd64 and linux/arm64 images to ghcr.io/ahnafnafee/songmirror from main, version tags, the weekly schedule, or manual dispatch
- eliminate persistent cache inputs and outputs from QEMU, Buildx, and BuildKit release steps, and pin every publishing action to a full commit SHA
- make Docker Compose consume the published image by default and document tags, digest pinning, provenance verification, updates, local builds, and rollback

## Security

Release builds deliberately trade speed for isolation: they restore no Actions or BuildKit cache, retain no builder state, and export no cache for later runs. The job keeps package and attestation write permissions local to the publisher and attests the exact pushed digest.

## Test plan

- [x] actionlint on CI and Docker publishing workflows
- [x] Docker Compose configuration with the default image and a digest override
- [x] cache-isolation and full-SHA action-reference assertions
- [x] cacheless Buildx build for linux/amd64 and linux/arm64
- [x] Python test suite: 296 passed, 1 skipped
- [x] git diff --check