### PR TITLE
feat(ui): expand sidebar links

### DIFF
--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -1166,12 +1166,31 @@ async function main() {
       console.log(`${faviconOk ? 'ok        ' : 'FAIL      '} favicon mark is proportional and fills the tile (ratio=${faviconGeometry.markRatio.toFixed(3)} coverage=${faviconGeometry.coverage.toFixed(3)})`)
       if (!faviconOk) results.push({ label: 'favicon mark geometry', overflow: true })
 
+      const projectLinks = [
+        ['SongMirror on GitHub', 'https://github.com/ahnafnafee/songmirror'],
+        ['Sponsor on GitHub', 'https://github.com/sponsors/ahnafnafee'],
+        ['Support on Ko-fi', 'https://ko-fi.com/ahnafnafee'],
+      ]
+
+      async function checkProjectLinks(scope, state) {
+        const group = scope.getByRole('group', { name: 'Project links', exact: true })
+        let linksOk = await group.isVisible() && await group.getByRole('link').count() === projectLinks.length
+        for (const [label, expectedHref] of projectLinks) {
+          const link = group.getByRole('link', { name: label, exact: true })
+          linksOk = linksOk && await link.isVisible() && await link.getAttribute('href') === expectedHref
+        }
+        console.log(`${linksOk ? 'ok        ' : 'FAIL      '} ${state} exposes all project and support links`)
+        if (!linksOk) results.push({ label: `${state} project links`, overflow: true })
+      }
+
+      await checkProjectLinks(page.locator('aside'), 'expanded sidebar')
       await checkOverflow(page, 'Sidebar expanded (default) @ 1280', results)
       await shot(page, 'sidebar-expanded-1280')
 
       // Collapse — rail shrinks to icon-only, tooltip labels via title attr.
       await page.getByRole('button', { name: 'Collapse sidebar', exact: true }).click()
       await page.waitForTimeout(250) // width transition
+      await checkProjectLinks(page.locator('aside'), 'collapsed sidebar')
       await checkOverflow(page, 'Sidebar collapsed @ 1280', results)
       await shot(page, 'sidebar-collapsed-1280')
       const storedAfterCollapse = await page.evaluate(() => window.localStorage.getItem('songmirror-sidebar-collapsed'))
@@ -1197,6 +1216,7 @@ async function main() {
       await page.waitForSelector('text=Next check')
       await page.getByRole('button', { name: 'Open menu', exact: true }).click()
       await page.waitForSelector('#mobile-nav')
+      await checkProjectLinks(page.locator('#mobile-nav'), 'mobile drawer')
       await checkOverflow(page, 'Mobile drawer open @ 375', results)
       await shot(page, 'sidebar-mobile-drawer-375')
 

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -1172,18 +1172,31 @@ async function main() {
         ['Support on Ko-fi', 'https://ko-fi.com/ahnafnafee'],
       ]
 
-      async function checkProjectLinks(scope, state) {
+      async function checkProjectLinks(scope, state, { centered = false } = {}) {
         const group = scope.getByRole('group', { name: 'Project links', exact: true })
         let linksOk = await group.isVisible() && await group.getByRole('link').count() === projectLinks.length
+        const linkBoxes = []
         for (const [label, expectedHref] of projectLinks) {
           const link = group.getByRole('link', { name: label, exact: true })
           linksOk = linksOk && await link.isVisible() && await link.getAttribute('href') === expectedHref
+          linkBoxes.push(await link.boundingBox())
         }
         console.log(`${linksOk ? 'ok        ' : 'FAIL      '} ${state} exposes all project and support links`)
         if (!linksOk) results.push({ label: `${state} project links`, overflow: true })
+
+        if (centered) {
+          const scopeBox = await scope.boundingBox()
+          const firstBox = linkBoxes[0]
+          const lastBox = linkBoxes.at(-1)
+          const dockCenter = firstBox && lastBox ? (firstBox.x + lastBox.x + lastBox.width) / 2 : NaN
+          const scopeCenter = scopeBox ? scopeBox.x + scopeBox.width / 2 : NaN
+          const centeredOk = Number.isFinite(dockCenter) && Math.abs(dockCenter - scopeCenter) <= 1
+          console.log(`${centeredOk ? 'ok        ' : 'FAIL      '} ${state} centers the project-link dock`)
+          if (!centeredOk) results.push({ label: `${state} project links centered`, overflow: true })
+        }
       }
 
-      await checkProjectLinks(page.locator('aside'), 'expanded sidebar')
+      await checkProjectLinks(page.locator('aside'), 'expanded sidebar', { centered: true })
       await checkOverflow(page, 'Sidebar expanded (default) @ 1280', results)
       await shot(page, 'sidebar-expanded-1280')
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   LuSettings2,
   LuX,
 } from 'react-icons/lu'
+import { SiGithubsponsors, SiKofi } from 'react-icons/si'
 import type { IconType } from 'react-icons'
 
 import songmirrorMark from '@/assets/brand/songmirror-mark.png'
@@ -20,6 +21,8 @@ import { useSidebarCollapsed } from '@/hooks/useSidebarCollapsed'
 import { cn } from '@/lib/cn'
 
 const REPO_URL = 'https://github.com/ahnafnafee/songmirror'
+const GITHUB_SPONSORS_URL = 'https://github.com/sponsors/ahnafnafee'
+const KOFI_URL = 'https://ko-fi.com/ahnafnafee'
 
 const NAV_ITEMS: Array<{ to: string; label: string; end: boolean; icon: IconType }> = [
   { to: '/', label: 'Dashboard', end: true, icon: LuLayoutDashboard },
@@ -28,6 +31,12 @@ const NAV_ITEMS: Array<{ to: string; label: string; end: boolean; icon: IconType
   { to: '/sync', label: 'Sync', end: false, icon: LuRefreshCw },
   { to: '/transfers', label: 'Transfers', end: false, icon: LuArrowLeftRight },
   { to: '/settings', label: 'Settings', end: false, icon: LuSettings2 },
+]
+
+const PROJECT_LINKS: Array<{ href: string; label: string; icon: IconType }> = [
+  { href: REPO_URL, label: 'SongMirror on GitHub', icon: LuGithub },
+  { href: GITHUB_SPONSORS_URL, label: 'Sponsor on GitHub', icon: SiGithubsponsors },
+  { href: KOFI_URL, label: 'Support on Ko-fi', icon: SiKofi },
 ]
 
 /** 240px persistent rail from `lg` (1024px) up — collapsible to a 68px
@@ -143,7 +152,7 @@ export function Sidebar() {
 
         {/* The nav above takes flex-1, so this sits on the rail's bottom edge. */}
         <div className="shrink-0 border-t border-border p-3">
-          <RepoLink />
+          <ProjectLinks stacked={collapsed} />
         </div>
         </div>
       </aside>
@@ -195,7 +204,7 @@ export function Sidebar() {
             </NavLink>
           ))}
           <div className="mt-2 border-t border-border pt-3">
-            <RepoLink />
+            <ProjectLinks />
           </div>
         </nav>
       )}
@@ -203,21 +212,28 @@ export function Sidebar() {
   )
 }
 
-/** Source link, centered on the sidebar's bottom edge. Icon-only in both rail
- * widths, so collapsing the rail doesn't change it. */
-function RepoLink() {
+/** Project and support links share a quiet footer dock. The collapsed rail
+ * stacks them so each action keeps a full-size keyboard and pointer target. */
+function ProjectLinks({ stacked = false }: { stacked?: boolean }) {
   return (
-    <div className="flex items-center justify-center">
-      <a
-        href={REPO_URL}
-        target="_blank"
-        rel="noreferrer"
-        title="SongMirror on GitHub"
-        aria-label="SongMirror on GitHub"
-        className="flex size-9 items-center justify-center rounded-control text-text-3 transition-colors duration-fast hover:bg-surface-2 hover:text-text"
-      >
-        <LuGithub className="size-[18px]" aria-hidden="true" />
-      </a>
+    <div
+      role="group"
+      aria-label="Project links"
+      className={cn('flex items-center gap-1', stacked && 'flex-col')}
+    >
+      {PROJECT_LINKS.map((item) => (
+        <a
+          key={item.href}
+          href={item.href}
+          target="_blank"
+          rel="noreferrer"
+          title={item.label}
+          aria-label={item.label}
+          className="flex size-9 items-center justify-center rounded-control text-text-3 transition-colors duration-fast hover:bg-accent-soft hover:text-accent"
+        >
+          <item.icon className="size-[18px]" aria-hidden="true" />
+        </a>
+      ))}
     </div>
   )
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -219,7 +219,7 @@ function ProjectLinks({ stacked = false }: { stacked?: boolean }) {
     <div
       role="group"
       aria-label="Project links"
-      className={cn('flex items-center gap-1', stacked && 'flex-col')}
+      className={cn('flex items-center justify-center gap-1', stacked && 'flex-col')}
     >
       {PROJECT_LINKS.map((item) => (
         <a


### PR DESCRIPTION
Extends the sidebar footer with a compact project-links dock for the repository, GitHub Sponsors, and Ko-fi. The controls remain horizontal in expanded desktop and mobile layouts, and stack in the collapsed rail to preserve full-size interaction targets. State-specific browser checks cover each responsive presentation. Verification: pnpm -C frontend lint; pnpm -C frontend build; pnpm -C frontend test:e2e (119 checks, 0 horizontal overflow failures).