### PR TITLE
fix(apple): quarantine rejected catalog tracks

### DIFF
--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -287,6 +287,20 @@ def set_links(conn, target, mapping):
         conn.commit()
 
 
+def delete_links(conn, target, spotify_ids):
+    """Forget proven-bad Spotify mappings so the next pass resolves again."""
+    ids = [spotify_id for spotify_id in spotify_ids if spotify_id]
+    for i in range(0, len(ids), 500):
+        chunk = ids[i : i + 500]
+        marks = ",".join("?" * len(chunk))
+        conn.execute(
+            f"DELETE FROM links WHERE target = ? AND spotify_id IN ({marks})",
+            [target, *chunk],
+        )
+    if ids:
+        conn.commit()
+
+
 def get_state(conn, pair, target):
     return conn.execute(
         "SELECT snapshot_id, target_count FROM sync_state WHERE pair = ? AND target = ?", (pair, target)

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -545,14 +545,21 @@ class AppleMusicTarget(MirrorTarget):
             return float(fallback)
 
     @staticmethod
-    def _error_detail(exc):
-        """A short credential-free Apple error description for diagnostics."""
+    def _error_payload(exc):
         response = getattr(exc, "response", None)
         if response is None:
-            return ""
+            return {}
         try:
             error = (response.json().get("errors") or [])[0]
         except (AttributeError, IndexError, TypeError, ValueError):
+            return {}
+        return error if isinstance(error, dict) else {}
+
+    @classmethod
+    def _error_detail(cls, exc):
+        """A short credential-free Apple error description for diagnostics."""
+        error = cls._error_payload(exc)
+        if not error:
             return ""
         code = error.get("code")
         message = " — ".join(
@@ -562,6 +569,17 @@ class AppleMusicTarget(MirrorTarget):
         if code:
             return f" (code {code})"
         return f" ({message})" if message else ""
+
+    @classmethod
+    def _is_unwritable_track_error(cls, exc):
+        """The track-specific 500 Apple uses for a catalog id it cannot add."""
+        if cls._error_status(exc) != 500:
+            return False
+        error = cls._error_payload(exc)
+        message = " ".join(
+            str(part) for part in (error.get("title"), error.get("detail")) if part
+        ).casefold()
+        return str(error.get("code") or "") == "50001" and "unable to update tracks" in message
 
     def _wait_for_write_window(self):
         deadline = getattr(self, "_write_not_before", 0.0)
@@ -591,23 +609,7 @@ class AppleMusicTarget(MirrorTarget):
             # especially important for fuzzy public-search hits: the next pass
             # must search again under the current stricter recording-version
             # rules instead of retrying a bad mapping forever.
-            isrc = track.get("isrc") or ""
-            candidates = cache.get("isrc", {}).get(isrc, [])
-            if candidates:
-                survivors = [
-                    candidate for candidate in candidates
-                    if str(candidate.get("id")) != str(catalog_id)
-                ]
-                if survivors:
-                    cache["isrc"][isrc] = survivors
-                else:
-                    cache["isrc"].pop(isrc, None)
-            search = cache.setdefault("search", {})
-            for key, value in list(search.items()):
-                if str(value) == str(catalog_id):
-                    del search[key]
-            cache["dirty"] = True
-            self._resolved_catalog_context.pop(str(catalog_id), None)
+            self._evict_catalog_id(catalog_id)
             return None
 
         replacement = str(replacement)
@@ -620,8 +622,33 @@ class AppleMusicTarget(MirrorTarget):
             f"{track.get('name', '')}|{primary}".casefold()
         ] = replacement
         cache["dirty"] = True
+        self._resolved_catalog_context.pop(str(catalog_id), None)
         self._resolved_catalog_context[replacement] = (track, cache)
         return replacement
+
+    def _evict_catalog_id(self, catalog_id):
+        """Remove one rejected catalog id from every resolution cache."""
+        context = getattr(self, "_resolved_catalog_context", {}).get(str(catalog_id))
+        if not context:
+            return
+        track, cache = context
+        isrc = track.get("isrc") or ""
+        candidates = cache.get("isrc", {}).get(isrc, [])
+        if candidates:
+            survivors = [
+                candidate for candidate in candidates
+                if str(candidate.get("id")) != str(catalog_id)
+            ]
+            if survivors:
+                cache["isrc"][isrc] = survivors
+            else:
+                cache["isrc"].pop(isrc, None)
+        search = cache.setdefault("search", {})
+        for key, value in list(search.items()):
+            if str(value) == str(catalog_id):
+                del search[key]
+        cache["dirty"] = True
+        self._resolved_catalog_context.pop(str(catalog_id), None)
 
     def _verify_add_landed(self, playlist, catalog_id, before_count):
         """True/False when a post-error read proves the outcome, None if reads fail.
@@ -648,6 +675,16 @@ class AppleMusicTarget(MirrorTarget):
             if check < 2:
                 time.sleep(1 + check)
         return False
+
+    def _catalog_track_label(self, catalog_id):
+        context = getattr(self, "_resolved_catalog_context", {}).get(str(catalog_id))
+        if not context:
+            return f"catalog id {catalog_id}"
+        track, _cache = context
+        name = (track.get("name") or "").strip()
+        artists = [artist for artist in (track.get("artists") or []) if artist]
+        credit = f" by {', '.join(artists)}" if artists else ""
+        return f"'{name}'{credit} (catalog id {catalog_id})" if name else f"catalog id {catalog_id}"
 
     def _add_one(self, playlist, catalog_id, before_count):
         url = f"{AMP}/me/library/playlists/{playlist['id']}/tracks"
@@ -712,6 +749,7 @@ class AppleMusicTarget(MirrorTarget):
                         f"Apple add {catalog_id} had an ambiguous outcome and the playlist "
                         "could not be verified; stopping this ordered queue until the next pass"
                     ) from e
+                track_label = self._catalog_track_label(catalog_id)
                 if not repaired:
                     replacement = self._repair_catalog_id(catalog_id)
                     repaired = True
@@ -723,6 +761,14 @@ class AppleMusicTarget(MirrorTarget):
                         catalog_id = replacement
                         before_count = 0
                         continue
+                if self._is_unwritable_track_error(e):
+                    self._evict_catalog_id(catalog_id)
+                    log_warn(
+                        f"Apple cannot add {track_label}; "
+                        "quarantining this catalog match and continuing with later tracks",
+                        tag=self.tag,
+                    )
+                    return None
 
         raise RuntimeError(
             f"Apple kept rejecting add {catalog_id} after 6 attempts; "
@@ -736,14 +782,19 @@ class AppleMusicTarget(MirrorTarget):
         confirmed_counts = {}
         added_catalog_ids = getattr(self, "_added_catalog_ids", {})
         self._added_catalog_ids = added_catalog_ids
+        added_requested_ids = []
         for catalog_id in target_ids:
             requested_id = catalog_id
             catalog_id = self.added_id(requested_id)
             before_count = confirmed_counts.get(catalog_id, 0)
             actual_id = self._add_one(playlist, catalog_id, before_count)
+            if actual_id is None:
+                continue
             added_catalog_ids[str(requested_id)] = str(actual_id)
             confirmed_counts[str(actual_id)] = before_count + 1
+            added_requested_ids.append(requested_id)
             polite_sleep(1.0)
+        return added_requested_ids
 
     def added_id(self, target_id):
         return getattr(self, "_added_catalog_ids", {}).get(str(target_id), target_id)

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -10,6 +10,7 @@ all live here once.
 """
 
 import time
+from collections import Counter
 
 from .. import archive
 from ..logs import (
@@ -154,7 +155,12 @@ class MirrorTarget:
         return target_id, "link"
 
     def add(self, playlist, target_ids):
-        """Append target_ids IN ORDER, one request per id (never batch)."""
+        """Append target_ids IN ORDER, one request per id (never batch).
+
+        Return ``None`` when every requested id was written. A provider that
+        can prove and quarantine a permanent per-track rejection may instead
+        return the requested ids that were actually written, in order.
+        """
         raise NotImplementedError
 
     def added_id(self, target_id):
@@ -181,6 +187,27 @@ class MirrorTarget:
         the library song, taking every copy with it)."""
         for _, raw in positioned:
             self.remove(playlist, raw)
+
+
+def _split_add_results(additions, result, id_at):
+    """Partition queued rows using an optional provider add-result sequence.
+
+    ``None`` is the long-standing all-succeeded contract. A concrete sequence
+    is a multiset of requested ids confirmed by a provider that deliberately
+    skipped a proven permanent rejection.
+    """
+    if result is None:
+        return list(additions), []
+    confirmed_counts = Counter(str(target_id) for target_id in result)
+    confirmed, rejected = [], []
+    for addition in additions:
+        key = str(id_at(addition))
+        if confirmed_counts[key] > 0:
+            confirmed.append(addition)
+            confirmed_counts[key] -= 1
+        else:
+            rejected.append(addition)
+    return confirmed, rejected
 
 
 def held_removals(target_name, playlist, tracks, max_removals, reason=None, *,
@@ -302,6 +329,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     # Resolve additions to target ids, preserving the oldest-first order.
     present = {target.track_id(t) for t in tgt_tracks if target.track_id(t)}
     additions, not_found, new_links, methods = [], [], {}, {}
+    rejected_link_ids = set()
     stopped_early = False
     deferred = 0
     for i, track in enumerate(to_add, 1):
@@ -345,7 +373,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
             new_links[track["id"]] = tid
         if tid not in present:
             method = method or "search"
-            additions.append((tid, label, method))
+            additions.append((tid, label, method, track))
             present.add(tid)
             methods[method] = methods.get(method, 0) + 1
     # A provider miss can be provisional (catalog throttling, regional indexing,
@@ -379,15 +407,6 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
             held_back = held_removals(target.name, name, removals, max_removals)
             removals_skipped, removals, guard = len(removals), [], True
 
-    for _, label, method in additions:
-        log_add(f"{label}  {paint('(' + method + ')', 'grey')}", dry=not execute, tag=tag)
-    for track in removals:
-        log_remove(f"{track['name']} - {track['artist']}", dry=not execute, tag=tag)
-    for track in held:
-        log_hold(f"kept (no {target.name} match for its Spotify twin): {track['name']} - {track['artist']}", tag=tag)
-    for track in not_found:
-        log_miss(f"not on {target.name}: {track['name']} - {', '.join(track['artists'])}", tag=tag)
-
     if execute:
         if additions or removals:
             # Invalidate before the first provider write: a batched/ordered add
@@ -401,9 +420,48 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
                     songs, target.source, playlist_id
                 )
         if additions:
-            target.add(tgt_playlist, [tid for tid, _, _ in additions])
+            result = target.add(tgt_playlist, [tid for tid, _, _, _ in additions])
+            additions, rejected = _split_add_results(additions, result, lambda item: item[0])
+            if rejected:
+                rejected_tracks = [track for _tid, _label, _method, track in rejected]
+                rejected_target_ids = {str(tid) for tid, _label, _method, _track in rejected}
+                rejected_source_ids = {
+                    source_id for source_id, target_id in new_links.items()
+                    if str(target_id) in rejected_target_ids
+                }
+                rejected_track_ids = {
+                    track.get("id") for track in rejected_tracks if track.get("id")
+                }
+                not_found.extend(rejected_tracks)
+                not_found.extend(
+                    track for track in to_add
+                    if track.get("id") in rejected_source_ids
+                    and track.get("id") not in rejected_track_ids
+                )
+                guard = True
+                for source_id in rejected_source_ids:
+                    new_links.pop(source_id, None)
+                    rejected_link_ids.add(source_id)
+                if removals:
+                    held.extend(removals)
+                    removals = []
+                methods = {}
+                for _tid, _label, method, _track in additions:
+                    methods[method] = methods.get(method, 0) + 1
+
+    for _, label, method, _track in additions:
+        log_add(f"{label}  {paint('(' + method + ')', 'grey')}", dry=not execute, tag=tag)
+    for track in removals:
+        log_remove(f"{track['name']} - {track['artist']}", dry=not execute, tag=tag)
+    for track in held:
+        log_hold(f"kept (no {target.name} match for its Spotify twin): {track['name']} - {track['artist']}", tag=tag)
+    for track in not_found:
+        log_miss(f"not on {target.name}: {track['name']} - {', '.join(track['artists'])}", tag=tag)
+
+    if execute:
         if source_key == "spotify":
             actual_id = getattr(target, "added_id", lambda target_id: target_id)
+            archive.delete_links(songs, target.source, rejected_link_ids)
             archive.set_links(
                 songs,
                 target.source,
@@ -1061,6 +1119,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         )
     interrupted = False       # a Pause/Stop mid-pass -> freeze the baseline too (partial advance is unsafe)
     new_links = {p.source: {} for p in peers}
+    rejected_link_ids = {p.source: set() for p in peers}
     new_state = {}   # source -> canonical membership to persist (only when the baseline is safe)
     applied_removals = {}  # source -> canonical ids this pass itself removed successfully
     for p in peers:
@@ -1175,6 +1234,20 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                      f"deferring {cap_deferred}", tag=p.tag)
             additions = additions[:max_adds]
             add_blockers.add("replacement additions exceeded the add cap")
+        if execute and additions:
+            result = p.add(
+                playlists[p.source],
+                [target_id for _cid, target_id, _method, _norm in additions],
+            )
+            additions, rejected = _split_add_results(additions, result, lambda item: item[1])
+            if rejected:
+                rejected_norms = [norm for _cid, _tid, _method, norm in rejected]
+                not_found.extend(rejected_norms)
+                add_blockers.add("the provider rejected one or more catalog matches")
+                rejected_link_ids[p.source].update(
+                    norm["_raw"]["id"] for norm in rejected_norms
+                    if norm["_source"] == "spotify" and norm["_raw"].get("id")
+                )
         for _, tid, _, norm in additions:
             if norm["_source"] == "spotify" and norm["_raw"].get("id"):
                 new_links[p.source][norm["_raw"]["id"]] = tid
@@ -1316,8 +1389,6 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             log_miss(f"not on {p.name}: {norm['name']} - {', '.join(norm['artists'])}", tag=p.tag)
 
         if execute:
-            if additions:
-                p.add(playlists[p.source], [tid for _, tid, _, _ in additions])
             for norm in safe:
                 p.remove(playlists[p.source], norm["_raw"])
             if removed_cids:
@@ -1337,6 +1408,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
 
     if execute:
         for p in peers:
+            archive.delete_links(songs, p.source, rejected_link_ids[p.source])
             archive.set_links(songs, p.source, new_links[p.source])
         # Advance every baseline when reads were trusted and no membership
         # change was held. When additions are incomplete or a removal is capped,

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -16,7 +16,7 @@ from ..engine.logs import log_add, log_miss, log_warn
 from ..engine.matching import spotify_track_keys, track_key, tracks_oldest_first
 from ..engine.runner import load_cache, save_cache
 from ..engine.targets import build_one, is_peer
-from ..engine.targets.base import TargetAuthError, _normalize
+from ..engine.targets.base import TargetAuthError, _normalize, _split_add_results
 
 
 def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_progress=None, should_continue=None):
@@ -91,7 +91,7 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
                 except Exception:
                     tid = None
             if tid:
-                additions.append(tid)
+                additions.append((tid, norm))
                 seen |= keys
                 log_add(f"{norm['name']} - {norm['artist']}", dry=not execute, tag="transfer")
             else:
@@ -104,7 +104,16 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
     deferred = max(0, len(additions) - max_adds)
     additions = additions[:max_adds]
     if execute and additions:
-        dest.add(dest_pl, additions)
+        result = dest.add(dest_pl, [target_id for target_id, _norm in additions])
+        additions, rejected = _split_add_results(additions, result, lambda item: item[0])
+        for _target_id, norm in rejected:
+            not_found.append({"name": norm["name"], "artist": norm["artist"],
+                              "key": track_key(norm["name"], norm["artist"])})
+            log_warn(
+                f"{getattr(dest, 'name', dest.source)} rejected its catalog match for "
+                f"{norm['name']} - {norm['artist']}; moved it to Needs review and continued",
+                tag="transfer",
+            )
     return {
         "added": len(additions),
         "deferred": deferred,

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -792,6 +792,47 @@ def test_reconcile_stops_ordered_adds_at_a_transient_resolution_error(tmp_path):
     conn.close()
 
 
+def test_reconcile_counts_only_provider_confirmed_adds(tmp_path):
+    class RejectingPeer(_P):
+        def add(self, playlist, ids):
+            self.requested = list(ids)
+            confirmed = [target_id for target_id in ids if not target_id.endswith("-B")]
+            for target_id in confirmed:
+                isrc = target_id.split("-", 1)[1]
+                self.added.append(isrc)
+                self._isrcs.append(isrc)
+            return confirmed
+
+    conn = archive.connect(str(tmp_path / "provider-rejection-nway.db"))
+    archive.set_links(conn, "apple", {"spotify-B": "apple-B"})
+    for source in ("spotify", "apple"):
+        archive.set_playlist_state(conn, "mix", source, set())
+    spotify = _P("spotify", ["A", "B", "C"])
+    apple = RejectingPeer("apple", [])
+
+    stats = reconcile(
+        [spotify, apple],
+        "Mix",
+        {"spotify": {"id": "s"}, "apple": {"id": "a"}},
+        _caches("spotify", "apple"),
+        conn,
+        execute=True,
+        max_removals=0,
+        max_adds=200,
+    )
+
+    assert apple.requested == ["apple-A", "apple-B", "apple-C"]
+    assert apple.added == ["A", "C"]
+    assert stats["added"] == 2
+    assert stats["missing"] == 1
+    assert stats["clean"] is False
+    assert archive.get_links(conn, "apple", ["spotify-A", "spotify-B", "spotify-C"]) == {
+        "spotify-A": "apple-A",
+        "spotify-C": "apple-C",
+    }
+    conn.close()
+
+
 def test_nonempty_pagination_collapse_never_plans_mass_removal(tmp_path):
     # A truncated provider read is often non-empty (for example 55 -> 5), so the
     # collapse guard must not only protect the zero-track case.

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -408,6 +408,77 @@ def test_one_way_mirror_defers_the_ordered_suffix_after_a_transient_resolve(tmp_
     songs.close()
 
 
+def test_one_way_mirror_counts_only_provider_confirmed_adds(tmp_path):
+    from songmirror.engine.targets.base import mirror_pair
+
+    songs = archive.connect(str(tmp_path / "provider-rejection-one-way.db"))
+    archive.set_links(songs, "apple", {
+        "source-blocked": "blocked",
+        "source-blocked-alias": "blocked",
+    })
+
+    class Target:
+        name, tag, source = "Apple Music", "apple", "apple"
+
+        def playlist_tracks(self, playlist):
+            return [{
+                "catalog_id": "obsolete",
+                "name": "Obsolete",
+                "artist": "Other Artist",
+                "duration_ms": 1,
+            }]
+
+        def track_id(self, track):
+            return track.get("catalog_id")
+
+        def expected_ids(self, tracks, links, cache):
+            return {}
+
+        def prefetch(self, tracks, cache):
+            pass
+
+        def resolve(self, track, cache):
+            return track["name"].casefold(), "search"
+
+        def add(self, playlist, ids):
+            self.requested = list(ids)
+            return ["later"]
+
+        def remove(self, playlist, track):
+            self.removed.append(track["catalog_id"])
+
+    target = Target()
+    target.removed = []
+    source_tracks = [
+        {"id": "source-blocked", "name": "Blocked", "artists": ["Artist"], "duration_ms": 1},
+        {"id": "source-blocked-alias", "name": "Blocked Alias", "artists": ["Artist"], "duration_ms": 1},
+        {"id": "source-later", "name": "Later", "artists": ["Artist"], "duration_ms": 1},
+    ]
+
+    stats = mirror_pair(
+        target,
+        source_tracks,
+        {"name": "Aurora"},
+        {"id": "apple-aurora"},
+        {"isrc": {}, "search": {}, "dirty": False},
+        songs,
+        execute=True,
+        max_removals=200,
+        max_adds=200,
+    )
+
+    assert target.requested == ["blocked", "later"]
+    assert stats["added"] == 1
+    assert stats["missing"] == 2
+    assert stats["held"] == 1
+    assert stats["clean"] is False
+    assert target.removed == []
+    assert archive.get_links(
+        songs, "apple", ["source-blocked", "source-blocked-alias", "source-later"]
+    ) == {"source-later": "later"}
+    songs.close()
+
+
 def test_one_way_unresolved_track_keeps_snapshot_retryable(tmp_path):
     from songmirror.engine.targets.base import mirror_pair
 

--- a/tests/test_targets_accessors.py
+++ b/tests/test_targets_accessors.py
@@ -342,6 +342,11 @@ def test_apple_add_repairs_a_stale_catalog_id_before_continuing(monkeypatch):
         if catalog_id == "1848462301":
             response = requests.Response()
             response.status_code = 500
+            response.headers["Content-Type"] = "application/json"
+            response._content = (
+                b'{"errors":[{"code":"50001","title":"Upstream Service Error",'
+                b'"detail":"Unable to update tracks"}]}'
+            )
             raise requests.HTTPError("500 Server Error", response=response)
         landed.append(catalog_id)
         return object()
@@ -363,6 +368,209 @@ def test_apple_add_repairs_a_stale_catalog_id_before_continuing(monkeypatch):
     assert target.added_id("1848462301") == "6791344492"
     assert cache["isrc"]["QZEQU2502334"][0]["id"] == "6791344492"
     assert cache["dirty"] is True
+
+
+def test_apple_add_quarantines_an_unwritable_50001_and_continues(monkeypatch):
+    """A catalog-specific rejection must not pin every later track forever."""
+    import json
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target._write_not_before = 0.0
+    target._public_search_not_before = 0.0
+    target._resolved_catalog_context = {}
+    target._added_catalog_ids = {}
+    cache = {
+        "isrc": {"USAAA2600001": [{"id": "bad-id"}]},
+        "search": {"blocked song|artist": "bad-id"},
+        "dirty": False,
+    }
+    target._remember_resolution({
+        "id": "source-bad",
+        "isrc": "USAAA2600001",
+        "name": "Blocked Song",
+        "artists": ["Artist"],
+        "duration_ms": 180000,
+    }, "bad-id", cache)
+
+    calls, landed, warnings = [], [], []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        if catalog_id == "bad-id":
+            response = requests.Response()
+            response.status_code = 500
+            response.headers["Content-Type"] = "application/json"
+            response._content = json.dumps({"errors": [{
+                "code": "50001",
+                "title": "Upstream Service Error",
+                "detail": "Unable to update tracks",
+            }]}).encode()
+            raise requests.HTTPError("500 Server Error", response=response)
+        landed.append(catalog_id)
+        return object()
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: [
+        {"catalog_id": catalog_id} for catalog_id in landed
+    ]
+    target._rebuild_session = lambda: None
+    target._public_search_once = lambda *_args: "bad-id"
+    monkeypatch.setattr(apple, "polite_sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+    monkeypatch.setattr(apple, "log_warn", lambda message, **_kwargs: warnings.append(message))
+
+    added = target.add({"id": "aurora"}, ["bad-id", "newest"])
+
+    assert added == ["newest"]
+    assert calls == ["bad-id", "newest"]
+    assert landed == ["newest"]
+    assert "USAAA2600001" not in cache["isrc"]
+    assert cache["search"] == {}
+    assert cache["dirty"] is True
+    assert any("'Blocked Song' by Artist (catalog id bad-id)" in warning for warning in warnings)
+
+
+def test_apple_add_evicts_a_rejected_replacement_before_continuing(monkeypatch):
+    """A repaired id that Apple also rejects must not be retried next pass."""
+    import json
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target._write_not_before = 0.0
+    target._public_search_not_before = 0.0
+    target._resolved_catalog_context = {}
+    target._added_catalog_ids = {}
+    cache = {
+        "isrc": {"USAAA2600001": [{"id": "bad-id"}]},
+        "search": {"blocked song|artist": "bad-id"},
+        "dirty": False,
+    }
+    target._remember_resolution({
+        "id": "source-bad",
+        "isrc": "USAAA2600001",
+        "name": "Blocked Song",
+        "artists": ["Artist"],
+        "duration_ms": 180000,
+    }, "bad-id", cache)
+
+    calls, landed = [], []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        if catalog_id in {"bad-id", "replacement-id"}:
+            response = requests.Response()
+            response.status_code = 500
+            response.headers["Content-Type"] = "application/json"
+            response._content = json.dumps({"errors": [{
+                "code": "50001",
+                "title": "Upstream Service Error",
+                "detail": "Unable to update tracks",
+            }]}).encode()
+            raise requests.HTTPError("500 Server Error", response=response)
+        landed.append(catalog_id)
+        return object()
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: [
+        {"catalog_id": catalog_id} for catalog_id in landed
+    ]
+    target._rebuild_session = lambda: None
+    target._public_search_once = lambda *_args: "replacement-id"
+    monkeypatch.setattr(apple, "polite_sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+
+    added = target.add({"id": "aurora"}, ["bad-id", "newest"])
+
+    assert added == ["newest"]
+    assert calls == ["bad-id", "replacement-id", "newest"]
+    assert "USAAA2600001" not in cache["isrc"]
+    assert cache["search"] == {}
+    assert cache["dirty"] is True
+    assert target._resolved_catalog_context == {}
+
+
+def test_apple_add_keeps_generic_500_failures_ordered_for_a_later_retry(monkeypatch):
+    """Only Apple's proven per-track rejection may let a later song pass."""
+    import json
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target._write_not_before = 0.0
+    target._resolved_catalog_context = {}
+    calls = []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        response = requests.Response()
+        response.status_code = 500
+        response.headers["Content-Type"] = "application/json"
+        response._content = json.dumps({"errors": [{
+            "code": "50000",
+            "title": "Internal Server Error",
+            "detail": "Please try again later",
+        }]}).encode()
+        raise requests.HTTPError("500 Server Error", response=response)
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: []
+    target._rebuild_session = lambda: None
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+
+    with pytest.raises(RuntimeError, match=r"after 6 attempts;.*ordered queue"):
+        target.add({"id": "aurora"}, ["retry-later", "must-not-overtake"])
+
+    assert calls == ["retry-later"] * 6
+
+
+@pytest.mark.parametrize("status_code", [408, 502])
+def test_apple_add_does_not_quarantine_non_500_responses(monkeypatch, status_code):
+    """The 50001 payload is safe to skip only on Apple's exact HTTP 500."""
+    import json
+    import requests
+
+    from songmirror.engine.targets import apple
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target._write_not_before = 0.0
+    target._resolved_catalog_context = {}
+    calls = []
+
+    def fake_request(method, url, *, json_body=None, **kwargs):
+        catalog_id = json_body["data"][0]["id"]
+        calls.append(catalog_id)
+        response = requests.Response()
+        response.status_code = status_code
+        response.headers["Content-Type"] = "application/json"
+        response._content = json.dumps({"errors": [{
+            "code": "50001",
+            "title": "Upstream Service Error",
+            "detail": "Unable to update tracks",
+        }]}).encode()
+        raise requests.HTTPError(f"{status_code} Server Error", response=response)
+
+    target._request = fake_request
+    target.playlist_tracks = lambda _playlist: []
+    target._rebuild_session = lambda: None
+    monkeypatch.setattr(apple.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(apple.random, "uniform", lambda *_args: 0)
+
+    with pytest.raises(RuntimeError, match=r"after 6 attempts;.*ordered queue"):
+        target.add({"id": "aurora"}, ["retry-later", "must-not-overtake"])
+
+    assert calls == ["retry-later"] * 6
 
 
 def test_apple_current_isrc_candidate_outranks_an_archived_link():

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -45,6 +45,48 @@ def test_transfer_copies_matches_skips_dupes_reports_conflicts():
     # "Dup" already exists on the destination (same track_key) -> skipped, not re-added
 
 
+def test_transfer_reports_a_provider_rejected_match_and_keeps_copying():
+    written = []
+
+    class _Source:
+        source = "spotify"
+
+        def playlist_tracks(self, playlist):
+            return [
+                {"id": "blocked", "name": "Blocked", "artists": ["Artist"],
+                 "duration_ms": 1000, "isrc": "I1", "added_at": "2020"},
+                {"id": "later", "name": "Later", "artists": ["Artist"],
+                 "duration_ms": 1000, "isrc": "I2", "added_at": "2021"},
+            ]
+
+    class _Destination:
+        source = "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def resolve(self, track, cache):
+            return f"dest-{track['name'].casefold()}", "search"
+
+        def add(self, playlist, ids):
+            written.append("dest-later")
+            return ["dest-later"]
+
+    result = transfer(
+        _Source(),
+        _Destination(),
+        {"id": "source"},
+        {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True,
+        max_adds=100,
+    )
+
+    assert written == ["dest-later"]
+    assert result["added"] == 1
+    assert [conflict["name"] for conflict in result["not_found"]] == ["Blocked"]
+
+
 def test_transfer_skips_unavailable_tidal_entries_without_aborting():
     added = []
     progress = []


### PR DESCRIPTION
## Summary

- distinguish Apple's verified per-track HTTP 500 / 50001 rejection from transient or ambiguous write failures
- attempt a current catalog replacement, then evict and quarantine only an unrecoverable match so valid later tracks can continue
- propagate confirmed and rejected additions through one-way sync, N-way reconcile, and transfers so links, counts, conflicts, baselines, and removal guards remain accurate

## Safety

- generic HTTP 500, HTTP 408/502, rate limits, network failures, and unverifiable outcomes still stop the ordered queue for a later retry
- a viable replacement is attempted before quarantine; a rejected replacement is evicted too
- rejected additions keep syncs unclean, delete stale durable links (including aliases), and hold destructive removals

## Reproduction and verification

- reproduced the reported warning and terminal failure deterministically through the real Apple target write path: the old behavior retried the same 50001 catalog ID six times and blocked a later valid track
- `uv run python -m pytest -q tests/test_targets_accessors.py tests/test_runner_summary.py tests/test_reconcile.py tests/test_transfers.py` — 137 passed
- `uv run python -m pytest -q` — 330 passed, 1 skipped
- `git diff --check` — passed
- rebuilt local Docker image `sha256:aa3658b2818b653a2e42c7bda8951038b028754ebe133615f4577604dd8f3902`; container is healthy at http://127.0.0.1:8888

The failure-path regression did not mutate a real Apple Music playlist; reproducing the provider response live requires the reporter's account/catalog context.

Fixes #19