### PR TITLE
Don't fail the whole Spotify playlist list over one bad entry

### DIFF
--- a/songmirror/engine/spotify_cookie.py
+++ b/songmirror/engine/spotify_cookie.py
@@ -334,14 +334,36 @@ def _library_image_sources(images):
     return out
 
 
-def library_playlists():
-    """Every playlist in the signed-in account's library.
+def _hydrate_playlist_name(uri):
+    """Best-effort single-playlist name lookup for a blank libraryV3 row. Some
+    followed playlists are nameless even here, so None is a valid outcome —
+    the caller falls back to a placeholder rather than treating it as fatal."""
+    try:
+        data = _pf("fetchPlaylist", {
+            "uri": uri, "offset": 0, "limit": 0, "enableWatchFeedEntrypoint": False,
+        })
+    except Exception as e:
+        log_warn(f"could not hydrate playlist name for {uri} ({e!r})", tag="spotify")
+        return None
+    return ((data.get("playlistV2") or {}).get("name") or "").strip() or None
+
+
+def library_directory():
+    """Every playlist in the signed-in account's library, plus whether the
+    read had to skip or guess at any row (`partial`).
 
     ``libraryV3`` is the web player's own filtered library query. It avoids the
     old rootlist plus one metadata request per playlist, and its capability data
     identifies followed playlists that are readable but not editable.
+
+    A row with no resolvable id is dropped; a row with an id but no name gets a
+    targeted lookup, falling back to a placeholder if that also comes back
+    nameless. Either way `partial` is set: `library_playlists()` ignores it for
+    browsing, but a sync consumer must not treat an absence as authoritative
+    when it's set.
     """
     out, offset, limit = [], 0, 100
+    partial = False
     while True:
         variables = {
             "filters": ["Playlists"], "order": "Alphabetical", "textFilter": None,
@@ -363,14 +385,26 @@ def library_playlists():
             if data.get("__typename") != "Playlist":
                 continue
             uri = data.get("uri") or item.get("_uri") or ""
-            if not str(uri).startswith("spotify:playlist:") or not data.get("name"):
-                raise RuntimeError("Spotify library read incomplete: playlist metadata was missing")
+            if not str(uri).startswith("spotify:playlist:"):
+                log_warn("skipping library row with no resolvable playlist id", tag="spotify")
+                partial = True
+                continue
+            name = data.get("name") or ""
+            if not name:
+                name = _hydrate_playlist_name(uri) or ""
+                if not name:
+                    pid = str(uri).rsplit(":", 1)[-1]
+                    name = f"Untitled playlist ({pid})"
+                    partial = True
+                    log_warn(
+                        f"playlist {pid} has no name even after a direct lookup - "
+                        f"using a fallback label", tag="spotify")
             owner = (data.get("ownerV2") or {}).get("data") or {}
             editable = bool((data.get("currentUserCapabilities") or {}).get("canEditItems"))
             out.append({
                 "id": str(uri).rsplit(":", 1)[-1],
                 "uri": uri,
-                "name": data.get("name") or "",
+                "name": name,
                 "description": data.get("description") or "",
                 "snapshot_id": data.get("revisionId"),
                 "owner": {"id": owner.get("username") or owner.get("id")},
@@ -380,7 +414,13 @@ def library_playlists():
             })
         offset += len(rows)
         if offset >= int(total):
-            return out
+            return out, partial
+
+
+def library_playlists():
+    """Tolerant, browse-facing view of `library_directory()`. A sync consumer
+    should call `library_directory()` directly and check `partial` instead."""
+    return library_directory()[0]
 
 
 def _playlist_track_total(playlist):

--- a/songmirror/engine/targets/spotify_target.py
+++ b/songmirror/engine/targets/spotify_target.py
@@ -62,8 +62,15 @@ class SpotifyTarget(MirrorTarget):
     # -- MirrorTarget ----------------------------------------------------------
     def list_playlists(self):
         if spotify_write_backend() == "cookie" or self._sp is None:
+            playlists, partial = spotify_cookie.library_directory()
+            if partial:
+                # An incomplete listing must not read as "doesn't exist" and create a duplicate.
+                raise TargetAuthError(
+                    "Spotify library read is incomplete - refusing to sync so an "
+                    "existing playlist isn't duplicated. Check the warnings above."
+                )
             best = {}
-            for playlist in spotify_cookie.library_playlists():
+            for playlist in playlists:
                 key = self.playlist_name(playlist).strip().casefold()
                 if not key:
                     continue

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -1739,6 +1739,40 @@ def test_nway_counts_and_names_a_playlist_it_could_not_sync(monkeypatch):
     assert entry["added"] == 0 and entry["removed"] == 0
 
 
+def test_spotify_target_partial_directory_never_reaches_create(monkeypatch, tmp_path):
+    """A partial library_directory() read must abort before create() is ever
+    reached, so it can't be mistaken for "this playlist doesn't exist"."""
+    from songmirror.engine.targets.base import TargetAuthError
+    from songmirror.engine.targets.spotify_target import SpotifyTarget
+
+    monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "cookie")
+
+    def boom_create(*a, **k):
+        raise AssertionError("a partial directory must never reach target.create()")
+
+    target = SpotifyTarget(None, str(tmp_path / "c.json"), sync_peer=True)
+    monkeypatch.setattr(target, "create", boom_create)
+    monkeypatch.setattr(
+        "songmirror.engine.spotify_cookie.library_directory",
+        lambda: ([{"id": "p1", "name": "Mix", "_owned": True, "_editable": True}], True),
+    )
+
+    songs = archive.connect(str(tmp_path / "songs.db"))
+    try:
+        with pytest.raises(TargetAuthError, match="incomplete"):
+            runner.run_target(
+                target,
+                [{"id": "sp1", "name": "Mix"}],  # same name as the one real row we do have
+                lambda pl: [],
+                songs,
+                _opts(execute=True),
+                links=[],
+                source=_FakeSource(),
+            )
+    finally:
+        songs.close()
+
+
 def test_failure_detail_is_bounded_but_the_count_is_not():
     counts, dest = {"failed": 0}, []
     for i in range(runner.FAILURE_DETAIL + 5):

--- a/tests/test_spotify_cookie.py
+++ b/tests/test_spotify_cookie.py
@@ -115,6 +115,96 @@ def test_cookie_library_playlists_are_read_in_one_filtered_request(monkeypatch):
     })]
 
 
+def _library_page(rows, total):
+    return {"me": {"libraryV3": {"totalCount": total, "items": rows}}}
+
+
+def _row(uri, name=None, revision="r"):
+    row = {"item": {"data": {
+        "__typename": "Playlist", "uri": uri, "description": "",
+        "revisionId": revision, "currentUserCapabilities": {"canEditItems": True},
+        "ownerV2": {"data": {"username": "me"}}, "images": {"items": []},
+    }}}
+    if name is not None:
+        row["item"]["data"]["name"] = name
+    return row
+
+
+def test_library_directory_valid_row_survives_a_sibling_with_an_unusable_uri(monkeypatch):
+    from songmirror.engine import spotify_cookie as sc
+
+    rows = [_row("spotify:playlist:good", name="Good"), _row("", name="Bad Uri")]
+    monkeypatch.setattr(sc, "_pf", lambda op, variables: _library_page(rows, 2))
+
+    playlists, partial = sc.library_directory()
+
+    assert [p["id"] for p in playlists] == ["good"]
+    assert partial is True
+
+
+def test_library_directory_hydrates_a_missing_name_from_a_targeted_lookup(monkeypatch):
+    from songmirror.engine import spotify_cookie as sc
+
+    rows = [_row("spotify:playlist:blank")]  # no "name" key at all -> falsy .get("name")
+    calls = []
+
+    def fake_pf(op, variables):
+        calls.append((op, variables))
+        if op == "libraryV3":
+            return _library_page(rows, 1)
+        assert op == "fetchPlaylist"
+        assert variables == {
+            "uri": "spotify:playlist:blank", "offset": 0, "limit": 0,
+            "enableWatchFeedEntrypoint": False,
+        }
+        return {"playlistV2": {"name": "Recovered Name"}}
+
+    monkeypatch.setattr(sc, "_pf", fake_pf)
+    playlists, partial = sc.library_directory()
+
+    assert playlists[0]["name"] == "Recovered Name"
+    assert partial is False  # a successful hydration is not a partial read
+    assert [op for op, _ in calls] == ["libraryV3", "fetchPlaylist"]
+
+
+def test_library_directory_falls_back_to_a_placeholder_when_hydration_also_comes_up_blank(monkeypatch):
+    from songmirror.engine import spotify_cookie as sc
+
+    rows = [_row("spotify:playlist:blank")]
+
+    def fake_pf(op, variables):
+        if op == "libraryV3":
+            return _library_page(rows, 1)
+        assert op == "fetchPlaylist"
+        return {"playlistV2": {"name": ""}}  # genuinely nameless even at the source
+
+    monkeypatch.setattr(sc, "_pf", fake_pf)
+    playlists, partial = sc.library_directory()
+
+    assert playlists[0]["name"] == "Untitled playlist (blank)"
+    assert partial is True  # a guessed label must not look like an authoritative name
+
+
+def test_library_directory_advances_pagination_by_raw_rows_not_accepted_rows(monkeypatch):
+    from songmirror.engine import spotify_cookie as sc
+
+    page1 = [_row("spotify:playlist:good", name="Good"), _row("", name="Bad Uri")]
+    page2 = [_row("spotify:playlist:last", name="Last")]
+    seen_offsets = []
+
+    def fake_pf(op, variables):
+        seen_offsets.append(variables["offset"])
+        return _library_page(page1, 3) if variables["offset"] == 0 else _library_page(page2, 3)
+
+    monkeypatch.setattr(sc, "_pf", fake_pf)
+    playlists, partial = sc.library_directory()
+
+    # 2 raw rows on page 1 (only 1 accepted) -> next offset is 2, not 1.
+    assert seen_offsets == [0, 2]
+    assert [p["id"] for p in playlists] == ["good", "last"]
+    assert partial is True
+
+
 def test_pathfinder_read_retries_transient_connection_failure(monkeypatch):
     from songmirror.engine import spotify_cookie as sc
 
@@ -201,10 +291,12 @@ def test_cookie_browse_hydrates_track_counts_and_caches_by_revision(monkeypatch)
 
 def test_cookie_target_lists_and_searches_without_spotipy(monkeypatch):
     monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "cookie")
-    monkeypatch.setattr(st.spotify_cookie, "library_playlists", lambda: [
+    rows = [
         {"id": "p1", "name": "Mix", "_owned": True},
         {"id": "p2", "name": "Mix", "_owned": False},
-    ])
+    ]
+    monkeypatch.setattr(st.spotify_cookie, "library_directory", lambda: (rows, False))
+    monkeypatch.setattr(st.spotify_cookie, "library_playlists", lambda: rows)
     monkeypatch.setattr(st.spotify_cookie, "search_tracks", lambda query, limit=8: [
         {"id": "hit", "name": "Song", "artists": [{"name": "Artist"}], "duration_ms": 180000},
     ])
@@ -213,6 +305,29 @@ def test_cookie_target_lists_and_searches_without_spotipy(monkeypatch):
     assert target.list_playlists()["mix"]["id"] == "p1"  # editable copy wins
     assert target.browse_playlists()[1]["_owned"] is False
     assert target._query("Song Artist")[0]["id"] == "hit"
+
+
+def test_sync_fails_closed_on_a_partial_spotify_directory(monkeypatch):
+    # A partial read must not read as "doesn't exist yet" and trigger a create.
+    monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "cookie")
+    monkeypatch.setattr(st.spotify_cookie, "library_directory", lambda: (
+        [{"id": "p1", "name": "Mix", "_owned": True}], True,
+    ))
+
+    target = SpotifyTarget(None, "cache.json", sync_peer=True)
+    with pytest.raises(TargetAuthError, match="incomplete"):
+        target.list_playlists()
+
+
+def test_browse_stays_tolerant_of_the_same_partial_directory(monkeypatch):
+    # browse_playlists() reads the tolerant library_playlists(), never raises.
+    monkeypatch.setattr(st.spotify_cookie, "library_playlists", lambda: [
+        {"id": "p1", "name": "Mix", "_owned": True},
+        {"id": "p2", "name": "Untitled playlist (p2)", "_owned": False},
+    ])
+
+    target = SpotifyTarget(None, "cache.json")
+    assert [p["id"] for p in target.browse_playlists()] == ["p1", "p2"]
 
 
 def test_reset_session_discards_every_cookie_derived_client():


### PR DESCRIPTION
If a library row can't be resolved to a playlist id, it now gets skipped instead of failing the whole load.

Turns out Spotify's library API can also return a null name for a playlist that's perfectly valid and still has a resolvable uri, seemingly at random, not just for playlists you actually lost access to. So the check no longer treats a missing name as fatal on its own — only a row with no usable playlist id gets dropped. Anything with a real id still shows up; a later playlist detail fetch can fill in the name properly.

Closes #23