### PR TITLE
fix(tidal): handle unavailable playlist entries

### DIFF
--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -313,6 +313,55 @@ const YTMUSIC_PLAYLIST_DETAIL = {
     })),
 }
 
+const TIDAL_PAGED_PLAYLIST = {
+  id: 'pl_tidal_hidden',
+  name: 'Old TIDAL mix',
+  count: 21,
+  image: '',
+}
+
+const TIDAL_PAGE_ONE = {
+  provider: 'tidal',
+  ...TIDAL_PAGED_PLAYLIST,
+  description: '',
+  owned: true,
+  editable: true,
+  external_url: 'https://listen.tidal.com/playlist/pl_tidal_hidden',
+  tracks: Array.from({ length: 20 }, (_, position) => ({
+    position,
+    id: position === 3 ? 'hidden-track' : `tidal-track-${position + 1}`,
+    occurrence_id: `tidal-entry-${position + 1}`,
+    name: position === 3 ? 'Unavailable TIDAL track' : `TIDAL track ${position + 1}`,
+    artist: position === 3 ? 'Catalog ID hidden-track' : 'TIDAL artist',
+    album: position === 3 ? null : 'TIDAL album',
+    duration_ms: position === 3 ? null : 180000,
+    image: '',
+    added_at: '',
+    external_url: position === 3 ? '' : `https://listen.tidal.com/track/tidal-track-${position + 1}`,
+    ...(position === 3 ? { unavailable: true } : {}),
+  })),
+  next_cursor: 'tidal-cursor-2',
+  complete: false,
+}
+
+const TIDAL_PAGE_TWO = {
+  ...TIDAL_PAGE_ONE,
+  tracks: [{
+    position: 20,
+    id: 'tidal-track-21',
+    occurrence_id: 'tidal-entry-21',
+    name: 'TIDAL track 21',
+    artist: 'TIDAL artist',
+    album: 'TIDAL album',
+    duration_ms: 180000,
+    image: '',
+    added_at: '',
+    external_url: 'https://listen.tidal.com/track/tidal-track-21',
+  }],
+  next_cursor: null,
+  complete: true,
+}
+
 // Polished, deterministic data used only for committed README/promo captures.
 // Every provider is connected and every playlist has cover art so the media
 // demonstrates the finished experience without setup errors or empty states.
@@ -797,6 +846,51 @@ async function main() {
       console.log(`${youtubeLatestOk ? 'ok        ' : 'FAIL      '} YouTube Music's undated newest-first response is not reversed (first=${JSON.stringify(firstYoutube?.slice(0, 50))})`)
       if (!youtubeLatestOk) results.push({ label: 'playlist ledger YouTube newest-first order', overflow: true })
       await checkOverflow(page, 'Playlist track ledger @ 1280', results)
+      await context.close()
+    }
+
+    // TIDAL exposes 20 playlist relationships per cursor page. The modal must
+    // render page one immediately, continue in the background, and preserve a
+    // removable placeholder when a relationship has no catalog metadata.
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'dark'))
+      const page = await context.newPage()
+      await installMocks(page, {
+        accounts: ACCOUNTS.map((account) => (
+          account.id === 'tidal' ? { ...account, state: 'connected', detail: null } : account
+        )),
+        playlists: { ...PLAYLISTS, tidal: [TIDAL_PAGED_PLAYLIST] },
+      })
+      const pageRequests = []
+      await page.route('**/api/playlists/tidal/pl_tidal_hidden*', async (route) => {
+        const url = new URL(route.request().url())
+        pageRequests.push(Object.fromEntries(url.searchParams))
+        const continuation = url.searchParams.get('cursor') === 'tidal-cursor-2'
+        if (continuation) await new Promise((resolve) => setTimeout(resolve, 350))
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(continuation ? TIDAL_PAGE_TWO : TIDAL_PAGE_ONE),
+        })
+      })
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/playlists', { waitUntil: 'networkidle' })
+      await page.getByRole('button', { name: 'Open Old TIDAL mix inside SongMirror' }).click()
+      const dialog = page.getByRole('dialog')
+      await dialog.getByText('Loaded 20 of 21 tracks from TIDAL…').waitFor()
+      const unavailableWarning = await dialog.getByText(/1 entry is no longer available in the TIDAL catalog/).isVisible()
+      const removablePlaceholder = await dialog.getByRole('button', { name: 'Select Unavailable TIDAL track' }).isVisible()
+      await dialog.getByText('Showing 1–21 of 21 tracks · 50 per page').waitFor()
+      const paginationContract = pageRequests.length === 2
+        && pageRequests[0].page_size === '20'
+        && !pageRequests[0].cursor
+        && pageRequests[1].cursor === 'tidal-cursor-2'
+        && pageRequests[1].offset === '20'
+      const tidalProgressiveOk = unavailableWarning && removablePlaceholder && paginationContract
+      console.log(`${tidalProgressiveOk ? 'ok        ' : 'FAIL      '} TIDAL playlist renders page one, appends its cursor page, and keeps unavailable entries removable`)
+      if (!tidalProgressiveOk) results.push({ label: 'TIDAL progressive playlist detail', overflow: true })
+      await checkOverflow(page, 'TIDAL progressive playlist detail @ 1280', results)
       await context.close()
     }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -120,13 +120,22 @@ export const api = {
   getPlaylistDetail: (
     provider: string,
     playlistId: string,
-    options: { refresh?: boolean; expectedCount?: number | null } = {},
+    options: {
+      refresh?: boolean
+      expectedCount?: number | null
+      pageSize?: 20
+      cursor?: string | null
+      offset?: number
+    } = {},
   ) => {
     const params = new URLSearchParams()
     if (options.refresh) params.set('refresh', 'true')
     if (options.expectedCount !== null && options.expectedCount !== undefined) {
       params.set('expected_count', String(options.expectedCount))
     }
+    if (options.pageSize) params.set('page_size', String(options.pageSize))
+    if (options.cursor) params.set('cursor', options.cursor)
+    if (options.offset) params.set('offset', String(options.offset))
     const query = params.size > 0 ? `?${params}` : ''
     return request<ProviderPlaylistDetail>(
       `/api/playlists/${encodeURIComponent(provider)}/${encodeURIComponent(playlistId)}${query}`,

--- a/frontend/src/components/playlists/PlaylistDetailModal.tsx
+++ b/frontend/src/components/playlists/PlaylistDetailModal.tsx
@@ -24,6 +24,7 @@ import { FIELD_INPUT_CLASSES } from '../ui/fieldStyles'
 import { FilterSelect } from '../ui/FilterSelect'
 import { Modal } from '../ui/Modal'
 import { LoadingStatus, Skeleton } from '../ui/Skeleton'
+import { Spinner } from '../ui/Spinner'
 
 type TrackOrder = 'latest' | 'playlist'
 
@@ -83,7 +84,7 @@ interface PlaylistDetailModalProps {
 export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: PlaylistDetailModalProps) {
   const provider = account?.id ?? null
   const playlistId = playlist?.id ?? null
-  const { detail, loading, refreshing, error, refresh } = usePlaylistDetail(
+  const { detail, loading, refreshing, loadingMore, error, refresh } = usePlaylistDetail(
     provider,
     playlistId,
     playlist?.count,
@@ -142,6 +143,10 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
   const selectedTracks = useMemo(
     () => detail?.tracks.filter((track) => selectedKeys.has(trackKey(track))) ?? [],
     [detail, selectedKeys],
+  )
+  const unavailableCount = useMemo(
+    () => detail?.tracks.filter((track) => track.unavailable).length ?? 0,
+    [detail],
   )
 
   function changeOrder(value: TrackOrder) {
@@ -296,6 +301,18 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
           </p>
         ) : null}
 
+        {unavailableCount > 0 ? (
+          <div className="flex items-start gap-2.5 rounded-control border border-warning/30 bg-warning-soft px-3.5 py-3 text-xs leading-relaxed text-text-2">
+            <span className="font-mono font-bold text-warning" aria-hidden="true">!</span>
+            <p>
+              {unavailableCount} {unavailableCount === 1 ? 'entry is' : 'entries are'} no longer available in the TIDAL catalog.
+              {detail?.editable
+                ? ' You can select and remove the placeholder entries here; transfers skip them.'
+                : ' Transfers skip these entries.'}
+            </p>
+          </div>
+        ) : null}
+
         {detail && detail.tracks.length > 0 ? (
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_12rem]">
             <label className="relative block">
@@ -305,7 +322,7 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
                 type="search"
                 value={query}
                 onChange={(event) => changeQuery(event.target.value)}
-                placeholder={`Search ${detail.tracks.length} tracks`}
+                placeholder={`Search ${detail.tracks.length}${loadingMore ? ' loaded' : ''} tracks`}
                 className={cn(FIELD_INPUT_CLASSES, 'pl-9')}
               />
             </label>
@@ -366,6 +383,19 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
           </p>
         ) : null}
 
+        {error && detail ? (
+          <p role="alert" className="rounded-control bg-danger-soft px-3.5 py-2.5 text-sm text-danger">
+            More tracks could not be loaded: {error}
+          </p>
+        ) : null}
+
+        {loadingMore && detail ? (
+          <p aria-live="polite" className="flex items-center gap-2 text-xs text-text-3">
+            <Spinner className="size-3.5 shrink-0" aria-hidden="true" />
+            Loaded {detail.tracks.length} of {detail.count} tracks from TIDAL…
+          </p>
+        ) : null}
+
         {loading && !detail ? (
           <LoadingStatus label={`Loading ${playlist?.name ?? 'playlist'} tracks…`}>
             <div className="flex flex-col gap-2">
@@ -398,6 +428,7 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
                     className={cn(
                       'playlist-track-row border-b border-border transition-colors last:border-b-0',
                       selected && 'bg-accent-soft/60',
+                      track.unavailable && 'bg-warning-soft/30',
                     )}
                   >
                     <div className="flex min-h-14 items-center gap-3 px-3 py-2 sm:px-4">
@@ -420,7 +451,9 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
                           </span>
                           <CoverArt image={track.image} className="size-10" />
                           <span className="min-w-0 flex-1">
-                            <span className="block truncate text-[13.5px] font-semibold text-text">{track.name}</span>
+                            <span className={cn('block truncate text-[13.5px] font-semibold text-text', track.unavailable && 'text-warning')}>
+                              {track.name}
+                            </span>
                             <span className="block truncate text-xs text-text-3">
                               {[track.artist, track.album, dateAdded].filter(Boolean).join(' · ') || 'Unknown artist'}
                             </span>
@@ -430,7 +463,9 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
                         <div className="flex min-w-0 flex-1 items-center gap-3">
                           <CoverArt image={track.image} className="size-10" />
                           <div className="min-w-0 flex-1">
-                            <p className="truncate text-[13.5px] font-semibold text-text">{track.name}</p>
+                            <p className={cn('truncate text-[13.5px] font-semibold text-text', track.unavailable && 'text-warning')}>
+                              {track.name}
+                            </p>
                             <p className="truncate text-xs text-text-3">
                               {[track.artist, track.album, dateAdded].filter(Boolean).join(' · ') || 'Unknown artist'}
                             </p>
@@ -482,7 +517,8 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
             </ol>
             <div className="flex flex-col gap-2 px-0.5 text-xs text-text-3 sm:flex-row sm:items-center sm:justify-between">
               <p aria-live="polite">
-                Showing {pageStart + 1}–{pageStart + pageTracks.length} of {orderedTracks.length} tracks · {PAGE_SIZE} per page
+                Showing {pageStart + 1}–{pageStart + pageTracks.length} of {orderedTracks.length}
+                {loadingMore ? ` loaded · ${detail.count} total` : ' tracks'} · {PAGE_SIZE} per page
               </p>
               {pageCount > 1 ? (
                 <div className="flex items-center gap-1.5">

--- a/frontend/src/components/transfers/TransferProgress.tsx
+++ b/frontend/src/components/transfers/TransferProgress.tsx
@@ -181,6 +181,7 @@ export function TransferProgress({
   const isActive = isRunning || isPaused
   const isDone = job.status === 'done'
   const isStopped = job.status === 'stopped'
+  const unavailable = job.unavailable ?? 0
   // `total` is 0 until the source playlist finishes reading; only then can the
   // bar go determinate. `processed` counts source tracks examined, not tracks
   // added (misses and already-present tracks still advance the scan).
@@ -237,6 +238,13 @@ export function TransferProgress({
 
       {job.error && <p className="rounded-control bg-danger-soft px-3 py-2 text-sm text-danger">{job.error}</p>}
 
+      {unavailable > 0 && (
+        <p className="rounded-control bg-warning-soft px-3 py-2 text-sm text-text-2">
+          Skipped {unavailable} unavailable TIDAL {unavailable === 1 ? 'entry' : 'entries'}. You can remove the hidden
+          {unavailable === 1 ? ' entry' : ' entries'} from the source playlist in the playlist inspector.
+        </p>
+      )}
+
       {isActive ? (
         <div className="flex flex-wrap items-end gap-4">
           {job.added > 0 || isPaused ? (
@@ -275,6 +283,7 @@ export function TransferProgress({
         <p className="text-sm text-text-2">
           <span className="font-semibold text-success">Done</span>
           <span className="font-mono"> · {job.added} added</span>
+          {unavailable > 0 && <span className="font-mono"> · {unavailable} unavailable skipped</span>}
           {job.deferred > 0 && <span className="font-mono"> · {job.deferred} deferred</span>}
           {unresolvedConflicts > 0 && <span className="font-mono"> · {unresolvedConflicts} need review</span>}
         </p>
@@ -282,12 +291,14 @@ export function TransferProgress({
         <p className="text-sm text-text-2">
           <span className="font-semibold text-text-2">Stopped</span>
           <span className="font-mono"> · {job.added} added</span>
+          {unavailable > 0 && <span className="font-mono"> · {unavailable} unavailable skipped</span>}
           {job.deferred > 0 && <span className="font-mono"> · {job.deferred} deferred</span>}
           {unresolvedConflicts > 0 && <span className="font-mono"> · {unresolvedConflicts} need review</span>}
         </p>
       ) : (
         <div className="flex flex-wrap gap-2">
           <CountChip tone="success" sign="+" value={job.added} />
+          {unavailable > 0 && <CountChip tone="warning" value={unavailable} />}
           {job.deferred > 0 && <CountChip tone="warning" value={job.deferred} />}
           {unresolvedConflicts > 0 && (
             <span className="inline-flex h-6 items-center rounded-chip bg-warning-soft px-2 font-mono text-xs font-semibold text-warning">

--- a/frontend/src/hooks/usePlaylistDetail.ts
+++ b/frontend/src/hooks/usePlaylistDetail.ts
@@ -1,43 +1,124 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import useSWR from 'swr'
 
 import { api, errorMessage } from '@/api'
 import type { ProviderPlaylistDetail } from '@/types'
 
-/** On-demand playlist contents. The server's SQLite-backed playlist cache makes
- * reopens instant; the visible Refresh action explicitly bypasses that cache. */
+const TIDAL_PAGE_SIZE = 20 as const
+
+/** On-demand playlist contents. Cached reads remain immediate; uncached TIDAL
+ * reads reveal the first provider page and append later cursor pages in place. */
 export function usePlaylistDetail(
   provider: string | null,
   playlistId: string | null,
   expectedCount?: number | null,
 ) {
+  const paged = provider === 'tidal'
   const key = provider && playlistId
     ? ['playlist-detail', provider, playlistId, expectedCount]
     : null
   const { data, error, isLoading, isValidating, mutate } = useSWR<ProviderPlaylistDetail>(
     key,
-    () => api.getPlaylistDetail(provider as string, playlistId as string, { expectedCount }),
+    () => api.getPlaylistDetail(provider as string, playlistId as string, {
+      expectedCount,
+      pageSize: paged ? TIDAL_PAGE_SIZE : undefined,
+    }),
     {
       revalidateOnFocus: false,
       dedupingInterval: 2_000,
     },
   )
+  const generation = useRef(0)
+  const loadingPages = useRef(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [pageError, setPageError] = useState<string | null>(null)
+
+  useEffect(() => {
+    generation.current += 1
+    loadingPages.current = false
+    setLoadingMore(false)
+    setRefreshing(false)
+    setPageError(null)
+    return () => {
+      generation.current += 1
+    }
+  }, [expectedCount, playlistId, provider])
+
+  useEffect(() => {
+    if (!paged || !provider || !playlistId || !data?.next_cursor || loadingPages.current) return
+
+    const currentGeneration = generation.current
+    loadingPages.current = true
+    setLoadingMore(true)
+    setPageError(null)
+
+    void (async () => {
+      let combined = data
+      let cursor = data.next_cursor
+      const seen = new Set<string>()
+
+      while (cursor && generation.current === currentGeneration) {
+        if (seen.has(cursor)) throw new Error('TIDAL returned a repeated playlist cursor')
+        seen.add(cursor)
+        const page = await api.getPlaylistDetail(provider, playlistId, {
+          expectedCount,
+          pageSize: TIDAL_PAGE_SIZE,
+          cursor,
+          offset: combined.tracks.length,
+        })
+        if (generation.current !== currentGeneration) return
+        combined = {
+          ...combined,
+          count: page.count ?? combined.count,
+          tracks: [...combined.tracks, ...page.tracks],
+          next_cursor: page.next_cursor,
+          complete: page.complete,
+        }
+        await mutate(combined, { revalidate: false })
+        cursor = page.next_cursor ?? null
+      }
+    })()
+      .catch((err: unknown) => {
+        if (generation.current === currentGeneration) setPageError(errorMessage(err))
+      })
+      .finally(() => {
+        if (generation.current === currentGeneration) {
+          loadingPages.current = false
+          setLoadingMore(false)
+        }
+      })
+  }, [data, expectedCount, mutate, paged, playlistId, provider])
 
   const refresh = useCallback(async () => {
-    await mutate(
-      api.getPlaylistDetail(provider as string, playlistId as string, {
+    const currentGeneration = generation.current + 1
+    generation.current = currentGeneration
+    loadingPages.current = false
+    setLoadingMore(false)
+    setRefreshing(true)
+    setPageError(null)
+    try {
+      const refreshed = await api.getPlaylistDetail(provider as string, playlistId as string, {
         refresh: true,
         expectedCount,
-      }),
-      { revalidate: false },
-    )
-  }, [expectedCount, mutate, playlistId, provider])
+        pageSize: paged ? TIDAL_PAGE_SIZE : undefined,
+      })
+      if (generation.current === currentGeneration) {
+        await mutate(refreshed, { revalidate: false })
+      }
+    } catch (err: unknown) {
+      if (generation.current === currentGeneration) setPageError(errorMessage(err))
+    } finally {
+      if (generation.current === currentGeneration) setRefreshing(false)
+    }
+  }, [expectedCount, mutate, paged, playlistId, provider])
 
   return {
     detail: data ?? null,
     loading: isLoading,
-    refreshing: isValidating,
-    error: error ? errorMessage(error) : null,
+    refreshing: isValidating || refreshing,
+    loadingMore,
+    error: error ? errorMessage(error) : pageError,
     refresh,
   }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -288,6 +288,8 @@ export interface ProviderPlaylistTrack {
   image: string
   added_at: string
   external_url: string
+  /** TIDAL relationship retained after its catalog metadata disappeared. */
+  unavailable?: boolean
 }
 
 export interface ProviderPlaylistDetail extends ProviderPlaylist {
@@ -295,6 +297,9 @@ export interface ProviderPlaylistDetail extends ProviderPlaylist {
   description: string
   editable: boolean
   tracks: ProviderPlaylistTrack[]
+  /** Opaque provider cursor while a large playlist is loading progressively. */
+  next_cursor?: string | null
+  complete?: boolean
 }
 
 export interface RemovePlaylistTrackRequest {
@@ -361,6 +366,8 @@ export interface TransferJob {
   dest: TransferEndpoint
   added: number
   deferred: number
+  /** Hidden source relationships skipped because the provider exposes no metadata. */
+  unavailable?: number
   /** Total source tracks to examine, or 0 before the source playlist has been
    * read (the progress bar stays indeterminate until then). */
   total: number

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -9,6 +9,7 @@ import random
 import re
 import time
 import uuid
+from urllib.parse import parse_qs, urlsplit
 
 import requests
 
@@ -26,6 +27,7 @@ API = "https://openapi.tidal.com/v2"
 TOKEN_URL = "https://auth.tidal.com/v1/oauth2/token"
 DEFAULT_TOKEN_FILE = "data/tidal_oauth.json"
 MAX_ISRC_FILTER_VALUES = 20
+PLAYLIST_ITEM_INCLUDE = ["items", "items.artists", "items.albums", "items.albums.coverArt"]
 
 
 class TidalTarget(MirrorTarget):
@@ -262,35 +264,145 @@ class TidalTarget(MirrorTarget):
         polite_sleep(0.4)
         return playlist
 
-    def playlist_tracks(self, playlist):
-        params = {"countryCode": self.country, "sort": "itemIndex"}
+    def _playlist_track_params(self, cursor=None):
+        # Ask the relationship endpoint to embed each item.  A playlist can
+        # retain a track after the top-level /tracks collection stops returning
+        # that catalog id; TIDAL still exposes its metadata in this context.
+        params = {
+            "countryCode": self.country,
+            "sort": "itemIndex",
+            "include": PLAYLIST_ITEM_INCLUDE,
+        }
+        if cursor:
+            params["page[cursor]"] = cursor
+        return params
+
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        """Minimal shape for a cursor continuation already validated on page one."""
+        return {
+            "id": str(playlist_id),
+            "attributes": {
+                "name": "",
+                "description": "",
+                "numberOfItems": expected_count,
+            },
+        }
+
+    @staticmethod
+    def _embedded_track_is_complete(track):
+        """Core identity fields required before embedded metadata is trusted."""
+        return bool(
+            track.get("name")
+            and any(track.get("artists") or [])
+            and track.get("duration_ms") is not None
+            and track.get("isrc")
+        )
+
+    @staticmethod
+    def _unavailable_playlist_track(track_id):
+        return {
+            "id": str(track_id),
+            "name": "Unavailable TIDAL track",
+            "artist": f"Catalog ID {track_id}",
+            "artists": [f"Catalog ID {track_id}"],
+            "album": None,
+            "image": "",
+            "duration_ms": None,
+            "isrc": None,
+            "unavailable": True,
+        }
+
+    def _playlist_tracks_from_body(self, body, *, allow_unavailable=False):
+        identifiers = [item for item in body.get("data") or [] if item.get("type") == "tracks"]
+        requested_ids = [str(item["id"]) for item in identifiers]
+        details = {
+            str(track["id"]): track
+            for track in self._tracks_from_body(body)
+            if self._embedded_track_is_complete(track)
+        }
+        missing = [track_id for track_id in requested_ids if track_id not in details]
+        if missing:
+            details.update(self._tracks_by_id(missing))
+            missing = [track_id for track_id in missing if track_id not in details]
+        if missing:
+            # The relationship listing is the membership authority; /tracks
+            # only hydrates metadata. TIDAL keeps serving a relationship after
+            # the catalog entry behind it disappears, so falling back to what
+            # that id last was keeps the entry a member instead of turning a
+            # delisting into a removal everywhere it is mirrored.
+            details = {**details, **self._archived_details(missing)}
+            missing = [track_id for track_id in missing if track_id not in details]
+        if missing and allow_unavailable:
+            details.update({
+                track_id: self._unavailable_playlist_track(track_id)
+                for track_id in missing
+            })
+            missing = []
+        if missing:
+            preview = ", ".join(missing[:5])
+            suffix = "..." if len(missing) > 5 else ""
+            raise RuntimeError(
+                "TIDAL playlist read incomplete: missing catalog details for "
+                f"{len(missing)} track relationship(s): {preview}{suffix}"
+            )
+
         tracks = []
-        for body in self._pages(f"playlists/{playlist['id']}/relationships/items", params):
-            identifiers = [item for item in body.get("data") or [] if item.get("type") == "tracks"]
-            requested_ids = [str(item["id"]) for item in identifiers]
-            details = self._tracks_by_id(requested_ids)
-            missing = [track_id for track_id in requested_ids if track_id not in details]
-            if missing:
-                # The relationship listing is the membership authority; /tracks
-                # only hydrates metadata. TIDAL keeps serving a relationship
-                # after the catalog entry behind it disappears, so falling back
-                # to what that id last was keeps the entry a member instead of
-                # turning a delisting into a removal everywhere it is mirrored.
-                details = {**details, **self._archived_details(missing)}
-                missing = [track_id for track_id in missing if track_id not in details]
-            if missing:
-                preview = ", ".join(missing[:5])
-                suffix = "..." if len(missing) > 5 else ""
-                raise RuntimeError(
-                    "TIDAL playlist read incomplete: missing catalog details for "
-                    f"{len(missing)} track relationship(s): {preview}{suffix}"
-                )
-            for item in identifiers:
-                track = details[str(item["id"])]
-                meta = item.get("meta") or {}
-                tracks.append({**track, "relationship_id": meta.get("itemId"),
-                               "added_at": meta.get("addedAt") or ""})
+        for item in identifiers:
+            track = details[str(item["id"])]
+            meta = item.get("meta") or {}
+            tracks.append({
+                **track,
+                "relationship_id": meta.get("itemId"),
+                "added_at": meta.get("addedAt") or "",
+            })
         return tracks
+
+    @staticmethod
+    def _playlist_next_cursor(body):
+        link = (body.get("links") or {}).get("next")
+        link = link.get("href") if isinstance(link, dict) else link
+        if not link:
+            return None
+        values = parse_qs(urlsplit(str(link)).query).get("page[cursor]") or []
+        if not values or not values[0]:
+            raise RuntimeError("TIDAL playlist pagination did not provide a next cursor")
+        return values[0]
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        body = self._request(
+            "GET",
+            f"playlists/{playlist['id']}/relationships/items",
+            params=self._playlist_track_params(cursor),
+        ).json()
+        return (
+            self._playlist_tracks_from_body(body, allow_unavailable=True),
+            self._playlist_next_cursor(body),
+        )
+
+    def _all_playlist_tracks(self, playlist, *, allow_unavailable=False):
+        tracks = []
+        path = f"playlists/{playlist['id']}/relationships/items"
+        for body in self._pages(path, self._playlist_track_params()):
+            tracks.extend(
+                self._playlist_tracks_from_body(
+                    body,
+                    allow_unavailable=allow_unavailable,
+                )
+            )
+        return tracks
+
+    def playlist_tracks(self, playlist):
+        """Strict sync read: incomplete metadata must abort reconciliation."""
+        return self._all_playlist_tracks(playlist)
+
+    def playlist_tracks_for_browse(self, playlist):
+        """Keep hidden entries visible and removable in the playlist inspector."""
+        return self._all_playlist_tracks(playlist, allow_unavailable=True)
+
+    def playlist_tracks_for_transfer(self, playlist):
+        """Return readable tracks plus marked hidden entries for add-only copies."""
+        return self._all_playlist_tracks(playlist, allow_unavailable=True)
 
     def _archived_details(self, ids):
         """Last-known metadata for track ids the catalog no longer describes."""

--- a/songmirror/services/playlists.py
+++ b/songmirror/services/playlists.py
@@ -296,6 +296,57 @@ class PlaylistService:
         self._prune_details(provider_id, [row["id"] for row in rows])
         return sorted(rows, key=lambda r: (r["name"] or "").casefold())
 
+    @staticmethod
+    def _normalize_tracks(provider_id, target, tracks, *, offset=0):
+        normalized = []
+        occurrence_id_getter = getattr(target, "occurrence_id", lambda track: None)
+        for position, track in enumerate(tracks, start=offset):
+            track_id = target.track_id(track)
+            if track_id is None:
+                continue
+            row = {
+                "position": position,
+                "id": str(track_id),
+                "isrc": str(track.get("isrc") or ""),
+                "occurrence_id": str(occurrence_id_getter(track) or ""),
+                "name": str(track.get("name") or track.get("title") or "Unknown track"),
+                "artist": _track_artist(track),
+                "album": track.get("album") or track.get("albumName"),
+                "duration_ms": track.get("duration_ms") or track.get("durationInMillis"),
+                "image": str(track.get("image") or _pl_image(track) or ""),
+                "added_at": str(
+                    track.get("added_at")
+                    or track.get("addedAt")
+                    or (track.get("attributes") or {}).get("dateAdded")
+                    or ""
+                ),
+                "external_url": (
+                    "" if track.get("unavailable")
+                    else _external_url(provider_id, "track", track_id)
+                ),
+            }
+            if track.get("unavailable"):
+                row["unavailable"] = True
+            normalized.append(row)
+        return normalized
+
+    @staticmethod
+    def _detail_payload(provider_id, playlist_id, target, playlist, tracks, *, count=None):
+        playlist_id_getter = getattr(target, "playlist_id", _pl_id)
+        playlist_id = str(playlist_id_getter(playlist) or playlist_id)
+        return {
+            "provider": provider_id,
+            "id": playlist_id,
+            "name": target.playlist_name(playlist),
+            "description": _plain_text(target.playlist_description(playlist)),
+            "count": len(tracks) if count is None else count,
+            "image": _pl_image(playlist),
+            "owned": bool(playlist.get("_owned", True)),
+            "editable": bool(target.is_editable(playlist)),
+            "external_url": _external_url(provider_id, "playlist", playlist_id),
+            "tracks": tracks,
+        }
+
     def detail(self, provider_id, playlist_id, *, refresh=False, expected_count=None):
         cached = self._cached_detail(provider_id, playlist_id)
         if (
@@ -316,53 +367,108 @@ class PlaylistService:
                 raise PlaylistNotFoundError(
                     f"That {_PROVIDER_NAMES.get(provider_id, provider_id)} playlist no longer exists. Refresh Browse."
                 )
-            tracks = target.playlist_tracks(playlist)
+            read_tracks = getattr(
+                target,
+                "playlist_tracks_for_browse",
+                target.playlist_tracks,
+            )
+            tracks = read_tracks(playlist)
         except PlaylistServiceError:
             raise
         except Exception as exc:
             self._failure(provider_id, "open that playlist", exc)
 
-        normalized = []
-        occurrence_id_getter = getattr(target, "occurrence_id", lambda track: None)
-        for position, track in enumerate(tracks):
-            track_id = target.track_id(track)
-            if track_id is None:
-                continue
-            normalized.append({
-                "position": position,
-                "id": str(track_id),
-                "isrc": str(track.get("isrc") or ""),
-                "occurrence_id": str(occurrence_id_getter(track) or ""),
-                "name": str(track.get("name") or track.get("title") or "Unknown track"),
-                "artist": _track_artist(track),
-                "album": track.get("album") or track.get("albumName"),
-                "duration_ms": track.get("duration_ms") or track.get("durationInMillis"),
-                "image": str(track.get("image") or _pl_image(track) or ""),
-                "added_at": str(
-                    track.get("added_at")
-                    or track.get("addedAt")
-                    or (track.get("attributes") or {}).get("dateAdded")
-                    or ""
-                ),
-                "external_url": _external_url(provider_id, "track", track_id),
-            })
-
-        playlist_id_getter = getattr(target, "playlist_id", _pl_id)
-        playlist_id = str(playlist_id_getter(playlist) or playlist_id)
-        detail = {
-            "provider": provider_id,
-            "id": playlist_id,
-            "name": target.playlist_name(playlist),
-            "description": _plain_text(target.playlist_description(playlist)),
-            "count": len(normalized),
-            "image": _pl_image(playlist),
-            "owned": bool(playlist.get("_owned", True)),
-            "editable": bool(target.is_editable(playlist)),
-            "external_url": _external_url(provider_id, "playlist", playlist_id),
-            "tracks": normalized,
-        }
-        self._cache_detail(detail)
+        normalized = self._normalize_tracks(provider_id, target, tracks)
+        detail = self._detail_payload(
+            provider_id,
+            playlist_id,
+            target,
+            playlist,
+            normalized,
+        )
+        # Hidden TIDAL relationships are useful in the inspector but are not
+        # authoritative song metadata. Avoid persisting placeholders into the
+        # archive, where a later strict sync read could mistake them for truth.
+        if not any(track.get("unavailable", False) for track in normalized):
+            self._cache_detail(detail)
         return detail
+
+    def detail_page(
+        self,
+        provider_id,
+        playlist_id,
+        *,
+        cursor=None,
+        offset=0,
+        refresh=False,
+        expected_count=None,
+    ):
+        """Return one provider-native track page for progressive playlist UI."""
+        if cursor is None:
+            cached = self._cached_detail(provider_id, playlist_id)
+            if (
+                cached is not None
+                and not refresh
+                and (expected_count is None or cached["count"] == expected_count)
+            ):
+                return {**cached, "next_cursor": None, "complete": True}
+            if refresh:
+                self._invalidate_detail(provider_id, playlist_id)
+
+        target = self._target(provider_id)
+        page_reader = getattr(target, "playlist_tracks_page", None)
+        if page_reader is None:
+            return {
+                **self.detail(
+                    provider_id,
+                    playlist_id,
+                    refresh=refresh,
+                    expected_count=expected_count,
+                ),
+                "next_cursor": None,
+                "complete": True,
+            }
+        try:
+            page_reference = getattr(target, "playlist_page_reference", None)
+            playlist = (
+                page_reference(str(playlist_id), expected_count)
+                if cursor is not None and page_reference is not None
+                else target.find_playlist(str(playlist_id))
+            )
+            if playlist is None:
+                self._invalidate_detail(provider_id, playlist_id)
+                raise PlaylistNotFoundError(
+                    f"That {_PROVIDER_NAMES.get(provider_id, provider_id)} playlist no longer exists. Refresh Browse."
+                )
+            tracks, next_cursor = page_reader(playlist, cursor=cursor)
+        except PlaylistServiceError:
+            raise
+        except Exception as exc:
+            self._failure(provider_id, "open that playlist", exc)
+
+        normalized = self._normalize_tracks(
+            provider_id,
+            target,
+            tracks,
+            offset=offset,
+        )
+        count = target.playlist_count(playlist)
+        if count is None:
+            count = expected_count
+        if count is None:
+            count = offset + len(normalized)
+        return {
+            **self._detail_payload(
+                provider_id,
+                playlist_id,
+                target,
+                playlist,
+                normalized,
+                count=count,
+            ),
+            "next_cursor": next_cursor,
+            "complete": next_cursor is None,
+        }
 
     def remove_track(self, provider_id, playlist_id, *, position, track_id, occurrence_id=""):
         self.remove_tracks(provider_id, playlist_id, selections=[{

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -12,7 +12,7 @@ import uuid
 
 from ..engine import logs, spotify, spotify_cookie
 from ..engine.config import parse_args, spotify_write_backend
-from ..engine.logs import log_add, log_miss
+from ..engine.logs import log_add, log_miss, log_warn
 from ..engine.matching import spotify_track_keys, track_key, tracks_oldest_first
 from ..engine.runner import load_cache, save_cache
 from ..engine.targets import build_one, is_peer
@@ -21,8 +21,10 @@ from ..engine.targets.base import TargetAuthError, _normalize
 
 def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_progress=None, should_continue=None):
     """Copy `src_pl` (on `source`) into `dest_pl` (on `dest`). Returns
-    {added, deferred, not_found: [{name, artist, key}], completed}. `not_found`
-    are tracks that resolved to nothing on the destination — the conflict queue.
+    {added, deferred, unavailable, not_found: [{name, artist, key}], completed}.
+    `not_found` are tracks that resolved to nothing on the destination — the
+    conflict queue. `unavailable` counts hidden source relationships that have
+    no metadata and are safely skipped by this adds-only workflow.
 
     `on_progress(processed, total, added)` (optional) fires after each source
     track is examined, so a caller can surface live progress against the total.
@@ -32,20 +34,48 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
     `completed=False`. Adds gathered before the break are still written, so a
     later re-run skips them (its dedup rebuilds from the destination) and resumes.
     """
-    src = [_normalize(t, source.source) for t in source.playlist_tracks(src_pl)]
-    dst = [_normalize(t, dest.source) for t in dest.playlist_tracks(dest_pl)]
+    read_source = getattr(
+        source,
+        "playlist_tracks_for_transfer",
+        source.playlist_tracks,
+    )
+    raw_source = list(read_source(src_pl))
+    unavailable = [track for track in raw_source if track.get("unavailable")]
+    src = [
+        _normalize(track, source.source)
+        for track in raw_source
+        if not track.get("unavailable")
+    ]
+    read_destination = getattr(
+        dest,
+        "playlist_tracks_for_transfer",
+        dest.playlist_tracks,
+    )
+    dst = [
+        _normalize(track, dest.source)
+        for track in read_destination(dest_pl)
+        if not track.get("unavailable")
+    ]
     seen = set().union(*(spotify_track_keys(n) for n in dst)) if dst else set()
 
-    total = len(src)
+    unavailable_count = len(unavailable)
+    total = len(raw_source)
+    if unavailable_count:
+        log_warn(
+            f"skipping {unavailable_count} unavailable source playlist "
+            f"entr{'y' if unavailable_count == 1 else 'ies'}",
+            tag="transfer",
+        )
     if on_progress:
-        on_progress(0, total, 0)  # publish the total once source is read, before matching begins
+        # Hidden entries are already processed: they cannot be matched or added.
+        on_progress(unavailable_count, total, 0)
     # Same-provider copy (e.g. a followed Spotify list into a new owned one): the
     # track's own id is already valid on the destination, so use it directly instead
     # of re-searching for it (which resolve() does for the cross-provider case).
     same_provider = source.source == dest.source
     additions, not_found = [], []
     completed = True
-    for i, norm in enumerate(tracks_oldest_first(src), 1):
+    for i, norm in enumerate(tracks_oldest_first(src), unavailable_count + 1):
         if should_continue and should_continue() != "run":
             completed = False  # paused or stopped — leave the rest for a re-run
             break
@@ -75,7 +105,13 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
     additions = additions[:max_adds]
     if execute and additions:
         dest.add(dest_pl, additions)
-    return {"added": len(additions), "deferred": deferred, "not_found": not_found, "completed": completed}
+    return {
+        "added": len(additions),
+        "deferred": deferred,
+        "unavailable": unavailable_count,
+        "not_found": not_found,
+        "completed": completed,
+    }
 
 
 def _friendly_error(e):
@@ -113,7 +149,7 @@ class TransferService:
             "dest": {"provider": spec["dest_provider"],
                      "playlist_id": spec.get("dest_playlist_id"),
                      "playlist_name": spec.get("dest_name", "")},
-            "added": 0, "deferred": 0, "conflicts": [], "error": None,
+            "added": 0, "deferred": 0, "unavailable": 0, "conflicts": [], "error": None,
             "total": 0, "processed": 0,  # live progress: source tracks examined / total
             "_spec": spec,      # kept so resume can re-run the same copy
             "_control": "run",  # "run" | "pause" | "stop" — polled by the running loop
@@ -231,11 +267,17 @@ class TransferService:
             res = await self._sync.run_exclusive(work)
             job["added"] = base_added + res["added"]
             job["deferred"] = res["deferred"]
+            job["unavailable"] = res["unavailable"]
             job["conflicts"] = [{**c, "resolved": False} for c in res["not_found"]]
             if res["completed"]:
                 job["status"] = "done"
-                self._emit("summary", f"transfer done: +{job['added']} ({len(res['not_found'])} unmatched)",
-                           "transfer", {"job_id": job["id"]})
+                self._emit(
+                    "summary",
+                    f"transfer done: +{job['added']} ({len(res['not_found'])} unmatched, "
+                    f"{res['unavailable']} unavailable skipped)",
+                    "transfer",
+                    {"job_id": job["id"]},
+                )
             else:
                 job["status"] = "stopped" if job.get("_control") == "stop" else "paused"
                 self._emit("note", f"transfer {job['status']}: +{job['added']} so far", "transfer")

--- a/songmirror/web/routers/playlists.py
+++ b/songmirror/web/routers/playlists.py
@@ -26,8 +26,34 @@ def playlist_detail(
     playlist_id: str,
     refresh: bool = False,
     expected_count: int | None = None,
+    page_size: int | None = None,
+    cursor: str | None = None,
+    offset: int = 0,
 ):
+    if page_size is not None and page_size != 20:
+        raise HTTPException(status_code=422, detail="page_size must be 20")
+    if offset < 0:
+        raise HTTPException(status_code=422, detail="offset must be non-negative")
+    if cursor is not None and not cursor.strip():
+        raise HTTPException(status_code=422, detail="cursor must not be blank")
+    if cursor is not None and page_size is None:
+        raise HTTPException(status_code=422, detail="cursor requires page_size")
+    if offset != 0 and (page_size is None or cursor is None):
+        raise HTTPException(status_code=422, detail="offset requires page_size and cursor")
+    if cursor is not None and offset == 0:
+        raise HTTPException(status_code=422, detail="cursor requires a positive offset")
+    if cursor is not None and len(cursor) > 2048:
+        raise HTTPException(status_code=422, detail="cursor is too long")
     try:
+        if page_size is not None:
+            return PlaylistService(request.app.state.settings).detail_page(
+                provider,
+                playlist_id,
+                cursor=cursor or None,
+                offset=offset,
+                refresh=refresh,
+                expected_count=expected_count,
+            )
         return PlaylistService(request.app.state.settings).detail(
             provider,
             playlist_id,

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -54,6 +54,114 @@ def test_tidal_jsonapi_track_shape_carries_isrc_artist_and_entry_id():
     }
 
 
+def test_tidal_playlist_read_uses_embedded_items_when_catalog_lookup_omits_track(monkeypatch):
+    """Playlist relationships retain metadata for catalog entries /tracks omits."""
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    target = TidalTarget.__new__(TidalTarget)
+    target.country = "US"
+    target._songs = None
+    calls = []
+    page = {
+        "data": [{
+            "type": "tracks",
+            "id": "delisted",
+            "meta": {"itemId": "entry-1", "addedAt": "2026-08-14T16:20:58Z"},
+        }],
+        "included": [
+            {
+                "type": "tracks",
+                "id": "delisted",
+                "attributes": {
+                    "title": "Still in the playlist",
+                    "duration": "PT3M2S",
+                    "isrc": "USAAA2600001",
+                },
+                "relationships": {
+                    "artists": {"data": [{"type": "artists", "id": "artist-1"}]},
+                    "albums": {"data": [{"type": "albums", "id": "album-1"}]},
+                },
+            },
+            {"type": "artists", "id": "artist-1", "attributes": {"name": "Artist"}},
+            {"type": "albums", "id": "album-1", "attributes": {"title": "Album"}},
+        ],
+    }
+
+    def pages(path, params):
+        calls.append((path, params))
+        return iter([page])
+
+    monkeypatch.setattr(target, "_pages", pages)
+    monkeypatch.setattr(
+        target,
+        "_tracks_by_id",
+        lambda ids: pytest.fail("embedded playlist metadata must be used before /tracks"),
+    )
+
+    tracks = target.playlist_tracks({"id": "playlist"})
+
+    assert calls == [(
+        "playlists/playlist/relationships/items",
+        {
+            "countryCode": "US",
+            "sort": "itemIndex",
+            "include": ["items", "items.artists", "items.albums", "items.albums.coverArt"],
+        },
+    )]
+    assert tracks == [{
+        "id": "delisted",
+        "relationship_id": "entry-1",
+        "name": "Still in the playlist",
+        "artist": "Artist",
+        "artists": ["Artist"],
+        "album": "Album",
+        "image": "",
+        "duration_ms": 182000,
+        "isrc": "USAAA2600001",
+        "added_at": "2026-08-14T16:20:58Z",
+    }]
+
+
+def test_tidal_playlist_read_enriches_partial_embedded_metadata(monkeypatch):
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    target = TidalTarget.__new__(TidalTarget)
+    target.country = "US"
+    target._songs = None
+    page = {
+        "data": [{"type": "tracks", "id": "track-1", "meta": {"itemId": "entry-1"}}],
+        "included": [{
+            "type": "tracks",
+            "id": "track-1",
+            "attributes": {"title": "Partial"},
+        }],
+    }
+    looked_up = []
+    monkeypatch.setattr(target, "_pages", lambda path, params: iter([page]))
+
+    def tracks_by_id(ids):
+        looked_up.extend(ids)
+        return {"track-1": {
+            "id": "track-1",
+            "name": "Complete",
+            "artist": "Artist",
+            "artists": ["Artist"],
+            "album": "Album",
+            "image": "",
+            "duration_ms": 182000,
+            "isrc": "USAAA2600001",
+        }}
+
+    monkeypatch.setattr(target, "_tracks_by_id", tracks_by_id)
+
+    tracks = target.playlist_tracks({"id": "playlist"})
+
+    assert looked_up == ["track-1"]
+    assert tracks[0]["name"] == "Complete"
+    assert tracks[0]["artist"] == "Artist"
+    assert tracks[0]["relationship_id"] == "entry-1"
+
+
 def test_tidal_playlist_read_fails_closed_when_catalog_detail_is_missing(monkeypatch):
     from songmirror.engine.targets.tidal import TidalTarget
 
@@ -124,6 +232,38 @@ def test_tidal_playlist_read_fails_closed_when_the_archive_cannot_identify_it(tm
     with pytest.raises(RuntimeError, match=r"incomplete.*t9"):
         target.playlist_tracks({"id": "playlist"})
     conn.close()
+
+
+def test_tidal_browse_read_keeps_unknown_entry_as_removable_placeholder():
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    target = TidalTarget.__new__(TidalTarget)
+    target.country = "US"
+    target._songs = None
+    target._pages = lambda path, params: iter([{
+        "data": [{
+            "type": "tracks",
+            "id": "hidden-1",
+            "meta": {"itemId": "entry-hidden", "addedAt": "2020-01-01"},
+        }],
+    }])
+    target._tracks_by_id = lambda ids: {}
+
+    tracks = target.playlist_tracks_for_browse({"id": "playlist"})
+
+    assert tracks == [{
+        "id": "hidden-1",
+        "name": "Unavailable TIDAL track",
+        "artist": "Catalog ID hidden-1",
+        "artists": ["Catalog ID hidden-1"],
+        "album": None,
+        "image": "",
+        "duration_ms": None,
+        "isrc": None,
+        "unavailable": True,
+        "relationship_id": "entry-hidden",
+        "added_at": "2020-01-01",
+    }]
 
 
 def test_tidal_connector_accepts_minimized_browser_headers(tmp_path, monkeypatch):

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -323,6 +323,136 @@ def test_playlist_detail_reuses_cache_until_explicit_refresh(monkeypatch, tmp_pa
     assert reads == ["playlist-1", "playlist-1"]
 
 
+def test_playlist_detail_page_returns_one_provider_page_with_total_and_offset(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    calls = []
+
+    class Target:
+        def find_playlist(self, playlist_id):
+            raise AssertionError("cursor pages must not rescan the provider playlist library")
+
+        def playlist_page_reference(self, playlist_id, expected_count=None):
+            return {
+                "id": playlist_id,
+                "attributes": {"name": "", "numberOfItems": expected_count},
+            }
+
+        def playlist_tracks_page(self, playlist, cursor=None):
+            calls.append((playlist["id"], cursor))
+            return ([{
+                "id": "track-21",
+                "name": "Next page",
+                "artist": "Artist",
+                "relationship_id": "entry-21",
+            }], "cursor-2")
+
+        def track_id(self, track):
+            return track["id"]
+
+        def occurrence_id(self, track):
+            return track.get("relationship_id")
+
+        def playlist_id(self, playlist):
+            return playlist["id"]
+
+        def playlist_count(self, playlist):
+            return playlist["attributes"]["numberOfItems"]
+
+        def playlist_name(self, playlist):
+            return playlist["attributes"]["name"]
+
+        def playlist_description(self, playlist):
+            return ""
+
+        def is_editable(self, playlist):
+            return True
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    detail = service.detail_page(
+        "tidal",
+        "playlist-1",
+        cursor="cursor-1",
+        offset=20,
+        expected_count=137,
+    )
+
+    assert calls == [("playlist-1", "cursor-1")]
+    assert detail["count"] == 137
+    assert detail["next_cursor"] == "cursor-2"
+    assert detail["complete"] is False
+    assert detail["tracks"][0]["position"] == 20
+    assert detail["tracks"][0]["occurrence_id"] == "entry-21"
+
+
+def test_playlist_detail_exposes_unavailable_tidal_entries_without_caching_them(monkeypatch, tmp_path):
+    from songmirror.services.playlists import PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    reads = []
+
+    class Target:
+        def find_playlist(self, playlist_id):
+            return {"id": playlist_id, "attributes": {"name": "Old mix"}}
+
+        def playlist_tracks(self, playlist):
+            raise AssertionError("playlist browsing must use the tolerant reader")
+
+        def playlist_tracks_for_browse(self, playlist):
+            reads.append(playlist["id"])
+            return [{
+                "id": "hidden-1",
+                "name": "Unavailable TIDAL track",
+                "artist": "Catalog ID hidden-1",
+                "relationship_id": "entry-hidden",
+                "unavailable": True,
+            }]
+
+        def track_id(self, track):
+            return track["id"]
+
+        def occurrence_id(self, track):
+            return track.get("relationship_id")
+
+        def playlist_id(self, playlist):
+            return playlist["id"]
+
+        def playlist_name(self, playlist):
+            return playlist["attributes"]["name"]
+
+        def playlist_description(self, playlist):
+            return ""
+
+        def is_editable(self, playlist):
+            return True
+
+    service = PlaylistService(SettingsStore(dir=tmp_path))
+    monkeypatch.setattr(service, "_target", lambda provider: Target())
+
+    first = service.detail("tidal", "playlist-1")
+    second = service.detail("tidal", "playlist-1")
+
+    assert reads == ["playlist-1", "playlist-1"]
+    assert first == second
+    assert first["tracks"] == [{
+        "position": 0,
+        "id": "hidden-1",
+        "isrc": "",
+        "occurrence_id": "entry-hidden",
+        "name": "Unavailable TIDAL track",
+        "artist": "Catalog ID hidden-1",
+        "album": None,
+        "duration_ms": None,
+        "image": "",
+        "added_at": "",
+        "external_url": "",
+        "unavailable": True,
+    }]
+
+
 def test_browse_prunes_cache_for_a_deleted_or_recreated_playlist(monkeypatch, tmp_path):
     from songmirror.engine import archive
     from songmirror.services.playlists import PlaylistService

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -45,6 +45,115 @@ def test_transfer_copies_matches_skips_dupes_reports_conflicts():
     # "Dup" already exists on the destination (same track_key) -> skipped, not re-added
 
 
+def test_transfer_skips_unavailable_tidal_entries_without_aborting():
+    added = []
+    progress = []
+
+    class _TidalSource:
+        source = "tidal"
+
+        def playlist_tracks(self, playlist):
+            raise AssertionError("one-off transfers must use the tolerant source reader")
+
+        def playlist_tracks_for_transfer(self, playlist):
+            return [
+                {
+                    "id": "hidden",
+                    "name": "Unavailable TIDAL track",
+                    "artist": "Catalog ID hidden",
+                    "unavailable": True,
+                },
+                {
+                    "id": "available",
+                    "name": "Available",
+                    "artists": ["Artist"],
+                    "duration_ms": 1000,
+                    "isrc": "USAAA2600001",
+                },
+            ]
+
+    class _Destination:
+        source = "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def resolve(self, track, cache):
+            return "apple-track", "isrc"
+
+        def add(self, playlist, ids):
+            added.extend(ids)
+
+    result = transfer(
+        _TidalSource(),
+        _Destination(),
+        {"id": "source"},
+        {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True,
+        max_adds=100,
+        on_progress=lambda processed, total, added_count: progress.append(
+            (processed, total, added_count)
+        ),
+    )
+
+    assert result["added"] == 1
+    assert result["unavailable"] == 1
+    assert result["not_found"] == []
+    assert added == ["apple-track"]
+    assert progress == [(1, 2, 0), (2, 2, 1)]
+
+
+def test_transfer_ignores_unavailable_tidal_destination_entries_during_dedup():
+    added = []
+
+    class _Source:
+        source = "apple"
+
+        def playlist_tracks(self, playlist):
+            return [{
+                "id": "source-track",
+                "name": "Available",
+                "artists": ["Artist"],
+                "duration_ms": 1000,
+                "isrc": "USAAA2600001",
+            }]
+
+    class _TidalDestination:
+        source = "tidal"
+
+        def playlist_tracks(self, playlist):
+            raise AssertionError("add-only destination dedup must use the tolerant reader")
+
+        def playlist_tracks_for_transfer(self, playlist):
+            return [{
+                "id": "hidden",
+                "name": "Unavailable TIDAL track",
+                "artist": "Catalog ID hidden",
+                "unavailable": True,
+            }]
+
+        def resolve(self, track, cache):
+            return "tidal-track", "isrc"
+
+        def add(self, playlist, ids):
+            added.extend(ids)
+
+    result = transfer(
+        _Source(),
+        _TidalDestination(),
+        {"id": "source"},
+        {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True,
+        max_adds=100,
+    )
+
+    assert result["added"] == 1
+    assert result["unavailable"] == 0
+    assert added == ["tidal-track"]
+
+
 def test_transfer_same_provider_copies_by_id_without_resolving():
     # Spotify -> Spotify (e.g. a followed list into a new owned one): the track's own
     # id is already valid on the destination, so transfer() copies it directly and

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,7 @@
 """Web layer smoke tests (FastAPI TestClient)."""
 
+import pytest
+
 from fastapi.testclient import TestClient
 
 from songmirror.services.settings import SettingsStore
@@ -311,6 +313,63 @@ def test_playlist_detail_and_serialized_remove_routes(tmp_path, monkeypatch):
     )]
     assert removed.json() == {"ok": True}
     assert seen == [("spotify", "playlist-1", 4, "track-5", "")]
+
+
+def test_playlist_detail_route_forwards_page_cursor(tmp_path, monkeypatch):
+    from songmirror.services.playlists import PlaylistService
+
+    calls = []
+
+    def detail_page(self, provider, playlist_id, **kwargs):
+        calls.append((provider, playlist_id, kwargs))
+        return {
+            "provider": provider,
+            "id": playlist_id,
+            "name": "Party",
+            "count": 137,
+            "tracks": [],
+            "next_cursor": "cursor-2",
+            "complete": False,
+        }
+
+    monkeypatch.setattr(PlaylistService, "detail_page", detail_page, raising=False)
+    monkeypatch.setattr(
+        PlaylistService,
+        "detail",
+        lambda *args, **kwargs: pytest.fail("paged reads must not load the full playlist"),
+    )
+
+    with TestClient(_app(tmp_path)) as client:
+        response = client.get(
+            "/api/playlists/tidal/playlist-1",
+            params={
+                "page_size": 20,
+                "cursor": "cursor-1",
+                "offset": 20,
+                "expected_count": 137,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["next_cursor"] == "cursor-2"
+    assert calls == [(
+        "tidal",
+        "playlist-1",
+        {"cursor": "cursor-1", "offset": 20, "refresh": False, "expected_count": 137},
+    )]
+
+
+@pytest.mark.parametrize("query", [
+    "offset=20",
+    "page_size=20&offset=20",
+    "page_size=20&cursor=cursor-1",
+    "page_size=20&cursor=%20&offset=20",
+])
+def test_playlist_detail_route_rejects_incomplete_page_coordinates(tmp_path, query):
+    with TestClient(_app(tmp_path)) as client:
+        response = client.get(f"/api/playlists/tidal/playlist-1?{query}")
+
+    assert response.status_code == 422
 
 
 def test_playlist_bulk_remove_route(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- hydrate TIDAL playlist relationships from their embedded JSON:API track metadata before falling back to the top-level catalog endpoint
- render genuinely unavailable relationships as removable placeholders and skip them in one-off, add-only transfers instead of aborting the copy
- load TIDAL playlist details in 20-track cursor pages so the modal becomes usable immediately and continues filling in the background

## Safety

Synchronization still uses the strict TIDAL reader. Unknown relationships therefore cannot be mistaken for deletions or propagate destructive changes. Placeholder metadata is never written to the song archive, while add-only transfer dedup tolerates unavailable entries on either endpoint.

## Verification

- `uv run python -m pytest -q` — 308 passed, 1 skipped
- `pnpm lint` and `pnpm build`
- `CI=1 pnpm test:e2e` — 119 browser checks, 0 horizontal-overflow failures
- rebuilt Docker deployment is healthy at `http://127.0.0.1:8888`
- live 271-track TIDAL playlist returned its first 20 tracks in 0.71 seconds instead of blocking for roughly 12.4 seconds; all 271 loaded across 14 cursor pages and retained the two catalog IDs that reproduced the original failure

Fixes #16