### PR TITLE
fix(sync): preserve partial provider outcomes

### DIFF
--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -1237,6 +1237,71 @@ async function main() {
     }
 
     // -----------------------------------------------------------------
+    // A destination auth failure is a partial one-way outcome, not a lost
+    // pass. The dashboard names the skipped service from per_target even if
+    // the separately refreshed account snapshot has not expired it yet.
+    // -----------------------------------------------------------------
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'light'))
+      const page = await context.newPage()
+      await installMocks(page)
+      await page.route('**/api/accounts', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ACCOUNTS.map((account) => ({ ...account, state: 'connected', detail: null }))),
+        })
+      })
+      await page.route('**/api/sync/status', async (route) => {
+        const partial = syncStatusFixture(initialSyncs())
+        partial.last.per_target = [
+          { name: 'Apple Music', added: 2, removed: 0, missing: 0, held: 0, deferred: 0, created: 0, skipped: 0 },
+          {
+            name: 'Amazon Music', added: 0, removed: 0, missing: 0, held: 0, deferred: 0, created: 0, skipped: 0,
+            auth_error: true,
+            error: 'Amazon Music /pandaToken did not return an access token; reconnect after signing in.',
+          },
+        ]
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(partial) })
+      })
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/', { waitUntil: 'networkidle' })
+      await page.waitForTimeout(200)
+
+      const text = await page.locator('body').innerText()
+      const targetAuthReported = text.includes('Amazon Music was skipped')
+        && text.includes('/pandaToken did not return an access token')
+        && text.includes('Other destinations and post-sync work continued.')
+        && !text.includes('The last pass failed')
+      console.log(`${targetAuthReported ? 'ok        ' : 'FAIL      '} one-way target auth failure is reported as an isolated partial outcome`)
+      if (!targetAuthReported) results.push({ label: 'one-way target auth failure reporting', overflow: true })
+      await checkOverflow(page, 'Dashboard with isolated target auth failure @ 1280', results)
+
+      await page.route('**/api/accounts', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ACCOUNTS.map((account) => (
+            account.id === 'amazon'
+              ? { ...account, state: 'expired', detail: 'Amazon Music session expired.' }
+              : { ...account, state: 'connected', detail: null }
+          ))),
+        })
+      })
+      await page.reload({ waitUntil: 'networkidle' })
+      await page.waitForTimeout(200)
+      const dedupText = await page.locator('body').innerText()
+      const amazonAlerts = await page.getByRole('button', { name: /Dismiss: Amazon Music/ }).count()
+      const targetAuthDeduped = amazonAlerts === 1
+        && dedupText.includes('Amazon Music sign-in expired')
+        && !dedupText.includes('Amazon Music was skipped')
+      console.log(`${targetAuthDeduped ? 'ok        ' : 'FAIL      '} account status deduplicates the matching per-target auth alert`)
+      if (!targetAuthDeduped) results.push({ label: 'one-way target auth alert deduplication', overflow: true })
+      await context.close()
+    }
+
+    // -----------------------------------------------------------------
     // "Needs a look" alerts are dismissable: one X per card, the count chip
     // follows, dismissals survive a reload, and a dismissal is FORGOTTEN once
     // that exact situation changes (a different held-count is a new problem,

--- a/frontend/src/components/dashboard/NeedsALook.tsx
+++ b/frontend/src/components/dashboard/NeedsALook.tsx
@@ -55,10 +55,13 @@ function diagnosticCount(rows: ChangeDiagnostic[]): number {
 }
 
 /** Every item here traces back to a real field — account state/detail, or the
- * last pass's own ok flag and per-target held/deferred/removals-skipped counts.
+ * last pass's own ok flag and per-target errors/held/deferred/removals-skipped counts.
  * Nothing is invented (no fabricated "last synced" claims). */
 function buildItems(accounts: Account[] | null, status: SyncStatus | null): NeedsLookItem[] {
   const items: NeedsLookItem[] = []
+  const accountProblems = new Set(
+    (accounts ?? []).filter((account) => account.state !== 'connected').map((account) => account.name),
+  )
 
   for (const a of accounts ?? []) {
     if (a.state === 'expired') {
@@ -94,6 +97,21 @@ function buildItems(accounts: Account[] | null, status: SyncStatus | null): Need
       icon: LuCircleAlert,
       title: 'The last pass failed',
       description: status.last.error || "It didn't complete successfully. The services it reached are unaffected.",
+    })
+  }
+
+  // Account status normally reports the same expired session. Keep the
+  // per-target result as a fallback for the interval before that independent
+  // snapshot refreshes, without rendering two cards for one provider.
+  for (const target of status?.last?.per_target ?? []) {
+    if (!target.auth_error || !target.error || accountProblems.has(target.name)) continue
+    items.push({
+      key: `target-auth-${target.name}`,
+      icon: LuTriangleAlert,
+      title: `${target.name} was skipped`,
+      description: target.error,
+      details: ['Other destinations and post-sync work continued.'],
+      action: { label: 'Reconnect', to: '/accounts' },
     })
   }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,6 +72,10 @@ export type Settings = Record<string, string>
 
 export interface TargetSummary {
   name: string
+  /** A one-way destination whose credentials failed is reported here without
+   * discarding successful sibling destinations or failing the whole pass. */
+  auth_error?: boolean
+  error?: string | null
   added: number
   removed: number
   missing: number

--- a/songmirror/amazon_music_web.py
+++ b/songmirror/amazon_music_web.py
@@ -370,7 +370,7 @@ class AmazonMusicWebClient:
         except (ValueError, TypeError, json.JSONDecodeError):
             return {}
 
-    def _renew(self) -> None:
+    def _renew(self, *, persist: bool = True, require_panda_token: bool = False) -> None:
         if not self.renewal_cookies:
             raise AmazonMusicWebAuthError(
                 "Amazon Music access token expired; reconnect once with a signed-in config.json or "
@@ -419,7 +419,15 @@ class AmazonMusicWebClient:
         token = self._response_json(token_response, "token renewal")
         self._merge_response_cookies(token_response)
 
-        access_token = str(token.get("accessToken") or config.get("accessToken") or "").strip()
+        panda_access_token = str(
+            token.get("accessToken") or token.get("access_token") or ""
+        ).strip()
+        config_access_token = str(config.get("accessToken") or "").strip()
+        access_token = (
+            panda_access_token
+            if require_panda_token
+            else panda_access_token or config_access_token
+        )
         current = self._authorization_context(self.headers)
         device_id = str(
             config.get("deviceId") or self.headers.get("device-id") or current.get("deviceId") or ""
@@ -444,7 +452,8 @@ class AmazonMusicWebClient:
         self.headers = parse_web_headers(json.dumps(refreshed_config))
         expires_in = self._number(token.get("expiresIn") or token.get("expires_in"))
         self._expires_at = time.time() + expires_in if expires_in > 0 else 0
-        self._persist_session()
+        if persist:
+            self._persist_session()
 
     def _ensure_access(self) -> bool:
         if not self.headers or (self._expires_at and self._expires_at <= time.time() + 90):
@@ -479,11 +488,20 @@ class AmazonMusicWebClient:
             )
         )
 
-    def execute(self, operation_name: str, query: str, variables=None, *, mutation=False):
+    def execute(
+        self,
+        operation_name: str,
+        query: str,
+        variables=None,
+        *,
+        mutation=False,
+        allow_renewal=True,
+    ):
         """Execute one operation and refresh/retry once on auth rejection."""
 
-        attempts = (2 if self.renewal_cookies else 1) if mutation else 5
-        refreshed = self._ensure_access()
+        can_renew = allow_renewal and bool(self.renewal_cookies)
+        attempts = (2 if can_renew else 1) if mutation else 5
+        refreshed = self._ensure_access() if allow_renewal else False
         for attempt in range(attempts):
             headers = {
                 **self.headers,
@@ -510,7 +528,7 @@ class AmazonMusicWebClient:
                 raise
 
             if response.status_code in (401, 403):
-                if self.renewal_cookies and not refreshed:
+                if can_renew and not refreshed:
                     self._renew()
                     refreshed = True
                     continue
@@ -537,7 +555,7 @@ class AmazonMusicWebClient:
                     str((error.get("extensions") or {}).get("code", "")) for error in errors
                 )
                 if self._auth_error(f"{messages} {codes}"):
-                    if self.renewal_cookies and not refreshed:
+                    if can_renew and not refreshed:
                         self._renew()
                         refreshed = True
                         continue
@@ -549,9 +567,25 @@ class AmazonMusicWebClient:
             return body.get("data") or {}
         raise RuntimeError("Amazon Music web request retry budget exhausted")
 
-    def validate(self) -> None:
-        data = self.execute("SongMirrorAmazonSession", SESSION_QUERY)
+    def validate(self, *, require_renewal: bool = False) -> None:
+        if require_renewal:
+            # A fresh config.json response proves only that its one-hour
+            # bootstrap token works. Exercise the cookie-authenticated renewal
+            # route before accepting a newly pasted session so "connected"
+            # also means SongMirror can survive that bootstrap expiring.
+            # Keep the candidate session off disk until both the panda-token
+            # response and the signed-in GraphQL identity have been proven.
+            # Disabling execute's normal retry also prevents a hidden second
+            # renewal from persisting before that identity check completes.
+            self._renew(persist=False, require_panda_token=True)
+        data = self.execute(
+            "SongMirrorAmazonSession",
+            SESSION_QUERY,
+            allow_renewal=not require_renewal,
+        )
         if not (data.get("user") or {}).get("id"):
             raise AmazonMusicWebAuthError(
                 "Amazon Music did not recognize a signed-in user; reconnect from a signed-in web player."
             )
+        if require_renewal:
+            self._persist_session()

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -19,6 +19,10 @@ from .targets import TargetAuthError, build_one, build_peers, build_targets, mir
 from .targets.base import _normalize, reconcile_state_key
 
 
+class _SourceAuthError(TargetAuthError):
+    """Auth failure raised while reading the one-way source, not a destination."""
+
+
 def _load_json(path):
     try:
         with open(path) as f:
@@ -91,6 +95,10 @@ def _summary_entry(name, agg):
     entry["held_removals"] = agg.get("held_removals", [])
     entry["change_diagnostics"] = agg.get("change_diagnostics", [])
     entry["failures"] = agg.get("failures", [])
+    if "error" in agg:
+        entry["error"] = agg["error"]
+    if "auth_error" in agg:
+        entry["auth_error"] = bool(agg["auth_error"])
     return entry
 
 
@@ -163,6 +171,8 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                         )
                     agg["created"] += 1
                     log_note(f"created {target.name} playlist '{name}' (name + description copied)", tag=target.tag)
+                except TargetAuthError:
+                    raise
                 except Exception as e:
                     _collect_failure(agg, agg["failures"], name, e)
                     log_warn(f"create '{name}' failed: {e!r}", tag=target.tag)
@@ -182,8 +192,16 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                 continue
 
             try:
+                source_tracks = get_source_tracks(sp_playlist)
+            except TargetAuthError as exc:
+                # The same TargetAuthError type is used by every provider.
+                # Preserve the origin so a shared source expiry cannot be
+                # mislabeled as an independent destination failure.
+                raise _SourceAuthError(str(exc)) from exc
+
+            try:
                 res = mirror_pair(
-                    target, get_source_tracks(sp_playlist), sp_playlist, tgt, cache, songs,
+                    target, source_tracks, sp_playlist, tgt, cache, songs,
                     execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
                     drain_removals=opts.apply_large_removals, should_continue=should_continue,
                     source_key=src_key, source_name=source.name, name=name,
@@ -340,7 +358,20 @@ def run_pass(opts, should_continue=None):
     def worker(target, songs):
         try:
             results[target.tag] = run_target(target, selected, get_source_tracks, songs, opts, links, source, ctrl)
-        except BaseException as e:  # surface after siblings finish
+        except _SourceAuthError as e:
+            # A one-way source is shared by every destination. Its failure
+            # invalidates the pass and must also suppress post-sync work.
+            errors.append((target, e))
+        except TargetAuthError as e:
+            # One-way targets are independent. Preserve a provider-scoped
+            # failure in the summary instead of discarding successful siblings
+            # and the optional post-sync stage after every worker has finished.
+            results[target.tag] = {
+                "name": target.name,
+                "error": str(e) or repr(e),
+                "auth_error": True,
+            }
+        except BaseException as e:  # unexpected failures remain fatal after siblings finish
             errors.append((target, e))
 
     started = time.monotonic()
@@ -380,6 +411,9 @@ def run_pass(opts, should_continue=None):
         agg = results.get(target.tag)
         if not agg:
             continue
+        if agg.get("auth_error"):
+            log_warn(f"{target.name} skipped: {agg['error']}", tag=target.tag)
+            continue
         notes = []
         if agg["created"]:
             notes.append(f"{agg['created']} created")
@@ -389,14 +423,18 @@ def run_pass(opts, should_continue=None):
         log_summary(f"{target.name:<14} {fmt_counts(agg['added'], agg['removed'], agg['missing'], agg['held'])}"
                     + paint(tail, "grey"), indent="  ")
 
-    for target, err in errors:
-        if isinstance(err, TargetAuthError):
-            raise err  # fatal; main() decides exit vs. loop-continue
+    if errors:
+        raise errors[0][1]
 
     c = ctrl()
     if c == "run":
         _post_sync(opts, sp, selected, source_is_spotify=src_is_spotify, should_continue=ctrl)
-    return _summary(opts, [_summary_entry(a["name"], a) for a in results.values()], pass_started,
+    per_target = [
+        _summary_entry(results[target.tag]["name"], results[target.tag])
+        for target in targets
+        if target.tag in results
+    ]
+    return _summary(opts, per_target, pass_started,
                     interrupted=(None if c == "run" else c))
 
 

--- a/songmirror/services/accounts/amazon_music.py
+++ b/songmirror/services/accounts/amazon_music.py
@@ -70,7 +70,14 @@ class AmazonMusicConnector(Connector):
         token = read_token(self._official_token_file())
         return bool(token.get("access_token") or token.get("refresh_token"))
 
-    def _validate(self, raw=None, renewal_request=None, *, prefer_persisted=True):
+    def _validate(
+        self,
+        raw=None,
+        renewal_request=None,
+        *,
+        prefer_persisted=True,
+        require_renewal=False,
+    ):
         try:
             client = AmazonMusicWebClient(
                 raw if raw is not None else self._raw_headers(),
@@ -80,7 +87,7 @@ class AmazonMusicConnector(Connector):
                 token_file=self._web_token_file(),
                 prefer_persisted=prefer_persisted,
             )
-            client.validate()
+            client.validate(require_renewal=require_renewal)
             self._validated_client = client
             return True, "auto-renewing web-player session"
         except AmazonMusicWebAuthError as exc:
@@ -126,7 +133,12 @@ class AmazonMusicConnector(Connector):
         except ValueError as exc:
             return ConnStatus("error", str(exc))
 
-        ok, detail = self._validate(minimized, renewal, prefer_persisted=False)
+        ok, detail = self._validate(
+            minimized,
+            renewal,
+            prefer_persisted=False,
+            require_renewal=True,
+        )
         if not ok:
             return ConnStatus("error", detail)
         client = getattr(self, "_validated_client", None)

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -1051,6 +1051,157 @@ def test_amazon_web_client_renews_rejected_token_and_retries_mutation_once(tmp_p
     assert persisted["expires_at"] > 0
 
 
+def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(tmp_path, monkeypatch):
+    import songmirror.amazon_music_web as amazon_web
+    from songmirror.services.accounts.amazon_music import AmazonMusicConnector
+
+    class Cookies:
+        @staticmethod
+        def get_dict():
+            return {}
+
+    class Response:
+        headers = {}
+        cookies = Cookies()
+
+        def __init__(self, status_code, body):
+            self.status_code = status_code
+            self._body = body
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise AssertionError(f"unexpected HTTP {self.status_code}")
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append(("GET", url))
+            if url == amazon_web.CONFIG_ENDPOINT:
+                return Response(
+                    200,
+                    {
+                        "accessToken": "config-bootstrap",
+                        "deviceId": "device-7",
+                        "deviceType": "A16ZV8BU3SN1N3",
+                    },
+                )
+            assert url == amazon_web.PANDA_TOKEN_ENDPOINT
+            return Response(200, {"accessToken": "", "expiresIn": 0})
+
+        def post(self, url, **kwargs):
+            self.calls.append(("POST", url))
+            assert url == amazon_web.ENDPOINT
+            return Response(200, {"data": {"user": {"id": "customer-1"}}})
+
+    session = Session()
+    monkeypatch.setattr(amazon_web.requests, "Session", lambda: session)
+    monkeypatch.setenv("AMAZON_MUSIC_WEB_HEADERS", "")
+    monkeypatch.setenv("AMAZON_MUSIC_RENEWAL_REQUEST", "")
+    monkeypatch.setenv("AMAZON_MUSIC_WEB_SESSION_FILE", str(tmp_path / "amazon-session.json"))
+    connector = AmazonMusicConnector(SettingsStore(dir=tmp_path))
+
+    status = connector.submit(
+        {
+            "AMAZON_MUSIC_WEB_HEADERS": json.dumps(
+                {
+                    "accessToken": "one-hour-bootstrap",
+                    "deviceId": "device-7",
+                    "deviceType": "A16ZV8BU3SN1N3",
+                }
+            ),
+            "AMAZON_MUSIC_RENEWAL_REQUEST": "Cookie: at-main-music=stale-session",
+        }
+    )
+
+    assert status.state == "error"
+    assert "/pandaToken did not return an access token" in status.detail
+    assert session.calls == [
+        ("GET", amazon_web.CONFIG_ENDPOINT),
+        ("GET", amazon_web.PANDA_TOKEN_ENDPOINT),
+    ]
+    assert not connector._store.get("AMAZON_MUSIC_WEB_HEADERS")
+    assert not connector._store.get("AMAZON_MUSIC_RENEWAL_REQUEST")
+    assert not (tmp_path / "amazon-session.json").exists()
+
+
+def test_amazon_connector_persists_renewal_only_after_user_validation(tmp_path, monkeypatch):
+    import songmirror.amazon_music_web as amazon_web
+    from songmirror.services.accounts.amazon_music import AmazonMusicConnector
+
+    class Cookies:
+        @staticmethod
+        def get_dict():
+            return {"at-main-music": "rotated-session"}
+
+    class Response:
+        headers = {}
+        cookies = Cookies()
+
+        def __init__(self, status_code, body):
+            self.status_code = status_code
+            self._body = body
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise AssertionError(f"unexpected HTTP {self.status_code}")
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append(("GET", url))
+            if url == amazon_web.CONFIG_ENDPOINT:
+                return Response(200, {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"})
+            assert url == amazon_web.PANDA_TOKEN_ENDPOINT
+            return Response(200, {"accessToken": "fresh-access", "expiresIn": 3600})
+
+        def post(self, url, **kwargs):
+            self.calls.append(("POST", url))
+            assert url == amazon_web.ENDPOINT
+            return Response(200, {"data": {"user": None}})
+
+    session = Session()
+    token_file = tmp_path / "amazon-session.json"
+    monkeypatch.setattr(amazon_web.requests, "Session", lambda: session)
+    monkeypatch.setenv("AMAZON_MUSIC_WEB_HEADERS", "")
+    monkeypatch.setenv("AMAZON_MUSIC_RENEWAL_REQUEST", "")
+    monkeypatch.setenv("AMAZON_MUSIC_WEB_SESSION_FILE", str(token_file))
+    connector = AmazonMusicConnector(SettingsStore(dir=tmp_path))
+
+    status = connector.submit(
+        {
+            "AMAZON_MUSIC_WEB_HEADERS": json.dumps(
+                {
+                    "accessToken": "one-hour-bootstrap",
+                    "deviceId": "device-7",
+                    "deviceType": "A16ZV8BU3SN1N3",
+                }
+            ),
+            "AMAZON_MUSIC_RENEWAL_REQUEST": "Cookie: at-main-music=candidate-session",
+        }
+    )
+
+    assert status.state == "error"
+    assert "did not recognize a signed-in user" in status.detail
+    assert session.calls == [
+        ("GET", amazon_web.CONFIG_ENDPOINT),
+        ("GET", amazon_web.PANDA_TOKEN_ENDPOINT),
+        ("POST", amazon_web.ENDPOINT),
+    ]
+    assert not connector._store.get("AMAZON_MUSIC_WEB_HEADERS")
+    assert not connector._store.get("AMAZON_MUSIC_RENEWAL_REQUEST")
+    assert not token_file.exists()
+
+
 def test_amazon_connector_accepts_web_session_without_beta_approval(tmp_path, monkeypatch):
     from songmirror.services.accounts.amazon_music import AmazonMusicConnector
 
@@ -1069,11 +1220,13 @@ def test_amazon_connector_accepts_web_session_without_beta_approval(tmp_path, mo
         ("AMAZON_MUSIC_RENEWAL_REQUEST", True),
     ]
 
-    monkeypatch.setattr(
-        connector,
-        "_validate",
-        lambda raw=None, renewal_request=None, **kwargs: (True, "auto-renewing web session"),
-    )
+    validation_kwargs = []
+
+    def accept_session(raw=None, renewal_request=None, **kwargs):
+        validation_kwargs.append(kwargs)
+        return True, "auto-renewing web session"
+
+    monkeypatch.setattr(connector, "_validate", accept_session)
     connected = connector.submit(
         {
             "AMAZON_MUSIC_WEB_HEADERS": (
@@ -1087,6 +1240,7 @@ def test_amazon_connector_accepts_web_session_without_beta_approval(tmp_path, mo
         }
     )
     assert connected.state == "connected"
+    assert validation_kwargs == [{"prefer_persisted": False, "require_renewal": True}]
     stored = json.loads(connector._store.get("AMAZON_MUSIC_WEB_HEADERS"))
     assert set(stored) == {"authorization", "x-api-key"}
     assert json.loads(connector._store.get("AMAZON_MUSIC_RENEWAL_REQUEST")) == {

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -2,6 +2,8 @@
 
 import threading
 
+import pytest
+
 from songmirror.engine import archive
 import songmirror.engine.runner as runner
 from songmirror.engine.config import Options
@@ -173,6 +175,161 @@ def test_oneway_target_workers_have_independent_archive_connections(monkeypatch,
 
     assert len(connection_ids) == len(targets)
     assert all(result["failed"] == 0 for result in summary["per_target"])
+
+
+def test_oneway_isolates_a_target_auth_error_and_keeps_sibling_results(monkeypatch, tmp_path):
+    from songmirror.engine.targets.base import TargetAuthError
+
+    class Source:
+        source, name = "spotify", "Spotify"
+
+        @staticmethod
+        def list_playlists():
+            return {"drive": {"id": "source-drive", "name": "Drive"}}
+
+        @staticmethod
+        def playlist_name(playlist):
+            return playlist["name"]
+
+        @staticmethod
+        def playlist_id(playlist):
+            return playlist["id"]
+
+        @staticmethod
+        def playlist_tracks(_playlist):
+            return [{"id": "source-track", "name": "Track", "artist": "Artist"}]
+
+    class Target:
+        def __init__(self, source, name):
+            self.source = self.tag = source
+            self.name = name
+            self.cache_file = str(tmp_path / f"{source}.json")
+
+        def list_playlists(self):
+            if self.tag == "amazon":
+                return {}
+            return {"drive": {"id": "apple-drive", "name": "Drive"}}
+
+        @staticmethod
+        def playlist_id(playlist):
+            return playlist["id"]
+
+        @staticmethod
+        def playlist_count(_playlist):
+            return 0
+
+        @staticmethod
+        def is_editable(_playlist):
+            return True
+
+        def create(self, _playlist):
+            raise TargetAuthError(
+                "Amazon Music /pandaToken did not return an access token; reconnect after signing in."
+            )
+
+    targets = [Target("apple", "Apple Music"), Target("amazon", "Amazon Music")]
+    post_sync_calls = []
+
+    def fake_mirror_pair(target, *args, **kwargs):
+        assert target.tag == "apple"
+        return {
+            "clean": True,
+            "added": 2,
+            "removed": 0,
+            "missing": 0,
+            "held": 0,
+            "deferred": 0,
+            "removals_skipped": 0,
+            "held_removals": [],
+            "target_count": 2,
+        }
+
+    monkeypatch.setattr(runner.spotify, "client", lambda writable=False: object())
+    monkeypatch.setattr(runner, "build_one", lambda *args, **kwargs: Source())
+    monkeypatch.setattr(runner, "build_targets", lambda *args, **kwargs: targets)
+    monkeypatch.setattr(runner.archive, "connect", lambda path: _FakeSongs())
+    monkeypatch.setattr(runner, "_load_links", lambda: [])
+    monkeypatch.setattr(runner, "mirror_pair", fake_mirror_pair)
+    monkeypatch.setattr(runner, "_post_sync", lambda *args, **kwargs: post_sync_calls.append(True))
+
+    summary = runner.run_pass(
+        _opts(
+            execute=True,
+            sync_source="spotify",
+            providers="spotify,apple,amazon",
+            playlists="Drive",
+        )
+    )
+
+    assert summary["ok"] is True
+    assert summary["error"] is None
+    by_name = {entry["name"]: entry for entry in summary["per_target"]}
+    assert by_name["Apple Music"]["added"] == 2
+    assert by_name["Apple Music"].get("error") is None
+    assert by_name["Amazon Music"]["auth_error"] is True
+    assert by_name["Amazon Music"]["error"] == (
+        "Amazon Music /pandaToken did not return an access token; reconnect after signing in."
+    )
+    assert post_sync_calls == [True]
+
+
+def test_oneway_source_auth_error_remains_fatal(monkeypatch, tmp_path):
+    from songmirror.engine.targets.base import TargetAuthError
+
+    class Source:
+        source, name = "spotify", "Spotify"
+
+        @staticmethod
+        def list_playlists():
+            return {"drive": {"id": "source-drive", "name": "Drive"}}
+
+        @staticmethod
+        def playlist_name(playlist):
+            return playlist["name"]
+
+        @staticmethod
+        def playlist_id(playlist):
+            return playlist["id"]
+
+        @staticmethod
+        def playlist_tracks(_playlist):
+            raise TargetAuthError("Spotify source session expired")
+
+    class Target:
+        source, tag, name = "apple", "apple", "Apple Music"
+        cache_file = str(tmp_path / "apple.json")
+
+        @staticmethod
+        def list_playlists():
+            return {"drive": {"id": "apple-drive", "name": "Drive"}}
+
+        @staticmethod
+        def playlist_id(playlist):
+            return playlist["id"]
+
+        @staticmethod
+        def is_editable(_playlist):
+            return True
+
+    post_sync_calls = []
+    monkeypatch.setattr(runner.spotify, "client", lambda writable=False: object())
+    monkeypatch.setattr(runner, "build_one", lambda *args, **kwargs: Source())
+    monkeypatch.setattr(runner, "build_targets", lambda *args, **kwargs: [Target()])
+    monkeypatch.setattr(runner.archive, "connect", lambda path: _FakeSongs())
+    monkeypatch.setattr(runner, "_load_links", lambda: [])
+    monkeypatch.setattr(runner, "_post_sync", lambda *args, **kwargs: post_sync_calls.append(True))
+
+    with pytest.raises(TargetAuthError, match="Spotify source session expired"):
+        runner.run_pass(
+            _opts(
+                execute=True,
+                sync_source="spotify",
+                providers="spotify,apple",
+                playlists="Drive",
+            )
+        )
+
+    assert post_sync_calls == []
 
 
 def test_nway_wraps_accumulated_summary(monkeypatch):


### PR DESCRIPTION
## Summary

- prove that a newly submitted Amazon Music web session can mint a fresh panda token before reporting it connected
- persist refreshed session data only after the renewed token passes the signed-in user check
- keep one-way destination auth failures scoped to that provider while preserving successful sibling results and post-sync work
- keep shared-source auth failures and N-way/group reconciliation fail-closed
- surface skipped destinations on the dashboard without duplicating an existing account alert

## Verification

- `uv run python -m pytest -q --tb=short` — 349 passed, 1 skipped
- `pnpm -C frontend lint`
- `pnpm -C frontend build`
- `pnpm -C frontend test:e2e` — 120 checks, 0 horizontal overflow failures
- independent replay of the empty panda token, failed identity persistence, source-auth, destination-create-auth, and alert-deduplication cases