### PR TITLE
perf(playlists): load details progressively across providers

### DIFF
--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -788,6 +788,13 @@ async function main() {
       const context = await browser.newContext()
       await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'dark'))
       const page = await context.newPage()
+      const spotifyDetailRequests = []
+      page.on('request', (request) => {
+        const url = new URL(request.url())
+        if (url.pathname === '/api/playlists/spotify/pl_spotify_1') {
+          spotifyDetailRequests.push(Object.fromEntries(url.searchParams))
+        }
+      })
       await installMocks(page)
       await page.route('**/api/accounts', async (route) => {
         await route.fulfill({
@@ -808,6 +815,10 @@ async function main() {
       const secondLatest = await dialog.locator('ol > li').nth(1).textContent()
       const firstPageRows = await dialog.locator('ol > li').count()
       const firstPageCovers = await dialog.locator('ol > li img').count()
+      const progressiveRequestOk = spotifyDetailRequests.length === 1
+        && spotifyDetailRequests[0].page_size === '20'
+      console.log(`${progressiveRequestOk ? 'ok        ' : 'FAIL      '} Spotify playlist detail opts into progressive provider pages`)
+      if (!progressiveRequestOk) results.push({ label: 'Spotify progressive playlist request', overflow: true })
       const latestOk = firstLatest?.includes('Track 117')
         && secondLatest?.includes('Track 118')
         && firstPageRows === 50

--- a/frontend/src/components/playlists/PlaylistDetailModal.tsx
+++ b/frontend/src/components/playlists/PlaylistDetailModal.tsx
@@ -392,7 +392,7 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
         {loadingMore && detail ? (
           <p aria-live="polite" className="flex items-center gap-2 text-xs text-text-3">
             <Spinner className="size-3.5 shrink-0" aria-hidden="true" />
-            Loaded {detail.tracks.length} of {detail.count} tracks from TIDAL…
+            Loaded {detail.tracks.length} of {detail.count} tracks from {account?.name ?? 'the provider'}…
           </p>
         ) : null}
 

--- a/frontend/src/hooks/usePlaylistDetail.ts
+++ b/frontend/src/hooks/usePlaylistDetail.ts
@@ -4,16 +4,16 @@ import useSWR from 'swr'
 import { api, errorMessage } from '@/api'
 import type { ProviderPlaylistDetail } from '@/types'
 
-const TIDAL_PAGE_SIZE = 20 as const
+const PROGRESSIVE_PAGE_SIZE = 20 as const
 
-/** On-demand playlist contents. Cached reads remain immediate; uncached TIDAL
- * reads reveal the first provider page and append later cursor pages in place. */
+/** On-demand playlist contents. Cached reads remain immediate; uncached reads
+ * reveal the first provider page and append later cursor pages in place. */
 export function usePlaylistDetail(
   provider: string | null,
   playlistId: string | null,
   expectedCount?: number | null,
 ) {
-  const paged = provider === 'tidal'
+  const paged = provider !== null && provider !== 'jellyfin'
   const key = provider && playlistId
     ? ['playlist-detail', provider, playlistId, expectedCount]
     : null
@@ -21,7 +21,7 @@ export function usePlaylistDetail(
     key,
     () => api.getPlaylistDetail(provider as string, playlistId as string, {
       expectedCount,
-      pageSize: paged ? TIDAL_PAGE_SIZE : undefined,
+      pageSize: paged ? PROGRESSIVE_PAGE_SIZE : undefined,
     }),
     {
       revalidateOnFocus: false,
@@ -59,19 +59,24 @@ export function usePlaylistDetail(
       const seen = new Set<string>()
 
       while (cursor && generation.current === currentGeneration) {
-        if (seen.has(cursor)) throw new Error('TIDAL returned a repeated playlist cursor')
+        if (seen.has(cursor)) throw new Error('The provider returned a repeated playlist cursor')
         seen.add(cursor)
         const page = await api.getPlaylistDetail(provider, playlistId, {
           expectedCount,
-          pageSize: TIDAL_PAGE_SIZE,
+          pageSize: PROGRESSIVE_PAGE_SIZE,
           cursor,
           offset: combined.tracks.length,
         })
         if (generation.current !== currentGeneration) return
+        const tracks = [...combined.tracks, ...page.tracks]
         combined = {
           ...combined,
-          count: page.count ?? combined.count,
-          tracks: [...combined.tracks, ...page.tracks],
+          // A continuation built from a minimal provider reference may not
+          // know the catalog total. Never let its partial count shrink the
+          // authoritative first-page total; unknown totals can still grow as
+          // pages arrive.
+          count: Math.max(combined.count ?? 0, page.count ?? 0, tracks.length),
+          tracks,
           next_cursor: page.next_cursor,
           complete: page.complete,
         }
@@ -101,7 +106,7 @@ export function usePlaylistDetail(
       const refreshed = await api.getPlaylistDetail(provider as string, playlistId as string, {
         refresh: true,
         expectedCount,
-        pageSize: paged ? TIDAL_PAGE_SIZE : undefined,
+        pageSize: paged ? PROGRESSIVE_PAGE_SIZE : undefined,
       })
       if (generation.current === currentGeneration) {
         await mutate(refreshed, { revalidate: false })

--- a/songmirror/deezer_web.py
+++ b/songmirror/deezer_web.py
@@ -350,20 +350,37 @@ class DeezerWebClient:
     def playlist_tracks(self, playlist_id: str) -> list[dict]:
         rows, cursor = [], None
         while True:
-            data = self.execute(
-                "SongMirrorDeezerPlaylistTracks",
-                PLAYLIST_TRACKS_QUERY,
-                {"playlistId": str(playlist_id), "first": 100, "cursor": cursor},
+            page_rows, cursor = self.playlist_tracks_page(
+                playlist_id,
+                cursor=cursor,
+                limit=100,
             )
-            connection = (((data.get("playlist") or {}).get("tracks")) or {})
-            rows.extend(edge.get("node") or {} for edge in connection.get("edges") or [])
-            page = connection.get("pageInfo") or {}
-            if not page.get("hasNextPage"):
+            rows.extend(page_rows)
+            if cursor is None:
                 return rows
-            next_cursor = page.get("endCursor")
-            if not next_cursor or next_cursor == cursor:
-                raise RuntimeError("Deezer returned a non-advancing playlist cursor")
-            cursor = next_cursor
+
+    def playlist_tracks_page(
+        self,
+        playlist_id: str,
+        cursor: str | None = None,
+        limit: int = 20,
+    ) -> tuple[list[dict], str | None]:
+        data = self.execute(
+            "SongMirrorDeezerPlaylistTracks",
+            PLAYLIST_TRACKS_QUERY,
+            {"playlistId": str(playlist_id), "first": limit, "cursor": cursor},
+        )
+        connection = (((data.get("playlist") or {}).get("tracks")) or {})
+        rows = [edge.get("node") or {} for edge in connection.get("edges") or []]
+        page = connection.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            return rows, None
+        next_cursor = page.get("endCursor")
+        if not next_cursor or next_cursor == cursor:
+            raise RuntimeError("Deezer returned a non-advancing playlist cursor")
+        if not rows:
+            raise RuntimeError("Deezer playlist read incomplete: an empty page advertised more tracks")
+        return rows, str(next_cursor)
 
     def create(self, title: str, description: str = "") -> dict:
         create_input = {

--- a/songmirror/engine/spotify.py
+++ b/songmirror/engine/spotify.py
@@ -263,6 +263,32 @@ def playlist_item_track(item):
     return track
 
 
+def _playlist_item_tracks(items):
+    tracks = []
+    for item in items:
+        track = playlist_item_track(item)
+        if not track:
+            continue
+        artists = [a.get("name", "") for a in track.get("artists", []) if a.get("name")]
+        album = track.get("album") or {}
+        images = [image for image in album.get("images") or [] if image and image.get("url")]
+        image = min(
+            images,
+            key=lambda candidate: abs(int(candidate.get("width") or 96) - 96),
+        )["url"] if images else ""
+        tracks.append({
+            "id": track.get("id"),
+            "isrc": (track.get("external_ids") or {}).get("isrc"),
+            "name": track.get("name", ""),
+            "artists": artists or [""],
+            "album": album.get("name"),
+            "duration_ms": track.get("duration_ms"),
+            "added_at": item.get("added_at") or "",
+            "image": image,
+        })
+    return tracks
+
+
 def _playlist_tracks_api(sp, playlist_id):
     tracks = []
     results = _retry(
@@ -270,30 +296,60 @@ def _playlist_tracks_api(sp, playlist_id):
         "playlist_items",
     )
     while results:
-        for item in results.get("items", []):
-            track = playlist_item_track(item)
-            if not track:
-                continue
-            artists = [a.get("name", "") for a in track.get("artists", []) if a.get("name")]
-            album = track.get("album") or {}
-            images = [image for image in album.get("images") or [] if image and image.get("url")]
-            image = min(
-                images,
-                key=lambda candidate: abs(int(candidate.get("width") or 96) - 96),
-            )["url"] if images else ""
-            tracks.append({
-                "id": track.get("id"),
-                "isrc": (track.get("external_ids") or {}).get("isrc"),
-                "name": track.get("name", ""),
-                "artists": artists or [""],
-                "album": album.get("name"),
-                "duration_ms": track.get("duration_ms"),
-                "added_at": item.get("added_at") or "",
-                "image": image,
-            })
+        tracks.extend(_playlist_item_tracks(results.get("items", [])))
         page = results
         results = _retry(lambda: sp.next(page), "tracks page") if results.get("next") else None
     return tracks
+
+
+def _playlist_page_offset(cursor):
+    if cursor is None:
+        return 0
+    try:
+        offset = int(cursor)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Spotify playlist cursor is not a valid offset") from exc
+    if offset < 0:
+        raise RuntimeError("Spotify playlist cursor is not a valid offset")
+    return offset
+
+
+def playlist_tracks_page(sp, playlist_id, cursor=None):
+    """Read one 20-entry Web API page for the progressive playlist UI."""
+    offset = _playlist_page_offset(cursor)
+    try:
+        results = _retry(
+            lambda: sp.playlist_items(
+                playlist_id,
+                market="from_token",
+                additional_types=("track",),
+                limit=20,
+                offset=offset,
+            ),
+            "playlist_items",
+        )
+    except spotipy.SpotifyException as exc:
+        # Development-mode apps cannot read followed playlists. The scraper has
+        # no offset primitive, so only a first-page rejection can safely fall
+        # back to its complete read without appending duplicates.
+        if cursor is None and exc.http_status == 403 and spotify_web.enabled():
+            log_note(f"{playlist_id}: official read forbidden (403); trying web-player fallback", tag="spotify")
+            try:
+                tracks = spotify_web.playlist_tracks(playlist_id)
+                log_note(f"{playlist_id}: web-player fallback read {len(tracks)} tracks", tag="spotify")
+                return tracks, None
+            except Exception as web_exc:
+                log_warn(f"{playlist_id}: web-player fallback failed ({web_exc!r})", tag="spotify")
+                raise exc
+        raise
+
+    items = results.get("items") or []
+    if results.get("next") and not items:
+        raise RuntimeError(
+            f"Spotify playlist read incomplete: stopped at {offset} with another page advertised"
+        )
+    next_cursor = str(offset + len(items)) if results.get("next") else None
+    return _playlist_item_tracks(items), next_cursor
 
 
 def playlist_tracks(sp, playlist_id):

--- a/songmirror/engine/spotify_cookie.py
+++ b/songmirror/engine/spotify_cookie.py
@@ -237,28 +237,40 @@ def add(playlist, track_ids):
         polite_sleep(0.3)
 
 
+def _content_page(playlist, cursor=None, *, limit=20):
+    """One raw web-player page plus a private numeric continuation offset."""
+    try:
+        offset = 0 if cursor is None else int(cursor)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Spotify playlist cursor is not a valid offset") from exc
+    if offset < 0:
+        raise RuntimeError("Spotify playlist cursor is not a valid offset")
+
+    data = _pf(
+        "fetchPlaylistContents",
+        {"uri": _puri(playlist), "offset": offset, "limit": limit},
+    )
+    page = (data.get("playlistV2") or {}).get("content") or {}
+    items = page.get("items") or []
+    raw_total = page.get("totalCount")
+    if raw_total is None:
+        raise RuntimeError("Spotify playlist read incomplete: page did not include totalCount")
+    total = int(raw_total)
+    if not items and offset < total:
+        raise RuntimeError(
+            f"Spotify playlist read incomplete: stopped at {offset} of {total} items"
+        )
+    next_offset = offset + len(items)
+    return items, (str(next_offset) if next_offset < total else None)
+
+
 def _content_items(playlist):
     """Yield every raw playlist item (paginated) from the web-player read."""
-    puri, offset = _puri(playlist), 0
+    cursor = None
     while True:
-        data = _pf("fetchPlaylistContents", {"uri": puri, "offset": offset, "limit": 100})
-        page = (data.get("playlistV2") or {}).get("content") or {}
-        items = page.get("items") or []
-        raw_total = page.get("totalCount")
-        if raw_total is None:
-            raise RuntimeError(
-                "Spotify playlist read incomplete: page did not include totalCount"
-            )
-        total = int(raw_total)
-        if not items:
-            if offset < total:
-                raise RuntimeError(
-                    f"Spotify playlist read incomplete: stopped at {offset} of {total} items"
-                )
-            return
+        items, cursor = _content_page(playlist, cursor, limit=100)
         yield from items
-        offset += len(items)
-        if offset >= total:
+        if cursor is None:
             return
 
 
@@ -497,22 +509,9 @@ def _isrc_singles(ids):
         polite_sleep(0.2)
 
 
-def playlist_tracks(playlist, require_isrc=False, known_isrc=None):
-    """Full track dicts (the shape spotify.playlist_tracks yields) via pathfinder —
-    works for private owned playlists the dev-mode official API 403s, and returns []
-    for a just-created empty playlist. The pathfinder payload carries no ISRC (confirmed
-    absent from the entire web-player surface). N-way reconciliation now seeds
-    missing Spotify identities from every ISRC-bearing peer in the same complete
-    read. ``require_isrc`` remains only for legacy callers that explicitly opt
-    into the developer catalog lookup.
-
-    known_isrc(ids) -> {id: isrc}, when given, supplies already-known ISRCs (the
-    persisted songs-DB cache) so only genuinely-new tracks hit the rate-limited /tracks
-    endpoint — the difference between "fetch every track every pass" (which earns a
-    penalty box) and "fetch each track once, ever". Transfers pass neither flag — a
-    same-provider copy uses the track id directly."""
+def _normalized_content_tracks(items):
     out = []
-    for it in _content_items(playlist):
+    for it in items:
         t = (it.get("itemV2") or {}).get("data") or {}
         uri = t.get("uri") or ""
         if not uri.startswith("spotify:track:"):
@@ -535,6 +534,10 @@ def playlist_tracks(playlist, require_isrc=False, known_isrc=None):
             "added_at": (it.get("addedAt") or {}).get("isoString") or "",
             "image": image,
         })
+    return out
+
+
+def _apply_playlist_isrcs(out, *, require_isrc=False, known_isrc=None):
     # Persisted ISRCs remain valuable in cookie-only mode, but a cache miss is
     # deliberately left blank for reconcile to infer from its ISRC-bearing peers.
     # Only legacy callers that explicitly request a complete ISRC read touch the
@@ -550,6 +553,35 @@ def playlist_tracks(playlist, require_isrc=False, known_isrc=None):
         for t in out:
             t["isrc"] = t.get("isrc") or fetched.get(t["id"])
     return out
+
+
+def playlist_tracks_page(playlist, cursor=None, *, known_isrc=None):
+    """Read one 20-entry pathfinder page for the progressive playlist UI."""
+    items, next_cursor = _content_page(playlist, cursor, limit=20)
+    tracks = _normalized_content_tracks(items)
+    return _apply_playlist_isrcs(tracks, known_isrc=known_isrc), next_cursor
+
+
+def playlist_tracks(playlist, require_isrc=False, known_isrc=None):
+    """Full track dicts (the shape spotify.playlist_tracks yields) via pathfinder —
+    works for private owned playlists the dev-mode official API 403s, and returns []
+    for a just-created empty playlist. The pathfinder payload carries no ISRC (confirmed
+    absent from the entire web-player surface). N-way reconciliation now seeds
+    missing Spotify identities from every ISRC-bearing peer in the same complete
+    read. ``require_isrc`` remains only for legacy callers that explicitly opt
+    into the developer catalog lookup.
+
+    known_isrc(ids) -> {id: isrc}, when given, supplies already-known ISRCs (the
+    persisted songs-DB cache) so only genuinely-new tracks hit the rate-limited /tracks
+    endpoint — the difference between "fetch every track every pass" (which earns a
+    penalty box) and "fetch each track once, ever". Transfers pass neither flag — a
+    same-provider copy uses the track id directly."""
+    tracks = _normalized_content_tracks(_content_items(playlist))
+    return _apply_playlist_isrcs(
+        tracks,
+        require_isrc=require_isrc,
+        known_isrc=known_isrc,
+    )
 
 
 def remove(playlist, track_ids):

--- a/songmirror/engine/targets/amazon_music.py
+++ b/songmirror/engine/targets/amazon_music.py
@@ -355,6 +355,72 @@ class AmazonMusicTarget(MirrorTarget):
                     details[str(track["id"])] = track
         return details
 
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        return {
+            "id": str(playlist_id),
+            "title": "",
+            "description": "",
+            "trackCount": expected_count,
+        }
+
+    @staticmethod
+    def _playlist_edges_tracks(edges, details=None):
+        if any((edge.get("node") or {}).get("id") is None for edge in edges):
+            raise RuntimeError(
+                "Amazon Music playlist read incomplete: a relationship entry has no track id"
+            )
+        details = details or {}
+        tracks = []
+        for edge in edges:
+            node = edge.get("node") or {}
+            track_id = str(node["id"])
+            cursor_value = str(edge.get("cursor") or "")
+            entry_id = edge.get("itemId")
+            if not entry_id:
+                entry_id = cursor_value.split(":", 1)[1] if ":" in cursor_value else cursor_value or None
+            tracks.append(_normalized_track({**node, **details.get(track_id, {})}, entry_id))
+        return tracks
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        if getattr(self, "_web", None) is not None:
+            data = self._graphql(
+                "SongMirrorAmazonPlaylistTracks",
+                WEB_PLAYLIST_TRACKS_QUERY,
+                {"id": str(playlist["id"]), "cursor": cursor, "limit": 20},
+            )
+            connection = (((data.get("playlist") or {}).get("tracks")) or {})
+            edges = connection.get("edges") or []
+            next_cursor = _next_cursor(
+                connection.get("pageInfo") or {},
+                cursor,
+                "playlist track",
+            )
+            if next_cursor is not None and not edges:
+                raise RuntimeError(
+                    "Amazon Music playlist read incomplete: an empty page advertised more tracks"
+                )
+            return self._playlist_edges_tracks(edges), next_cursor
+
+        params = {"limit": 20}
+        if cursor:
+            params["cursor"] = cursor
+        body = self._request("GET", f"playlists/{playlist['id']}/tracks", params=params)
+        connection = self._connection(body, "data", "playlist", "tracks")
+        edges = connection.get("edges") or []
+        next_cursor = _next_cursor(
+            connection.get("pageInfo") or {},
+            cursor,
+            "playlist track",
+        )
+        if next_cursor is not None and not edges:
+            raise RuntimeError(
+                "Amazon Music playlist read incomplete: an empty page advertised more tracks"
+            )
+        ids = [str((edge.get("node") or {}).get("id")) for edge in edges
+               if (edge.get("node") or {}).get("id") is not None]
+        return self._playlist_edges_tracks(edges, self._track_details(ids)), next_cursor
+
     def playlist_tracks(self, playlist):
         if getattr(self, "_web", None) is not None:
             tracks, cursor = [], None

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -41,6 +41,23 @@ def _headers():
     }
 
 
+def _normalized_playlist_track(track):
+    attrs = track.get("attributes", {})
+    play_params = attrs.get("playParams", {})
+    artwork = attrs.get("artwork") or {}
+    image = str(artwork.get("url") or "").replace("{w}", "128").replace("{h}", "128")
+    return {
+        "relationship_id": track.get("id"),
+        "catalog_id": play_params.get("catalogId") or play_params.get("id"),
+        "name": attrs.get("name", ""),
+        "artist": attrs.get("artistName", ""),
+        "album": attrs.get("albumName"),
+        "duration_ms": attrs.get("durationInMillis"),
+        "added_at": attrs.get("dateAdded") or "",
+        "image": image,
+    }
+
+
 class AppleMusicTarget(MirrorTarget):
     name = "Apple Music"
     tag = "apple"
@@ -162,6 +179,49 @@ class AppleMusicTarget(MirrorTarget):
         r = self._request("POST", f"{AMP}/me/library/playlists", json_body={"attributes": attributes})
         return r.json()["data"][0]
 
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        return {
+            "id": str(playlist_id),
+            "attributes": {
+                "name": "",
+                "description": {},
+                "canEdit": True,
+            },
+            "_page_count": expected_count,
+        }
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        try:
+            offset = 0 if cursor is None else int(cursor)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Apple Music playlist cursor is not a valid offset") from exc
+        if offset < 0:
+            raise RuntimeError("Apple Music playlist cursor is not a valid offset")
+
+        response = self._request(
+            "GET",
+            f"{AMP}/me/library/playlists/{playlist['id']}/tracks",
+            params={"limit": 20, "offset": offset},
+            ok404=True,
+        )
+        if response is None:
+            if offset:
+                raise RuntimeError("Apple Music playlist read incomplete: a later page returned 404")
+            playlist["_page_count"] = 0
+            return [], None
+        data = response.json()
+        rows = data.get("data") or []
+        total = (data.get("meta") or {}).get("total")
+        if total is not None:
+            playlist["_page_count"] = int(total)
+        if data.get("next") and not rows:
+            raise RuntimeError(
+                "Apple Music playlist read incomplete: next page was advertised but no rows were returned"
+            )
+        next_cursor = str(offset + len(rows)) if data.get("next") else None
+        return [_normalized_playlist_track(track) for track in rows], next_cursor
+
     def playlist_tracks(self, playlist):
         tracks, offset = [], 0
         while True:
@@ -175,21 +235,7 @@ class AppleMusicTarget(MirrorTarget):
                 return tracks
             data = r.json()
             rows = data.get("data") or []
-            for t in rows:
-                attrs = t.get("attributes", {})
-                pp = attrs.get("playParams", {})
-                artwork = attrs.get("artwork") or {}
-                image = str(artwork.get("url") or "").replace("{w}", "128").replace("{h}", "128")
-                tracks.append({
-                    "relationship_id": t.get("id"),
-                    "catalog_id": pp.get("catalogId") or pp.get("id"),
-                    "name": attrs.get("name", ""),
-                    "artist": attrs.get("artistName", ""),
-                    "album": attrs.get("albumName"),
-                    "duration_ms": attrs.get("durationInMillis"),
-                    "added_at": attrs.get("dateAdded") or "",
-                    "image": image,
-                })
+            tracks.extend(_normalized_playlist_track(track) for track in rows)
             if not data.get("next"):
                 return tracks
             if not rows:
@@ -205,6 +251,8 @@ class AppleMusicTarget(MirrorTarget):
         # Library-playlist attributes carry no trackCount, so read it from the
         # tracks endpoint's meta.total (one light limit=1 call). Cached against
         # the playlist's lastModifiedDate so it's recomputed only when it changes.
+        if playlist.get("_page_count") is not None:
+            return int(playlist["_page_count"])
         pid = playlist.get("id")
         mod = playlist.get("attributes", {}).get("lastModifiedDate")
         hit = _COUNT_CACHE.get(pid)

--- a/songmirror/engine/targets/deezer.py
+++ b/songmirror/engine/targets/deezer.py
@@ -3,6 +3,7 @@
 import os
 import random
 import time
+from urllib.parse import parse_qs, urlsplit
 
 import requests
 
@@ -198,6 +199,66 @@ class DeezerTarget(MirrorTarget):
             raise RuntimeError(f"Deezer did not return the created playlist id ({result!r})")
         polite_sleep(0.4)
         return self._request("GET", f"playlist/{playlist_id}")
+
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        return {
+            "id": str(playlist_id),
+            "title": "",
+            "description": "",
+            "nb_tracks": expected_count,
+            "_owned": True,
+        }
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        if self._web is not None:
+            try:
+                rows, next_cursor = self._web.playlist_tracks_page(
+                    str(playlist["id"]),
+                    cursor=cursor,
+                    limit=20,
+                )
+            except DeezerWebAuthError as exc:
+                raise TargetAuthError(str(exc)) from exc
+            return [_normalized_track(track) for track in rows], next_cursor
+
+        try:
+            offset = 0 if cursor is None else int(cursor)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Deezer playlist cursor is not a valid offset") from exc
+        if offset < 0:
+            raise RuntimeError("Deezer playlist cursor is not a valid offset")
+        body = self._request(
+            "GET",
+            f"playlist/{playlist['id']}/tracks",
+            params={"limit": 20, "index": offset},
+        )
+        rows = body.get("data") or []
+        next_offset = offset + len(rows)
+        next_cursor = None
+        next_url = body.get("next")
+        if next_url:
+            values = parse_qs(urlsplit(str(next_url)).query).get("index") or []
+            try:
+                advertised = int(values[0]) if values else next_offset
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError("Deezer returned an invalid playlist continuation") from exc
+            if not rows or advertised <= offset:
+                raise RuntimeError("Deezer returned a non-advancing playlist cursor")
+            next_cursor = str(advertised)
+        else:
+            total = body.get("total")
+            if total is not None and next_offset < int(total):
+                if not rows:
+                    raise RuntimeError(
+                        f"Deezer playlist read incomplete: stopped at {offset} of {int(total)} tracks"
+                    )
+                next_cursor = str(next_offset)
+        return [
+            _normalized_track(track)
+            for track in rows
+            if track.get("id") is not None
+        ], next_cursor
 
     def playlist_tracks(self, playlist):
         if self._web is not None:

--- a/songmirror/engine/targets/qobuz.py
+++ b/songmirror/engine/targets/qobuz.py
@@ -158,6 +158,52 @@ class QobuzTarget(MirrorTarget):
         polite_sleep(0.4)
         return playlist
 
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        return {
+            "id": str(playlist_id),
+            "name": "",
+            "description": "",
+            "tracks_count": expected_count,
+        }
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        try:
+            offset = 0 if cursor is None else int(cursor)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Qobuz playlist cursor is not a valid offset") from exc
+        if offset < 0:
+            raise RuntimeError("Qobuz playlist cursor is not a valid offset")
+
+        body = self._request(
+            "GET",
+            "playlist/get",
+            params={
+                "playlist_id": playlist["id"],
+                "extra": "tracks",
+                "limit": 20,
+                "offset": offset,
+            },
+        )
+        container = body.get("tracks") or {}
+        items = container.get("items") or []
+        if any(track.get("id") is None for track in items):
+            raise RuntimeError(
+                "Qobuz playlist read incomplete: a playlist item is missing its track id"
+            )
+        next_offset = offset + len(items)
+        total = container.get("total")
+        if total is not None:
+            total = int(total)
+            if not items and next_offset < total:
+                raise RuntimeError(
+                    f"Qobuz playlist read incomplete: stopped at {offset} of {total} tracks"
+                )
+            next_cursor = str(next_offset) if next_offset < total else None
+        else:
+            next_cursor = str(next_offset) if len(items) == 20 else None
+        return [_normalized_track(track) for track in items], next_cursor
+
     def playlist_tracks(self, playlist):
         tracks, offset = [], 0
         while True:

--- a/songmirror/engine/targets/spotify_target.py
+++ b/songmirror/engine/targets/spotify_target.py
@@ -114,6 +114,22 @@ class SpotifyTarget(MirrorTarget):
                 playlist["id"], require_isrc=False, known_isrc=known)
         return spotify.playlist_tracks(self._sp, playlist["id"])
 
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        return {
+            "id": str(playlist_id),
+            "name": "",
+            "description": "",
+            "items": {"total": expected_count},
+            "_owned": True,
+            "_editable": True,
+        }
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        if spotify_write_backend() == "cookie":
+            return spotify_cookie.playlist_tracks_page(playlist["id"], cursor=cursor)
+        return spotify.playlist_tracks_page(self._sp, playlist["id"], cursor=cursor)
+
     def track_id(self, track):
         return track.get("id")
 

--- a/songmirror/engine/targets/ytmusic.py
+++ b/songmirror/engine/targets/ytmusic.py
@@ -133,6 +133,66 @@ def _artist_from_channel(channel):
     return _TOPIC_RE.sub("", channel or "").strip()
 
 
+def _normalized_data_api_playlist_item(item):
+    video_id = item.get("contentDetails", {}).get("videoId")
+    if not video_id:
+        return None
+    snippet = item.get("snippet", {})
+    artist = _artist_from_channel(snippet.get("videoOwnerChannelTitle", ""))
+    thumbnails = snippet.get("thumbnails") or {}
+    image = next((
+        (thumbnails.get(size) or {}).get("url")
+        for size in ("medium", "high", "default")
+        if (thumbnails.get(size) or {}).get("url")
+    ), "")
+    return {
+        "id": video_id,
+        "videoId": video_id,
+        "playlistItemId": item.get("id"),
+        "name": snippet.get("title", ""),
+        "artist": artist,
+        "artists": [artist] if artist else [""],
+        "album": None,
+        "duration_ms": None,
+        "added_at": snippet.get("publishedAt") or "",
+        "image": image,
+    }
+
+
+def _normalized_youtubei_playlist_track(track):
+    video_id = track.get("videoId")
+    if not video_id:
+        return None
+    artists = [
+        artist
+        for artist in (
+            _artist_from_channel(value.get("name", ""))
+            for value in (track.get("artists") or [])
+        )
+        if artist
+    ]
+    album = track.get("album")
+    duration_seconds = track.get("duration_seconds")
+    thumbnails = track.get("thumbnails") or []
+    image = next((
+        thumb.get("url")
+        for thumb in reversed(thumbnails)
+        if isinstance(thumb, dict) and thumb.get("url")
+    ), "")
+    return {
+        "id": video_id,
+        "videoId": video_id,
+        "setVideoId": track.get("setVideoId"),
+        "name": track.get("title", ""),
+        "artist": ", ".join(artists),
+        "artists": artists or [""],
+        "album": album.get("name") if isinstance(album, dict) else None,
+        "duration_ms": duration_seconds * 1000 if duration_seconds else None,
+        "added_at": track.get("dateAdded") or "",
+        "image": image,
+    }
+
+
 def _err_reason(response):
     try:
         errors = response.json().get("error", {}).get("errors", [])
@@ -266,28 +326,47 @@ class YTMusicTarget(MirrorTarget):
         polite_sleep(2.0)  # let the new playlist settle before writing to it
         return {"playlistId": pid, "title": name, "count": 0}
 
+    @staticmethod
+    def playlist_page_reference(playlist_id, expected_count=None):
+        return {
+            "playlistId": str(playlist_id),
+            "title": "",
+            "count": expected_count,
+        }
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        params = {
+            "part": "snippet,contentDetails",
+            "playlistId": playlist["playlistId"],
+            "maxResults": 20,
+        }
+        if cursor:
+            params["pageToken"] = cursor
+        data = self._request("GET", "playlistItems", params=params).json()
+        items = data.get("items") or []
+        next_cursor = data.get("nextPageToken") or None
+        if next_cursor is not None and next_cursor == cursor:
+            raise RuntimeError("YouTube Music returned a non-advancing playlist cursor")
+        if next_cursor is not None and not items:
+            raise RuntimeError(
+                "YouTube Music playlist read incomplete: an empty page advertised more tracks"
+            )
+        return [
+            track
+            for item in items
+            if (track := _normalized_data_api_playlist_item(item)) is not None
+        ], next_cursor
+
     def playlist_tracks(self, playlist):
-        tracks = []
-        for item in self._paged("playlistItems", {
-                "part": "snippet,contentDetails", "playlistId": playlist["playlistId"], "maxResults": 50}):
-            vid = item.get("contentDetails", {}).get("videoId")
-            if not vid:
-                continue
-            sn = item.get("snippet", {})
-            artist = _artist_from_channel(sn.get("videoOwnerChannelTitle", ""))
-            thumbnails = sn.get("thumbnails") or {}
-            image = next((
-                (thumbnails.get(size) or {}).get("url")
-                for size in ("medium", "high", "default")
-                if (thumbnails.get(size) or {}).get("url")
-            ), "")
-            tracks.append({
-                "id": vid, "videoId": vid, "playlistItemId": item.get("id"),
-                "name": sn.get("title", ""), "artist": artist, "artists": [artist] if artist else [""],
-                "album": None, "duration_ms": None,
-                "added_at": sn.get("publishedAt") or "", "image": image,
+        return [
+            track
+            for item in self._paged("playlistItems", {
+                "part": "snippet,contentDetails",
+                "playlistId": playlist["playlistId"],
+                "maxResults": 50,
             })
-        return tracks
+            if (track := _normalized_data_api_playlist_item(item)) is not None
+        ]
 
     def track_id(self, track):
         return track.get("videoId")
@@ -361,6 +440,102 @@ def _expired(fn, what):
                               "re-export the browser cookies (Settings -> YouTube Music).")
 
 
+_YOUTUBEI_COLLABORATIVE_CURSOR_PREFIX = "songmirror:ytmusic:collaborative:"
+
+
+def _youtubei_playlist_page(api, playlist_id, cursor=None):
+    """Read one native youtubei shelf page while retaining its continuation.
+
+    ytmusicapi's public ``get_playlist`` intentionally follows every shelf
+    continuation and discards the token. The inspector needs the lower-level
+    page boundary, so use the same parser/navigation helpers as that method and
+    return the opaque token to the browser. YouTube currently serves up to 100
+    entries in a native page; unlike the Data API, that size is not configurable.
+    """
+    from ytmusicapi.continuations import get_continuation_token
+    from ytmusicapi.navigation import (
+        CONTENT,
+        EDITABLE_PLAYLIST_DETAIL_HEADER,
+        HEADER,
+        RESPONSIVE_HEADER,
+        SECTION,
+        SECTION_LIST_ITEM,
+        TAB_CONTENT,
+        TWO_COLUMN_RENDERER,
+        nav,
+    )
+    from ytmusicapi.parsers.playlists import parse_playlist_header_meta, parse_playlist_items
+
+    native_cursor = cursor
+    is_collaborative = False
+    if cursor and cursor.startswith(_YOUTUBEI_COLLABORATIVE_CURSOR_PREFIX):
+        native_cursor = cursor[len(_YOUTUBEI_COLLABORATIVE_CURSOR_PREFIX):]
+        if not native_cursor:
+            raise RuntimeError("YouTube Music returned an invalid playlist cursor")
+        is_collaborative = True
+
+    if native_cursor:
+        response = api._send_request("browse", {"continuation": native_cursor})
+        items = nav(
+            response,
+            [
+                "onResponseReceivedActions",
+                0,
+                "appendContinuationItemsAction",
+                "continuationItems",
+            ],
+            True,
+        )
+        if not items:
+            raise RuntimeError(
+                "YouTube Music playlist read incomplete: a continuation returned no items"
+            )
+    else:
+        browse_id = str(playlist_id)
+        if not browse_id.startswith("VL"):
+            browse_id = f"VL{browse_id}"
+        response = api._send_request("browse", {"browseId": browse_id}, "")
+        header_data = nav(
+            response,
+            [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM],
+            True,
+        )
+        is_audio_playlist = str(playlist_id).startswith(("OLA", "VLOLA"))
+        if header_data:
+            if EDITABLE_PLAYLIST_DETAIL_HEADER[0] in header_data:
+                header = nav(
+                    header_data,
+                    [*EDITABLE_PLAYLIST_DETAIL_HEADER, *HEADER, *RESPONSIVE_HEADER],
+                )
+            else:
+                header = nav(header_data, RESPONSIVE_HEADER)
+            is_collaborative = "collaborators" in parse_playlist_header_meta(header)
+        elif not is_audio_playlist:
+            # Logged-out responses are translated by _expired after their
+            # missing shelf raises below. OLA/audio playlists legitimately
+            # omit the normal playlist header, matching ytmusicapi's reader.
+            is_collaborative = False
+        section = nav(
+            response,
+            [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION],
+        )
+        shelf = nav(
+            section,
+            [*CONTENT, "musicPlaylistShelfRenderer"],
+        )
+        items = shelf.get("contents") or []
+
+    next_native_cursor = get_continuation_token(items) if items else None
+    if next_native_cursor is not None and next_native_cursor == native_cursor:
+        raise RuntimeError("YouTube Music returned a non-advancing playlist cursor")
+    next_cursor = (
+        f"{_YOUTUBEI_COLLABORATIVE_CURSOR_PREFIX}{next_native_cursor}"
+        if is_collaborative and next_native_cursor is not None
+        else next_native_cursor
+    )
+    return parse_playlist_items(items, is_collaborative=is_collaborative), next_cursor
+
+
 class YTMusicBrowserTarget(YTMusicTarget):
     """No-quota YT reads/writes via ytmusicapi's authenticated youtubei API, so a
     large backfill isn't capped at the Data API's ~200 adds/day. Trade-off: the
@@ -411,26 +586,26 @@ class YTMusicBrowserTarget(YTMusicTarget):
     def playlist_tracks(self, playlist):
         data = _expired(lambda: self._api.get_playlist(playlist["playlistId"], limit=None),
                         f"playlist '{playlist.get('title', '')}'") or {}
-        tracks = []
-        for t in data.get("tracks") or []:
-            vid = t.get("videoId")
-            if not vid:
-                continue
-            artists = [a for a in (_artist_from_channel(x.get("name", ""))
-                                   for x in (t.get("artists") or [])) if a]
-            album = t.get("album")
-            ds = t.get("duration_seconds")
-            thumbnails = t.get("thumbnails") or []
-            image = next((thumb.get("url") for thumb in reversed(thumbnails)
-                          if isinstance(thumb, dict) and thumb.get("url")), "")
-            tracks.append({
-                "id": vid, "videoId": vid, "setVideoId": t.get("setVideoId"),
-                "name": t.get("title", ""), "artist": ", ".join(artists), "artists": artists or [""],
-                "album": album.get("name") if isinstance(album, dict) else None,
-                "duration_ms": ds * 1000 if ds else None,
-                "added_at": t.get("dateAdded") or "", "image": image,
-            })
-        return tracks
+        return [
+            track
+            for raw in data.get("tracks") or []
+            if (track := _normalized_youtubei_playlist_track(raw)) is not None
+        ]
+
+    def playlist_tracks_page(self, playlist, cursor=None):
+        rows, next_cursor = _expired(
+            lambda: _youtubei_playlist_page(
+                self._api,
+                playlist["playlistId"],
+                cursor=cursor,
+            ),
+            f"playlist '{playlist.get('title', '')}'",
+        )
+        return [
+            track
+            for raw in rows
+            if (track := _normalized_youtubei_playlist_track(raw)) is not None
+        ], next_cursor
 
     def add(self, playlist, target_ids):
         # YouTube may stamp a whole batch alike and reorder it. Singleton writes

--- a/tests/test_playlist_pages.py
+++ b/tests/test_playlist_pages.py
@@ -1,0 +1,467 @@
+"""Provider-native playlist pages used by the progressive web inspector."""
+
+
+class _Response:
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def _spotify_item(track_id):
+    return {
+        "added_at": "2026-08-25T00:00:00Z",
+        "track": {
+            "id": track_id,
+            "type": "track",
+            "name": f"Track {track_id}",
+            "artists": [{"name": "Artist"}],
+            "album": {"name": "Album", "images": []},
+            "duration_ms": 123_000,
+            "external_ids": {"isrc": f"ISRC{track_id}"},
+        },
+    }
+
+
+def _spotify_cookie_item(track_id):
+    return {
+        "itemV2": {
+            "data": {
+                "uri": f"spotify:track:{track_id}",
+                "name": f"Track {track_id}",
+                "artists": {"items": [{"profile": {"name": "Artist"}}]},
+                "albumOfTrack": {"name": "Album", "coverArt": {"sources": []}},
+                "trackDuration": {"totalMilliseconds": 123_000},
+            }
+        },
+        "addedAt": {"isoString": "2026-08-25T00:00:00Z"},
+    }
+
+
+def test_spotify_oauth_playlist_page_uses_one_twenty_track_request():
+    from songmirror.engine import spotify
+
+    calls = []
+
+    class Client:
+        def playlist_items(self, playlist_id, **params):
+            calls.append((playlist_id, params))
+            return {
+                "items": [_spotify_item("21"), _spotify_item("22")],
+                "next": "https://api.spotify.com/v1/playlists/p/tracks?offset=22",
+                "total": 42,
+            }
+
+    tracks, cursor = spotify.playlist_tracks_page(Client(), "playlist", cursor="20")
+
+    assert [track["id"] for track in tracks] == ["21", "22"]
+    assert cursor == "22"
+    assert calls == [("playlist", {
+        "market": "from_token",
+        "additional_types": ("track",),
+        "limit": 20,
+        "offset": 20,
+    })]
+
+
+def test_spotify_cookie_playlist_page_uses_one_twenty_track_request(monkeypatch):
+    from songmirror.engine import spotify_cookie
+
+    calls = []
+
+    def pathfinder(_operation, variables):
+        calls.append(variables)
+        return {
+            "playlistV2": {
+                "content": {
+                    "items": [_spotify_cookie_item("21"), _spotify_cookie_item("22")],
+                    "totalCount": 42,
+                }
+            }
+        }
+
+    monkeypatch.setattr(spotify_cookie, "_pf", pathfinder)
+
+    tracks, cursor = spotify_cookie.playlist_tracks_page("playlist", cursor="20")
+
+    assert [track["id"] for track in tracks] == ["21", "22"]
+    assert cursor == "22"
+    assert calls == [{"uri": "spotify:playlist:playlist", "offset": 20, "limit": 20}]
+
+
+def test_qobuz_playlist_page_advances_by_raw_rows():
+    from songmirror.engine.targets.qobuz import QobuzTarget
+
+    target = QobuzTarget.__new__(QobuzTarget)
+    calls = []
+
+    def request(method, endpoint, params=None):
+        calls.append((method, endpoint, params))
+        return {
+            "tracks": {
+                "items": [{"id": 21, "title": "Twenty one", "performer": {"name": "Artist"}}],
+                "total": 41,
+            }
+        }
+
+    target._request = request
+    tracks, cursor = target.playlist_tracks_page({"id": "playlist"}, cursor="20")
+
+    assert tracks[0]["id"] == "21"
+    assert cursor == "21"
+    assert calls == [("GET", "playlist/get", {
+        "playlist_id": "playlist",
+        "extra": "tracks",
+        "limit": 20,
+        "offset": 20,
+    })]
+
+
+def test_deezer_rest_playlist_page_keeps_tokens_private_and_uses_index():
+    from songmirror.engine.targets.deezer import DeezerTarget
+
+    target = DeezerTarget.__new__(DeezerTarget)
+    target._web = None
+    calls = []
+
+    def request(method, path, params=None):
+        calls.append((method, path, params))
+        return {
+            "data": [{"id": 21, "title": "Twenty one", "artist": {"name": "Artist"}}],
+            "total": 41,
+            "next": "https://api.deezer.com/playlist/p/tracks?access_token=secret&index=21&limit=20",
+        }
+
+    target._request = request
+    tracks, cursor = target.playlist_tracks_page({"id": "playlist"}, cursor="20")
+
+    assert tracks[0]["id"] == "21"
+    assert cursor == "21"
+    assert "secret" not in cursor
+    assert calls == [("GET", "playlist/playlist/tracks", {"limit": 20, "index": 20})]
+
+
+def test_deezer_web_playlist_page_passes_through_graphql_cursor():
+    from songmirror.engine.targets.deezer import DeezerTarget
+
+    class Web:
+        def playlist_tracks_page(self, playlist_id, cursor=None, limit=20):
+            assert (playlist_id, cursor, limit) == ("playlist", "page-1", 20)
+            return ([{"id": "21", "title": "Twenty one", "artist": {"name": "Artist"}}], "page-2")
+
+    target = DeezerTarget.__new__(DeezerTarget)
+    target._web = Web()
+
+    tracks, cursor = target.playlist_tracks_page({"id": "playlist"}, cursor="page-1")
+
+    assert tracks[0]["id"] == "21"
+    assert cursor == "page-2"
+
+
+def test_amazon_web_playlist_page_uses_one_graphql_connection_page():
+    from songmirror.engine.targets.amazon_music import AmazonMusicTarget
+
+    target = AmazonMusicTarget.__new__(AmazonMusicTarget)
+    target._web = object()
+    calls = []
+
+    def graphql(operation, query, variables):
+        calls.append((operation, variables))
+        return {
+            "playlist": {
+                "tracks": {
+                    "edges": [{
+                        "cursor": "0:entry-21",
+                        "itemId": "entry-21",
+                        "node": {"id": "ASIN21", "title": "Twenty one"},
+                    }],
+                    "pageInfo": {"hasNextPage": True, "token": "page-2"},
+                }
+            }
+        }
+
+    target._graphql = graphql
+    tracks, cursor = target.playlist_tracks_page({"id": "playlist"}, cursor="page-1")
+
+    assert tracks[0]["id"] == "ASIN21"
+    assert tracks[0]["relationship_id"] == "entry-21"
+    assert cursor == "page-2"
+    assert calls == [("SongMirrorAmazonPlaylistTracks", {
+        "id": "playlist",
+        "cursor": "page-1",
+        "limit": 20,
+    })]
+
+
+def test_amazon_rest_playlist_page_hydrates_only_that_page():
+    from songmirror.engine.targets.amazon_music import AmazonMusicTarget
+
+    target = AmazonMusicTarget.__new__(AmazonMusicTarget)
+    target._web = None
+    calls = []
+
+    def request(method, path, params=None):
+        calls.append((method, path, params))
+        return {
+            "data": {"playlist": {"tracks": {
+                "edges": [{"cursor": "0:entry-21", "node": {"id": "ASIN21"}}],
+                "pageInfo": {"hasNextPage": True, "token": "page-2"},
+            }}}
+        }
+
+    target._request = request
+    hydrated = []
+    target._track_details = lambda ids: (hydrated.extend(ids), {
+        "ASIN21": {"id": "ASIN21", "title": "Twenty one"}
+    })[1]
+
+    tracks, cursor = target.playlist_tracks_page({"id": "playlist"}, cursor="page-1")
+
+    assert tracks[0]["id"] == "ASIN21"
+    assert cursor == "page-2"
+    assert hydrated == ["ASIN21"]
+    assert calls == [("GET", "playlists/playlist/tracks", {"limit": 20, "cursor": "page-1"})]
+
+
+def test_apple_playlist_page_uses_offset_and_reuses_meta_total():
+    from songmirror.engine.targets.apple import AppleMusicTarget
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    calls = []
+
+    def request(method, url, params=None, ok404=False):
+        calls.append((method, url, params, ok404))
+        return _Response({
+            "data": [{
+                "id": "entry-21",
+                "attributes": {
+                    "name": "Twenty one",
+                    "artistName": "Artist",
+                    "playParams": {"catalogId": "catalog-21"},
+                },
+            }],
+            "meta": {"total": 41},
+            "next": "/next",
+        })
+
+    target._request = request
+    playlist = {"id": "playlist", "attributes": {}}
+    tracks, cursor = target.playlist_tracks_page(playlist, cursor="20")
+
+    assert tracks[0]["catalog_id"] == "catalog-21"
+    assert cursor == "21"
+    assert target.playlist_count(playlist) == 41
+    assert len(calls) == 1
+    assert calls[0][2] == {"limit": 20, "offset": 20}
+
+
+def test_youtube_oauth_playlist_page_uses_one_twenty_item_request():
+    from songmirror.engine.targets.ytmusic import YTMusicTarget
+
+    target = YTMusicTarget.__new__(YTMusicTarget)
+    calls = []
+
+    def request(method, path, params=None):
+        calls.append((method, path, params))
+        return _Response({
+            "items": [{
+                "id": "entry-21",
+                "contentDetails": {"videoId": "video-21"},
+                "snippet": {"title": "Twenty one", "videoOwnerChannelTitle": "Artist - Topic"},
+            }],
+            "nextPageToken": "page-2",
+        })
+
+    target._request = request
+    tracks, cursor = target.playlist_tracks_page({"playlistId": "playlist"}, cursor="page-1")
+
+    assert tracks[0]["videoId"] == "video-21"
+    assert tracks[0]["artist"] == "Artist"
+    assert cursor == "page-2"
+    assert calls == [("GET", "playlistItems", {
+        "part": "snippet,contentDetails",
+        "playlistId": "playlist",
+        "maxResults": 20,
+        "pageToken": "page-1",
+    })]
+
+
+def test_youtube_oauth_terminal_first_page_does_not_treat_null_as_repeated():
+    from songmirror.engine.targets.ytmusic import YTMusicTarget
+
+    target = YTMusicTarget.__new__(YTMusicTarget)
+    target._request = lambda *args, **kwargs: _Response({"items": []})
+
+    tracks, cursor = target.playlist_tracks_page({"playlistId": "playlist"})
+
+    assert tracks == []
+    assert cursor is None
+
+
+def test_youtube_browser_terminal_first_page_does_not_treat_null_as_repeated(monkeypatch):
+    from ytmusicapi import continuations, navigation
+    from ytmusicapi.parsers import playlists
+
+    from songmirror.engine.targets.ytmusic import _youtubei_playlist_page
+
+    items = [{"fixture": "track"}]
+
+    def navigate(_node, path, _none_if_absent=False):
+        if path[-1] == 0:
+            return None
+        if path[-1] == "sectionListRenderer":
+            return {"contents": []}
+        if path == ["contents", 0, "musicPlaylistShelfRenderer"]:
+            return {"contents": items}
+        raise AssertionError(path)
+
+    monkeypatch.setattr(navigation, "nav", navigate)
+    monkeypatch.setattr(continuations, "get_continuation_token", lambda _items: None)
+    monkeypatch.setattr(
+        playlists,
+        "parse_playlist_items",
+        lambda _items, is_collaborative=False: [{"videoId": "video-1"}],
+    )
+    api = type("Api", (), {"_send_request": lambda self, *args: {}})()
+
+    tracks, cursor = _youtubei_playlist_page(api, "playlist")
+
+    assert tracks == [{"videoId": "video-1"}]
+    assert cursor is None
+
+
+def test_youtube_browser_playlist_page_preserves_collaborative_context(monkeypatch):
+    from ytmusicapi import continuations, navigation
+    from ytmusicapi.parsers import playlists
+
+    from songmirror.engine.targets.ytmusic import (
+        _YOUTUBEI_COLLABORATIVE_CURSOR_PREFIX,
+        _youtubei_playlist_page,
+    )
+
+    first_items = [{"fixture": "first"}]
+    second_items = [{"fixture": "second"}]
+    requests = []
+    parsed_contexts = []
+
+    class Api:
+        def _send_request(self, *args):
+            requests.append(args)
+            return {"fixture": "continuation" if "continuation" in args[1] else "first"}
+
+    def navigate(node, path, _none_if_absent=False):
+        if node.get("fixture") == "continuation":
+            assert path[-1] == "continuationItems"
+            return second_items
+        if path == [*navigation.TWO_COLUMN_RENDERER, *navigation.TAB_CONTENT,
+                    *navigation.SECTION_LIST_ITEM]:
+            return {"musicResponsiveHeaderRenderer": {"fixture": "header"}}
+        if path == navigation.RESPONSIVE_HEADER:
+            return {"fixture": "header"}
+        if path == [*navigation.TWO_COLUMN_RENDERER, "secondaryContents", *navigation.SECTION]:
+            return {"contents": [{"musicPlaylistShelfRenderer": {"contents": first_items}}]}
+        if path == [*navigation.CONTENT, "musicPlaylistShelfRenderer"]:
+            return {"contents": first_items}
+        raise AssertionError(path)
+
+    def parse_items(items, is_collaborative=False):
+        parsed_contexts.append(is_collaborative)
+        return [{"videoId": items[0]["fixture"]}]
+
+    monkeypatch.setattr(navigation, "nav", navigate)
+    monkeypatch.setattr(playlists, "parse_playlist_header_meta", lambda _header: {
+        "collaborators": {"text": "by Artist and 1 other", "avatars": []}
+    })
+    monkeypatch.setattr(playlists, "parse_playlist_items", parse_items)
+    monkeypatch.setattr(
+        continuations,
+        "get_continuation_token",
+        lambda items: "native-page-2" if items is first_items else None,
+    )
+
+    first_tracks, cursor = _youtubei_playlist_page(Api(), "playlist")
+    second_tracks, terminal_cursor = _youtubei_playlist_page(Api(), "playlist", cursor=cursor)
+
+    assert first_tracks == [{"videoId": "first"}]
+    assert second_tracks == [{"videoId": "second"}]
+    assert cursor == f"{_YOUTUBEI_COLLABORATIVE_CURSOR_PREFIX}native-page-2"
+    assert terminal_cursor is None
+    assert parsed_contexts == [True, True]
+    assert requests == [
+        ("browse", {"browseId": "VLplaylist"}, ""),
+        ("browse", {"continuation": "native-page-2"}),
+    ]
+
+
+def test_youtube_browser_audio_playlist_page_allows_missing_header(monkeypatch):
+    from ytmusicapi import continuations, navigation
+    from ytmusicapi.parsers import playlists
+
+    from songmirror.engine.targets.ytmusic import _youtubei_playlist_page
+
+    items = [{"fixture": "audio-track"}]
+    requests = []
+
+    class Api:
+        def _send_request(self, *args):
+            requests.append(args)
+            return {"fixture": "audio"}
+
+    def navigate(_node, path, _none_if_absent=False):
+        if path == [*navigation.TWO_COLUMN_RENDERER, *navigation.TAB_CONTENT,
+                    *navigation.SECTION_LIST_ITEM]:
+            return None
+        if path == [*navigation.TWO_COLUMN_RENDERER, "secondaryContents", *navigation.SECTION]:
+            return {"contents": [{"musicPlaylistShelfRenderer": {"contents": items}}]}
+        if path == [*navigation.CONTENT, "musicPlaylistShelfRenderer"]:
+            return {"contents": items}
+        raise AssertionError(path)
+
+    def fail_header_parse(_header):
+        raise AssertionError("audio playlists do not have a regular playlist header")
+
+    monkeypatch.setattr(navigation, "nav", navigate)
+    monkeypatch.setattr(playlists, "parse_playlist_header_meta", fail_header_parse)
+    monkeypatch.setattr(
+        playlists,
+        "parse_playlist_items",
+        lambda rows, is_collaborative=False: [{
+            "videoId": rows[0]["fixture"],
+            "is_collaborative": is_collaborative,
+        }],
+    )
+    monkeypatch.setattr(continuations, "get_continuation_token", lambda _items: None)
+
+    tracks, cursor = _youtubei_playlist_page(Api(), "OLAaudio")
+
+    assert tracks == [{"videoId": "audio-track", "is_collaborative": False}]
+    assert cursor is None
+    assert requests == [("browse", {"browseId": "VLOLAaudio"}, "")]
+
+
+def test_youtube_browser_playlist_page_returns_one_native_page(monkeypatch):
+    from songmirror.engine.targets import ytmusic
+    from songmirror.engine.targets.ytmusic import YTMusicBrowserTarget
+
+    calls = []
+
+    def read_page(api, playlist_id, cursor=None):
+        calls.append((api, playlist_id, cursor))
+        return ([{
+            "videoId": "video-21",
+            "setVideoId": "entry-21",
+            "title": "Twenty one",
+            "artists": [{"name": "Artist - Topic"}],
+        }], "page-2")
+
+    monkeypatch.setattr(ytmusic, "_youtubei_playlist_page", read_page)
+    target = YTMusicBrowserTarget.__new__(YTMusicBrowserTarget)
+    target._api = object()
+
+    tracks, cursor = target.playlist_tracks_page({"playlistId": "playlist"}, cursor="page-1")
+
+    assert tracks[0]["videoId"] == "video-21"
+    assert tracks[0]["artist"] == "Artist"
+    assert cursor == "page-2"
+    assert calls == [(target._api, "playlist", "page-1")]


### PR DESCRIPTION
## Summary

- load playlist details progressively for Spotify, Qobuz, Deezer, Amazon Music, Apple Music, and both YouTube Music connection modes
- preserve provider-native cursors, ordering, counts, and YouTube collaborative/audio-playlist parsing while appending pages in the UI
- keep the strict full-playlist readers used by syncs and transfers unchanged

## Context

This follows the TIDAL pagination work in #17 and applies the same responsiveness improvement to the other transferable services. Refs #16.

## Verification

- `uv run python -m pytest -q` — 322 passed, 1 skipped
- `pnpm lint` and `pnpm build` — passed
- `CI=1 pnpm test:e2e` — 119 browser checks, 0 horizontal-overflow failures
- focused pagination and playlist-web tests — 69 passed
- live page reconstruction matched full reads for Spotify (30 tracks), Qobuz (33), Deezer (35), Amazon Music (30), Apple Music (37), and YouTube Music (1,571 across 16 native pages)
- rebuilt local Docker image `sha256:30f509dac4dc3aaa6cc6c016c5a1e64e9701faae24d9c675036f43eb39ded855` is healthy at `http://127.0.0.1:8888`
- zero-mutation Spotify-to-YouTube transfer confidence run completed 16/16 with 0 unavailable tracks and 0 conflicts