### PR TITLE
fix(deezer): normalize pasted track links

### DIFF
--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -73,6 +73,11 @@ class MirrorTarget:
         """Stable id of an existing target track (for diffing / linking)."""
         raise NotImplementedError
 
+    @classmethod
+    def normalize_manual_track_id(cls, value):
+        """Provider catalog id represented by a manually pasted id or link."""
+        return "" if value is None else str(value).strip()
+
     def occurrence_id(self, track):
         """Provider id for one physical playlist entry, when available."""
         for key in ("relationship_id", "playlistItemId", "setVideoId"):

--- a/songmirror/engine/targets/deezer.py
+++ b/songmirror/engine/targets/deezer.py
@@ -2,8 +2,9 @@
 
 import os
 import random
+import re
 import time
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, unquote, urlsplit
 
 import requests
 
@@ -21,6 +22,16 @@ from .provider_utils import best_candidate, source_playlist_details
 
 API = "https://api.deezer.com"
 DEFAULT_TOKEN_FILE = "data/deezer_oauth.json"
+_TRACK_PATH_RE = re.compile(r"(?:^|/)track/(\d+)(?=$|[/?#])", re.IGNORECASE)
+_SHARE_LINK_HOSTS = {"link.deezer.com"}
+
+
+def _track_id_from_reference(value):
+    decoded = unquote(str(value).strip())
+    if re.fullmatch(r"\d+", decoded):
+        return decoded
+    match = _TRACK_PATH_RE.search(decoded)
+    return match.group(1) if match else None
 
 
 def _normalized_track(track):
@@ -275,6 +286,42 @@ class DeezerTarget(MirrorTarget):
     def track_id(self, track):
         return str(track.get("id")) if track.get("id") is not None else None
 
+    @classmethod
+    def normalize_manual_track_id(cls, value):
+        """Extract Deezer's numeric catalog id from a pasted id or track URL."""
+        raw = super().normalize_manual_track_id(value)
+        track_id = _track_id_from_reference(raw)
+        if track_id:
+            return track_id
+
+        try:
+            parts = urlsplit(raw)
+        except ValueError:
+            parts = None
+        is_share_link = (
+            parts
+            and parts.scheme == "https"
+            and (parts.hostname or "").lower() in _SHARE_LINK_HOSTS
+        )
+        if is_share_link:
+            try:
+                response = requests.head(
+                    raw,
+                    allow_redirects=False,
+                    timeout=REQUEST_TIMEOUT,
+                )
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                raise ValueError(
+                    "Could not resolve that Deezer share link; paste its full track URL or numeric ID."
+                ) from exc
+            track_id = _track_id_from_reference(response.headers.get("Location", ""))
+            if track_id:
+                return track_id
+            raise ValueError("That Deezer share link does not point to a track.")
+
+        raise ValueError("Paste a numeric Deezer track ID or a Deezer track URL.")
+
     def playlist_count(self, playlist):
         return playlist.get("nb_tracks", playlist.get("estimatedTracksCount"))
 
@@ -325,7 +372,14 @@ class DeezerTarget(MirrorTarget):
             return best_candidate(track, candidates) or str(candidates[0]["id"]), "isrc"
         key = track_key(track.get("name", ""), " ".join(track.get("artists") or []))
         if key in cache["search"]:
-            return cache["search"][key], "search"
+            cached = cache["search"][key]
+            if cached is None:
+                return None, "search"
+            normalized = self.normalize_manual_track_id(cached)
+            if normalized != cached:
+                cache["search"][key] = normalized
+                cache["dirty"] = True
+            return normalized, "search"
         primary = (track.get("artists") or [""])[0]
         queries = [f"{track.get('name', '')} {primary}".strip()]
         roman = f"{romanized(track.get('name'))} {romanized(primary)}".strip()
@@ -346,13 +400,20 @@ class DeezerTarget(MirrorTarget):
         if self._web is not None:
             try:
                 for target_id in target_ids:
-                    self._web.add(str(playlist["id"]), [str(target_id)])
+                    self._web.add(
+                        str(playlist["id"]),
+                        [self.normalize_manual_track_id(target_id)],
+                    )
                     polite_sleep(0.25)
                 return
             except DeezerWebAuthError as exc:
                 raise TargetAuthError(str(exc)) from exc
         for target_id in target_ids:
-            self._request("POST", f"playlist/{playlist['id']}/tracks", params={"songs": str(target_id)})
+            self._request(
+                "POST",
+                f"playlist/{playlist['id']}/tracks",
+                params={"songs": self.normalize_manual_track_id(target_id)},
+            )
             polite_sleep(0.25)
 
     def remove(self, playlist, track):

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -16,7 +16,7 @@ from ..engine.logs import log_add, log_miss, log_warn
 from ..engine.matching import spotify_track_keys, track_key, tracks_oldest_first
 from ..engine.runner import load_cache, save_cache
 from ..engine.targets import build_one, is_peer
-from ..engine.targets.base import TargetAuthError, _normalize, _split_add_results
+from ..engine.targets.base import MirrorTarget, TargetAuthError, _normalize, _split_add_results
 
 
 def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_progress=None, should_continue=None):
@@ -219,6 +219,9 @@ class TransferService:
         job = self._jobs.get(job_id)
         if not job:
             return False
+        normalizer = job.get("_dest_id_normalizer")
+        if normalizer:
+            dest_id = normalizer(dest_id)
         cache_file = job.get("_dest_cache_file")
         if cache_file:
             cache = load_cache(cache_file)
@@ -250,6 +253,11 @@ class TransferService:
             self._emit("warn", f"transfer: {job['error']}", "transfer")
             return
         job["_dest_cache_file"] = dst.cache_file
+        job["_dest_id_normalizer"] = getattr(
+            dst,
+            "normalize_manual_track_id",
+            MirrorTarget.normalize_manual_track_id,
+        )
         # Adds already on the destination from an earlier (paused) run — this
         # run's transfer() skips them via dedup, so keep the counter cumulative.
         base_added = job["added"]

--- a/songmirror/web/routers/transfers.py
+++ b/songmirror/web/routers/transfers.py
@@ -1,6 +1,6 @@
 """One-off playlist transfers + conflict resolution."""
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
@@ -38,7 +38,11 @@ def transfer_status(job_id: str, request: Request):
 def resolve_conflict(job_id: str, request: Request, body: dict = Body(...)):
     # Declared before the generic /{action} route below so it isn't shadowed
     # (FastAPI matches routes in declaration order).
-    return {"ok": request.app.state.transfers.resolve(job_id, body["key"], body["dest_id"])}
+    try:
+        resolved = request.app.state.transfers.resolve(job_id, body["key"], body["dest_id"])
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {"ok": resolved}
 
 
 @router.post("/api/transfers/{job_id}/{action}")

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -1170,13 +1170,81 @@ def test_deezer_web_adds_tracks_one_at_a_time_in_order(monkeypatch):
     })()
     monkeypatch.setattr(deezer, "polite_sleep", lambda _: None)
 
-    target.add({"id": "playlist-1"}, ["12", "34", "56"])
+    target.add(
+        {"id": "playlist-1"},
+        ["12", "https://www.deezer.com/tr/track/34", "56"],
+    )
 
     assert calls == [
         ("playlist-1", ["12"]),
         ("playlist-1", ["34"]),
         ("playlist-1", ["56"]),
     ]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("4160591112", "4160591112"),
+        ("https://www.deezer.com/tr/track/4160591112", "4160591112"),
+        ("https://www.deezer.com/track/4160591112?utm_source=deezer", "4160591112"),
+    ],
+)
+def test_deezer_normalizes_manually_pasted_track_ids(value, expected):
+    from songmirror.engine.targets.deezer import DeezerTarget
+
+    assert DeezerTarget.normalize_manual_track_id(value) == expected
+
+
+def test_deezer_resolves_opaque_share_link_before_normalizing(monkeypatch):
+    from songmirror.engine.config import REQUEST_TIMEOUT
+    from songmirror.engine.targets import deezer
+    from songmirror.engine.targets.deezer import DeezerTarget
+
+    share_url = "https://link.deezer.com/s/329PNcTc3WAXFmFAcVm1m"
+    calls = []
+
+    class Response:
+        headers = {
+            "Location": (
+                "https://link.deezer.com/?dest=https%3A%2F%2Fwww.deezer.com%2Ftrack%2F"
+                "3347649401%3Futm_source%3Duser_sharing"
+            )
+        }
+
+        @staticmethod
+        def raise_for_status():
+            pass
+
+    def head(url, **kwargs):
+        calls.append((url, kwargs))
+        return Response()
+
+    monkeypatch.setattr(deezer.requests, "head", head)
+
+    assert DeezerTarget.normalize_manual_track_id(share_url) == "3347649401"
+    assert calls == [
+        (share_url, {"allow_redirects": False, "timeout": REQUEST_TIMEOUT}),
+    ]
+
+
+def test_deezer_normalizes_legacy_manual_url_from_resolve_cache():
+    from songmirror.engine.targets.deezer import DeezerTarget
+    from songmirror.engine.matching import track_key
+
+    key = track_key("Song", "Artist")
+    cache = {
+        "isrc": {},
+        "search": {key: "https://www.deezer.com/tr/track/4160591112"},
+    }
+
+    target = DeezerTarget.__new__(DeezerTarget)
+    assert target.resolve({"name": "Song", "artists": ["Artist"]}, cache) == (
+        "4160591112",
+        "search",
+    )
+    assert cache["search"][key] == "4160591112"
+    assert cache["dirty"] is True
 
 
 def test_new_provider_create_helpers_accept_non_spotify_shapes():

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -460,3 +460,31 @@ def test_transfer_service_resolve_writes_cache(monkeypatch, tmp_path):
     asyncio.run(scenario())
     assert "chosen-id" in out["cache"]["search"].values()  # accepted match cached for next run
     assert out["job"]["conflicts"][0]["resolved"] is True
+
+
+def test_transfer_service_normalizes_manual_id_before_writing_cache(monkeypatch, tmp_path):
+    from songmirror.engine.targets.deezer import DeezerTarget
+    from songmirror.engine.runner import load_cache
+
+    out = {}
+
+    async def scenario():
+        _, dst = _service(monkeypatch, tmp_path)
+        dst.normalize_manual_track_id = DeezerTarget.normalize_manual_track_id
+        bus = EventBus()
+        bus.bind_loop(asyncio.get_running_loop())
+        sync = SyncService(SettingsStore(dir=tmp_path), bus)
+        svc = TransferService(SettingsStore(dir=tmp_path), bus, sync)
+        job = svc.submit({"source_provider": "apple", "source_playlist_id": "p1",
+                          "dest_provider": "deezer", "dest_playlist_id": "p1"})
+        j = await _await_job(svc, job["id"])
+        svc.resolve(
+            job["id"],
+            j["conflicts"][0]["key"],
+            "https://www.deezer.com/tr/track/4160591112",
+        )
+        out["cache"] = load_cache(dst.cache_file)
+
+    asyncio.run(scenario())
+
+    assert "4160591112" in out["cache"]["search"].values()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -18,6 +18,25 @@ def test_health(tmp_path):
         assert client.get("/health").json() == {"ok": True}
 
 
+def test_transfer_conflict_resolution_returns_manual_id_validation_error(tmp_path):
+    app = _app(tmp_path)
+
+    def reject_manual_id(*_args):
+        raise ValueError("Paste a numeric Deezer track ID or a Deezer track URL.")
+
+    app.state.transfers.resolve = reject_manual_id
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/transfers/job-1/resolve",
+            json={"key": "song artist", "dest_id": "not-a-track"},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": "Paste a numeric Deezer track ID or a Deezer track URL.",
+    }
+
+
 def test_playlist_export_routes_return_downloads(tmp_path, monkeypatch):
     from songmirror.services.playlist_exports import PlaylistExport
     from songmirror.services.playlists import PlaylistService


### PR DESCRIPTION
## Summary

- normalize raw IDs and regional Deezer track URLs before saving manual conflict resolutions
- resolve allowlisted `link.deezer.com` share redirects to their numeric catalog track IDs
- repair legacy URL-valued cache entries and validate IDs before Deezer playlist mutations

## Test plan

- [x] `.venv/Scripts/python.exe -m pytest -q` (345 passed, 1 skipped)
- [x] verify a live opaque Deezer share link resolves to the redirected track ID
- [x] run `git diff --check`

Closes #26