### PR TITLE
fix(sync): refine provider fallbacks

### DIFF
--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -198,7 +198,7 @@ function syncStatusFixture(syncsData) {
             { target: 'Apple Music', playlist: 'Road Trip 2025', track: 'Confirmed Candidate', artist: 'Signal', reason: 'removal mirroring is off for this sync', category: 'confirmed_removal_disabled', source: 'Qobuz', evidence: 'two trusted source snapshots confirmed the absence' },
           ],
           change_diagnostics: [
-            { category: 'uncertain_match', playlist: 'Road Trip 2025', provider: 'Apple Music', count: 1, evidence: 'a similar destination track had no safe source-side replacement match' },
+            { category: 'uncertain_match', playlist: 'Road Trip 2025', provider: 'Apple Music', count: 1, evidence: 'kept "Enemy (From Arcane)" — Imagine Dragons; unresolved source track "Enemy (with JID) - from Arcane" — Imagine Dragons' },
             { category: 'unconfirmed_absence', playlist: 'Road Trip 2025', provider: 'Qobuz', count: 2, evidence: 'missing from one trusted snapshot; a second trusted snapshot is required' },
             { category: 'incomplete_read', playlist: 'Some Old Mix', provider: 'YouTube Music', count: 1, evidence: 'read 8 of 10 baseline identities; changes ignored' },
             { category: 'confirmed_absence', playlist: 'Road Trip 2025', provider: 'Qobuz', count: 1, evidence: 'missing from two consecutive trusted snapshots on this provider' },
@@ -1330,7 +1330,10 @@ async function main() {
       if (!startOk) results.push({ label: 'needs a look dismissable cards', overflow: true })
 
       const needsLookText = await page.locator('body').innerText()
-      const heldExplained = needsLookText.includes('1 destination match remained uncertain') && needsLookText.includes('Road Trip 2025')
+      const heldExplained = needsLookText.includes('1 destination match remained uncertain')
+        && needsLookText.includes('Road Trip 2025')
+        && needsLookText.includes('Enemy (From Arcane)')
+        && needsLookText.includes('Enemy (with JID) - from Arcane')
       const firstReadExplained = needsLookText.includes('2 playlist absences awaiting verification') && needsLookText.includes('not treated as a deletion')
       const anomalyExplained = needsLookText.includes('1 provider read signal rejected as unsafe') && needsLookText.includes('changes ignored')
       const confirmedExplained = needsLookText.includes('1 confirmed removal candidate kept') && needsLookText.includes('two consecutive complete reads')
@@ -1362,6 +1365,8 @@ async function main() {
 
       // Same slot, different situation: a changed held-count is a NEW problem,
       // so it must resurface — and the stale dismissal is pruned from storage.
+      // One-way evidence is bounded to 50 detail rows, but the headline must
+      // retain the authoritative aggregate when more tracks were held.
       await page.route('**/api/sync/status', async (route) => {
         if (route.request().method() !== 'GET') return route.fallback()
         await route.fulfill({
@@ -1371,8 +1376,16 @@ async function main() {
             running: false, mode: null, running_job: null, master: true, scheduled: true,
             next_run_at: Math.floor(Date.now() / 1000) + 3600,
             last: {
-              mode: 'nway', execute: true, duration_s: 30, ok: true, error: null,
-              per_target: [{ name: 'Apple Music', added: 0, removed: 0, missing: 0, held: 9, deferred: 0, created: 0, skipped: 0 }],
+              mode: 'oneway', execute: true, duration_s: 30, ok: true, error: null,
+              per_target: [{
+                name: 'Apple Music', added: 0, removed: 0, missing: 60, held: 70,
+                uncertain_matches: 60,
+                deferred: 0, created: 0, skipped: 0,
+                change_diagnostics: Array.from({ length: 50 }, (_, index) => ({
+                  category: 'uncertain_match', playlist: 'Road Trip 2025', provider: 'Apple Music', count: 1,
+                  evidence: `kept "Existing ${index + 1}"; unresolved source track "Source ${index + 1}"`,
+                })),
+              }],
             },
             jobs: [],
           }),
@@ -1381,11 +1394,11 @@ async function main() {
       await page.reload({ waitUntil: 'networkidle' })
       await page.waitForSelector('h2:has-text("Needs a look")')
       await page.waitForTimeout(150)
-      const resurfaced = (await page.locator('body').innerText()).includes('9 destination matches remained uncertain')
+      const resurfaced = (await page.locator('body').innerText()).includes('60 destination matches remained uncertain')
       const stored = await page.evaluate(() => window.localStorage.getItem('songmirror-dismissed-alerts'))
       const prunedOk = resurfaced && stored === '[]'
-      console.log(`${prunedOk ? 'ok        ' : 'FAIL      '} a changed situation resurfaces and prunes the stale dismissal (resurfaced=${resurfaced}, stored=${stored})`)
-      if (!prunedOk) results.push({ label: 'needs a look dismiss pruning', overflow: true })
+      console.log(`${prunedOk ? 'ok        ' : 'FAIL      '} capped one-way evidence keeps the aggregate total and resurfaces the changed situation (resurfaced=${resurfaced}, stored=${stored})`)
+      if (!prunedOk) results.push({ label: 'needs a look aggregate total and dismissal pruning', overflow: true })
 
       // The sidebar wordmark is a link home from anywhere in the app.
       await page.goto(BASE_URL + '/settings', { waitUntil: 'networkidle' })

--- a/frontend/src/components/dashboard/NeedsALook.tsx
+++ b/frontend/src/components/dashboard/NeedsALook.tsx
@@ -226,8 +226,17 @@ function buildItems(accounts: Account[] | null, status: SyncStatus | null): Need
   const uncertainRows = diagnosticsByCategory(diagnostics, 'uncertain_match')
   const structuredHeldTotal = diagnosticCount(uncertainRows)
   const heldTotal = targets.reduce((sum, target) => sum + target.held, 0)
-  if (structuredHeldTotal > 0 || (heldTotal > 0 && diagnostics.length === 0)) {
-    const total = structuredHeldTotal || heldTotal
+  const hasUncertainTotal = targets.some((target) => target.uncertain_matches !== undefined)
+  const reportedUncertainTotal = targets.reduce(
+    (sum, target) => sum + (target.uncertain_matches ?? 0),
+    0,
+  )
+  // Exact evidence is intentionally bounded by the backend. Its dedicated
+  // aggregate remains authoritative when more matches exist than fit in that
+  // detail window. Older saved passes fall back to the original held count.
+  const legacyHeldTotal = !hasUncertainTotal && diagnostics.length === 0 ? heldTotal : 0
+  const total = Math.max(structuredHeldTotal, reportedUncertainTotal, legacyHeldTotal)
+  if (total > 0) {
     const details = structuredHeldTotal > 0
       ? diagnosticDetails(uncertainRows)
       : targets.filter((target) => target.held > 0)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -80,6 +80,9 @@ export interface TargetSummary {
   removed: number
   missing: number
   held: number
+  /** Holds caused specifically by an unresolved source/destination catalog
+   * match. Unlike `held`, this excludes removals blocked for other reasons. */
+  uncertain_matches?: number
   deferred: number
   /** Removals held back this pass because they exceeded max_removals and the sync
    * hasn't opted into draining them — surfaced so the skip isn't silent. */

--- a/songmirror/engine/matching.py
+++ b/songmirror/engine/matching.py
@@ -220,6 +220,31 @@ def _best(sim, q_variants, c_variants):
     return max((sim(a, b) for a in q_variants for b in c_variants if a and b), default=0.0)
 
 
+def _artist_variants(track):
+    artists = track.get("artists") or ([track["artist"]] if track.get("artist") else [])
+    joined = " ".join(str(artist) for artist in artists if artist)
+    display = track.get("artist") or joined
+    variants = {
+        variant
+        for variant in (
+            normalize_text(joined),
+            romanized(joined),
+            normalize_text(display),
+            romanized(display),
+        )
+        if variant
+    }
+    # Provider punctuation varies for compact stage names (AC/DC vs ACDC,
+    # M|A|R|R|S vs MARRS). Keep the ordinary tokenized forms too so multi-artist
+    # subset matching still behaves as before.
+    variants.update(variant.replace(" ", "") for variant in list(variants))
+    return variants
+
+
+def _artist_similarity(track, candidate):
+    return _best(_sim_loose, _artist_variants(track), _artist_variants(candidate))
+
+
 def fuzzy_in(key, keys, threshold=FUZZY_THRESHOLD):
     # ponytail: O(len(keys)) scan per unmatched track; fine for playlist-sized
     # sets, index it if someone mirrors a 50k-track monster.
@@ -275,14 +300,7 @@ def same_catalog_recording(track, candidate):
     if not wanted or wanted != existing:
         return False
 
-    def artist_variants(value):
-        artists = value.get("artists") or ([value["artist"]] if value.get("artist") else [])
-        joined = " ".join(str(a) for a in artists if a)
-        display = value.get("artist") or joined
-        return {v for v in (normalize_text(joined), romanized(joined),
-                            normalize_text(display), romanized(display)) if v}
-
-    artist_sim = _best(_sim_loose, artist_variants(track), artist_variants(candidate))
+    artist_sim = _artist_similarity(track, candidate)
     if artist_sim < FUZZY_THRESHOLD:
         return False
 
@@ -290,6 +308,37 @@ def same_catalog_recording(track, candidate):
     candidate_duration = candidate.get("duration_ms")
     if duration is not None and candidate_duration is not None:
         return abs(duration - candidate_duration) <= CATALOG_DURATION_TOLERANCE_MS
+    return True
+
+
+def same_unresolved_recording(source_track, existing_track, threshold=0.8):
+    """Whether an unresolved source item can safely protect an existing copy.
+
+    This guard intentionally favors retention, but title and artist evidence
+    must be evaluated independently. Comparing one combined ``title|artist``
+    string lets a shared title and one common artist token outweigh a different
+    performer (for example, two unrelated songs named "Bad Blood"). Duration,
+    when both providers expose it, must also agree closely.
+    """
+    if creative_version_markers(source_track.get("name")) != creative_version_markers(
+        existing_track.get("name")
+    ):
+        return False
+
+    title_similarity = _best(
+        _sim_loose,
+        _name_variants(source_track.get("name")),
+        _name_variants(existing_track.get("name")),
+    )
+    if title_similarity < threshold:
+        return False
+    if _artist_similarity(source_track, existing_track) < FUZZY_THRESHOLD:
+        return False
+
+    source_duration = source_track.get("duration_ms")
+    existing_duration = existing_track.get("duration_ms")
+    if source_duration is not None and existing_duration is not None:
+        return abs(source_duration - existing_duration) <= CATALOG_DURATION_TOLERANCE_MS
     return True
 
 
@@ -342,26 +391,32 @@ def compute_diff(sp_tracks, target_tracks, expected_by_sp, target_id_of, thresho
     return to_add, to_remove
 
 
+def match_unresolved_removals(to_remove, not_found_tracks, threshold=0.8):
+    """Return safe removals and the unresolved source match protecting each hold."""
+    safe, protected = [], []
+    for track in to_remove:
+        source_match = next(
+            (
+                source_track
+                for source_track in not_found_tracks
+                if same_unresolved_recording(source_track, track, threshold)
+            ),
+            None,
+        )
+        if source_match is not None:
+            protected.append((track, source_match))
+        else:
+            safe.append(track)
+    return safe, protected
+
+
 def protect_removals(to_remove, not_found_tracks, threshold=0.8):
     """Split removals into (safe, held): a target track resembling a Spotify
     track that has NO match on that service must not be deleted — that would
-    drop the song with no replacement. Deliberately loose threshold: wrongly
-    holding leaves an extra track; wrongly deleting loses music."""
-    nf_keys = set()
-    nf_keys_by_version = {}
-    for track in not_found_tracks:
-        keys = spotify_track_keys(track)
-        nf_keys |= keys
-        version = frozenset(creative_version_markers(track.get("name")))
-        nf_keys_by_version.setdefault(version, set()).update(keys)
-    safe, held = [], []
-    for track in to_remove:
-        key = track_key(track["name"], track["artist"])
-        compatible_keys = nf_keys_by_version.get(
-            frozenset(creative_version_markers(track.get("name"))), set()
-        )
-        if key in nf_keys or fuzzy_in(key, compatible_keys, threshold):
-            held.append(track)
-        else:
-            safe.append(track)
-    return safe, held
+    drop the song with no replacement. The title threshold is deliberately
+    loose because wrongly holding leaves an extra track while wrongly deleting
+    loses music; artist and duration evidence are still checked independently."""
+    safe, protected = match_unresolved_removals(
+        to_remove, not_found_tracks, threshold
+    )
+    return safe, [track for track, _source_match in protected]

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -52,7 +52,8 @@ def save_cache(cache_file, cache):
         json.dump({"isrc": cache["isrc"], "search": cache["search"]}, f, indent=1)
 
 
-_SUMMARY_KEYS = ("added", "removed", "missing", "held", "deferred", "removals_skipped",
+_SUMMARY_KEYS = ("added", "removed", "missing", "held", "uncertain_matches",
+                 "deferred", "removals_skipped",
                  "created", "skipped", "failed", "isrc_fallback", "identity_changes",
                  "unconfirmed_absences", "confirmed_absences", "read_anomalies")
 
@@ -134,9 +135,9 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
     path (empty `links` => byte-for-byte unchanged when the source is Spotify)."""
     src_key = source.source
     agg = {"name": target.name, "pairs": 0, "added": 0, "removed": 0, "missing": 0,
-           "held": 0, "deferred": 0, "removals_skipped": 0,
+           "held": 0, "uncertain_matches": 0, "deferred": 0, "removals_skipped": 0,
            "skipped": 0, "created": 0, "failed": 0,
-           "held_removals": [], "failures": []}
+           "held_removals": [], "change_diagnostics": [], "failures": []}
     cache = load_cache(target.cache_file)
     try:
         tgt_by_name = target.list_playlists()
@@ -209,7 +210,11 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                 agg["pairs"] += 1
                 for k in ("added", "removed", "missing", "held", "deferred", "removals_skipped"):
                     agg[k] += res[k]
+                agg["uncertain_matches"] += res.get("uncertain_matches", 0)
                 _collect_held(agg["held_removals"], res.get("held_removals", []))
+                _collect_diagnostics(
+                    agg["change_diagnostics"], res.get("change_diagnostics", [])
+                )
                 if res["clean"] and snapshot:
                     archive.set_state(songs, state_key, target.source, snapshot, res["target_count"])
             except TargetAuthError:
@@ -357,6 +362,9 @@ def run_pass(opts, should_continue=None):
 
     def worker(target, songs):
         try:
+            binder = getattr(target, "bind_archive", None)
+            if binder is not None:
+                binder(songs)
             results[target.tag] = run_target(target, selected, get_source_tracks, songs, opts, links, source, ctrl)
         except _SourceAuthError as e:
             # A one-way source is shared by every destination. Its failure
@@ -518,7 +526,8 @@ def _run_peer_reconcile(opts, sp, selected, songs, should_continue=None, *,
     spotify_cookie.take_singles_used()   # drop any residue from a pass that died mid-read
     dirs = {p.source: p.list_playlists() for p in peers}
     caches = {p.source: load_cache(p.cache_file) for p in peers}
-    total = {"added": 0, "removed": 0, "missing": 0, "held": 0, "deferred": 0,
+    total = {"added": 0, "removed": 0, "missing": 0, "held": 0,
+             "uncertain_matches": 0, "deferred": 0,
              "removals_skipped": 0, "failed": 0, "identity_changes": 0,
              "unconfirmed_absences": 0, "confirmed_absences": 0, "read_anomalies": 0}
     # Both lists stay out of `total` so the scalar accumulate loop stays scalar.

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -18,7 +18,8 @@ from ..logs import (
     log_remove, log_repair, log_section, log_summary, log_warn, paint,
 )
 from ..matching import (
-    catalog_name, compute_diff, fuzzy_in, protect_removals, romanized,
+    catalog_name, compute_diff, fuzzy_in, match_unresolved_removals,
+    protect_removals, romanized,
     normalize_canonical_id, normalize_isrc, same_catalog_recording,
     spotify_track_keys, track_addition_order_key, track_key,
 )
@@ -104,6 +105,9 @@ class MirrorTarget:
     def hydrate_playlist_counts(self, playlists):
         """Optionally enrich browse rows whose list API omits cheap counts."""
         return playlists
+
+    def bind_archive(self, songs):
+        """Attach this worker's archive connection when a provider needs history."""
 
     def playlist_id(self, playlist):
         """Stable id of a library playlist, for explicit pairing lookups."""
@@ -392,7 +396,8 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         log_warn(f"{len(additions)} additions exceed --max-adds={max_adds}; deferring {cap_deferred} to next pass", tag=tag)
         additions, guard = additions[:max_adds], True
 
-    removals, held = protect_removals(to_remove, not_found)
+    removals, uncertain_matches = match_unresolved_removals(to_remove, not_found)
+    held = [existing for existing, _unresolved in uncertain_matches]
     removals_skipped, held_back = 0, []
     if not sp_tracks and tgt_tracks:
         log_warn(f"{source_name} returned 0 tracks but {target.name} has {len(tgt_tracks)}; skipping all removals this pass", tag=tag)
@@ -487,10 +492,28 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         + (paint(f"  via {via}", "grey") if via else ""),
         tag=tag,
     )
+    change_diagnostics = []
+    for existing, unresolved in uncertain_matches:
+        existing_artist = existing.get("artist") or ", ".join(existing.get("artists") or [])
+        unresolved_artist = unresolved.get("artist") or ", ".join(
+            unresolved.get("artists") or []
+        )
+        change_diagnostics.append({
+            "category": "uncertain_match",
+            "playlist": name,
+            "provider": target.name,
+            "count": 1,
+            "evidence": (
+                f'kept "{existing.get("name", "")}" — {existing_artist}; '
+                f'unresolved source track "{unresolved.get("name", "")}" — {unresolved_artist}'
+            ),
+        })
     return {
         "clean": execute and not guard, "added": len(additions), "removed": len(removals),
         "missing": len(not_found), "held": len(held), "deferred": deferred,
+        "uncertain_matches": len(uncertain_matches),
         "removals_skipped": removals_skipped, "held_removals": held_back,
+        "change_diagnostics": change_diagnostics,
         "target_count": len(tgt_tracks) + len(additions) - len(removals),
     }
 
@@ -1062,7 +1085,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     authority_bootstrap = authorities is not None and bool(authorities - initialized)
     stats = {"clean": execute and not collapsed and not awaiting_confirmation and not authority_bootstrap,
              "added": 0, "removed": 0, "missing": 0,
-             "held": 0, "deferred": 0, "removals_skipped": 0, "held_removals": [],
+             "held": 0, "uncertain_matches": 0,
+             "deferred": 0, "removals_skipped": 0, "held_removals": [],
              "identity_changes": identity_changes,
              "unconfirmed_absences": awaiting_confirmation,
              "confirmed_absences": confirmed_absence_count,
@@ -1377,6 +1401,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                        "replacement additions incomplete" if provider_add_incomplete else
                        "no re-add match")
         if held and not provider_add_incomplete and not authority_bootstrap:
+            stats["uncertain_matches"] += len(held)
             diagnostics.append({
                 "category": "uncertain_match", "playlist": name,
                 "provider": p.name, "count": len(held),

--- a/songmirror/engine/targets/spotify_target.py
+++ b/songmirror/engine/targets/spotify_target.py
@@ -35,6 +35,9 @@ class SpotifyTarget(MirrorTarget):
         # read instead of being fetched from Spotify's developer API.
         self._songs = songs
 
+    def bind_archive(self, songs):
+        self._songs = songs
+
     def _user(self):
         if self._me is None:
             if spotify_write_backend() == "cookie" or self._sp is None:

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -68,6 +68,9 @@ class TidalTarget(MirrorTarget):
             raise RuntimeError("Missing TIDAL OAuth token; connect TIDAL in Accounts")
         self._session = requests.Session()
 
+    def bind_archive(self, songs):
+        self._songs = songs
+
     # -- auth / HTTP ---------------------------------------------------------
     def _access(self, force=False):
         if not force and token_is_live(self._tok):

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -114,6 +114,62 @@ def test_diff_replaces_a_wrong_live_variant_instead_of_fuzzy_protecting_it():
     assert held == []
 
 
+def test_removal_guard_does_not_conflate_same_title_tracks_by_different_artists():
+    source = [sp(
+        "Bad Blood",
+        "Black Pistol Fire",
+        None,
+        "",
+        dur=229_320,
+    )]
+    unrelated = ap("Bad Blood", "Black Math", "black-math")
+    unrelated["duration_ms"] = 208_000
+
+    safe, held = protect_removals([unrelated], source)
+
+    assert safe == [unrelated]
+    assert held == []
+
+
+def test_removal_guard_requires_artist_agreement_when_durations_match():
+    source = [sp("The Sound of Silence", "Disturbed", None, "", dur=244_000)]
+    different_artist = ap(
+        "Sound of Silence Original", "Simon & Garfunkel", "different-artist"
+    )
+    different_artist["duration_ms"] = 244_000
+
+    safe, held = protect_removals([different_artist], source)
+
+    assert safe == [different_artist]
+    assert held == []
+
+
+def test_removal_guard_requires_duration_agreement_when_artists_match():
+    source = [sp("The Sound of Silence", "Disturbed", None, "", dur=244_000)]
+    different_recording = ap(
+        "Sound of Silence Original", "Disturbed", "different-recording"
+    )
+    different_recording["duration_ms"] = 180_000
+
+    safe, held = protect_removals([different_recording], source)
+
+    assert safe == [different_recording]
+    assert held == []
+
+
+def test_removal_guard_accepts_punctuation_only_artist_drift():
+    source = [sp("Thunderstruck", "AC/DC", None, "", dur=292_000)]
+    compact_artist = ap("Thunderstruck", "ACDC", "compact-artist")
+    compact_artist["duration_ms"] = 292_000
+
+    to_add, to_remove = compute_diff(source, [compact_artist], {}, cid_of)
+    safe, held = protect_removals(to_remove, source)
+
+    assert to_add == source
+    assert safe == []
+    assert held == [compact_artist]
+
+
 def run():
     assert parse_interval("900") == 900 and parse_interval("15m") == 900 and parse_interval("1h") == 3600
 

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -177,6 +177,119 @@ def test_oneway_target_workers_have_independent_archive_connections(monkeypatch,
     assert all(result["failed"] == 0 for result in summary["per_target"])
 
 
+def test_oneway_tidal_uses_archived_details_for_a_delisted_playlist_entry(monkeypatch, tmp_path):
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    song_cache = tmp_path / "songs.db"
+    seed = archive.connect(str(song_cache))
+    archived = {
+        "id": "156738999",
+        "name": "Rome",
+        "artist": "Dojo Cuts",
+        "artists": ["Dojo Cuts"],
+        "album": "Rome",
+        "duration_ms": 227_000,
+        "isrc": "QZDMQ1918901",
+    }
+    archive.upsert_many(seed, "tidal", [archived])
+    seed.close()
+
+    class Source:
+        source, name = "spotify", "Spotify"
+
+        @staticmethod
+        def list_playlists():
+            return {"drive": {"id": "spotify-drive", "name": "Drive"}}
+
+        @staticmethod
+        def playlist_name(playlist):
+            return playlist["name"]
+
+        @staticmethod
+        def playlist_id(playlist):
+            return playlist["id"]
+
+        @staticmethod
+        def playlist_tracks(_playlist):
+            return [{**archived, "id": "spotify-rome"}]
+
+    class Response:
+        @staticmethod
+        def json():
+            return {"data": [], "included": []}
+
+    class DelistedTidal(TidalTarget):
+        def __init__(self):
+            self.cache_file = str(tmp_path / "tidal.json")
+            self.country = "US"
+            self._songs = None
+
+        @staticmethod
+        def list_playlists():
+            return {
+                "drive": {
+                    "id": "tidal-drive",
+                    "attributes": {"name": "Drive", "numberOfItems": 1},
+                }
+            }
+
+        @staticmethod
+        def _pages(path, params=None):
+            assert path == "playlists/tidal-drive/relationships/items"
+            yield {
+                "data": [{
+                    "type": "tracks",
+                    "id": "156738999",
+                    "meta": {"itemId": "relationship-rome"},
+                }],
+                "included": [],
+                "links": {},
+            }
+
+        @staticmethod
+        def _request(method, path, **kwargs):
+            assert (method, path) == ("GET", "tracks")
+            return Response()
+
+        @staticmethod
+        def prefetch(source_tracks, cache):
+            pass
+
+        @staticmethod
+        def expected_ids(source_tracks, links, cache):
+            return {"spotify-rome": {"156738999"}}
+
+        @staticmethod
+        def resolve(track, cache):
+            raise AssertionError("the archived TIDAL relationship is already present")
+
+        @staticmethod
+        def add(playlist, target_ids):
+            raise AssertionError("the archived TIDAL relationship is already present")
+
+        @staticmethod
+        def remove(playlist, track):
+            raise AssertionError("the archived TIDAL relationship must be retained")
+
+    target = DelistedTidal()
+    monkeypatch.setattr(runner.spotify, "client", lambda writable=False: object())
+    monkeypatch.setattr(runner, "build_one", lambda *args, **kwargs: Source())
+    monkeypatch.setattr(runner, "build_targets", lambda *args, **kwargs: [target])
+    monkeypatch.setattr(runner, "_load_links", lambda: [])
+    monkeypatch.setattr(runner, "_post_sync", lambda *args, **kwargs: None)
+
+    summary = runner.run_pass(_opts(
+        execute=True,
+        sync_source="spotify",
+        providers="spotify,tidal",
+        playlists="Drive",
+        song_cache_file=str(song_cache),
+    ))
+
+    assert summary["per_target"][0]["failed"] == 0
+    assert target._songs is not None
+
+
 def test_oneway_isolates_a_target_auth_error_and_keeps_sibling_results(monkeypatch, tmp_path):
     from songmirror.engine.targets.base import TargetAuthError
 
@@ -379,7 +492,7 @@ def test_authoritative_group_routes_with_writable_spotify(monkeypatch):
     assert summary["per_target"][0]["added"] == 2
 
 
-def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
+def test_run_target_honors_explicit_pairing_and_collects_diagnostics(monkeypatch, tmp_path):
     from songmirror.engine import archive
     from songmirror.services.playlists import PlaylistLink
 
@@ -407,13 +520,22 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
             raise AssertionError("must not create; the paired target already exists")
 
     captured = {}
+    diagnostic = {
+        "category": "uncertain_match",
+        "playlist": "Workout",
+        "provider": "Apple Music",
+        "count": 1,
+        "evidence": "kept existing; unresolved source track replacement",
+    }
 
     def fake_mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs_, *,
                          execute, max_removals, max_adds, drain_removals=False, should_continue=None,
                          source_key="spotify", source_name="Spotify", name=None):
         captured["tgt_id"] = tgt_playlist["id"]
-        return {"clean": True, "added": 1, "removed": 0, "missing": 0, "held": 0,
-                "deferred": 2, "removals_skipped": 0, "target_count": 1}
+        return {"clean": True, "added": 1, "removed": 0, "missing": 0, "held": 1,
+                "deferred": 2, "removals_skipped": 0, "target_count": 1,
+                "uncertain_matches": 1,
+                "change_diagnostics": [diagnostic]}
 
     monkeypatch.setattr(runner, "mirror_pair", fake_mirror_pair)
 
@@ -424,7 +546,10 @@ def test_run_target_honors_explicit_pairing(monkeypatch, tmp_path):
 
     assert captured["tgt_id"] == "t99"          # paired target used, not same-name match
     assert agg["added"] == 1
+    assert agg["held"] == 1
     assert agg["deferred"] == 2
+    assert agg["uncertain_matches"] == 1
+    assert agg["change_diagnostics"] == [diagnostic]
     assert archive.get_state(songs, "LINK1", "apple") is not None  # state keyed by the link id
     songs.close()
 
@@ -850,6 +975,77 @@ def test_one_way_reuses_a_conservative_archived_recording_match(tmp_path):
     songs.close()
 
 
+def test_one_way_uncertain_hold_names_existing_and_unresolved_tracks(tmp_path):
+    from songmirror.engine.targets.base import mirror_pair
+
+    songs = archive.connect(str(tmp_path / "uncertain-hold.db"))
+
+    class Target:
+        name, tag, source = "YouTube Music", "yt", "ytmusic"
+
+        @staticmethod
+        def playlist_tracks(playlist):
+            return [{
+                "id": "youtube-silence",
+                "name": "Sound of Silence Original",
+                "artist": "Disturbed",
+                "artists": ["Disturbed"],
+                "duration_ms": 200_000,
+            }]
+
+        @staticmethod
+        def track_id(track):
+            return track["id"]
+
+        @staticmethod
+        def expected_ids(tracks, links, cache):
+            return {}
+
+        @staticmethod
+        def prefetch(tracks, cache):
+            pass
+
+        @staticmethod
+        def resolve(track, cache):
+            return None, None
+
+        @staticmethod
+        def remove(playlist, track):
+            raise AssertionError("an unresolved equivalent must remain protected")
+
+    stats = mirror_pair(
+        Target(),
+        [{
+            "id": "spotify-silence",
+            "name": "The Sound of Silence",
+            "artist": "Disturbed",
+            "artists": ["Disturbed"],
+            "duration_ms": 200_000,
+        }],
+        {"name": "Drive"},
+        {"id": "youtube-drive"},
+        {"isrc": {}, "search": {}, "dirty": False},
+        songs,
+        execute=True,
+        max_removals=200,
+        max_adds=200,
+    )
+
+    assert stats["held"] == 1
+    assert stats["uncertain_matches"] == 1
+    assert stats["change_diagnostics"] == [{
+        "category": "uncertain_match",
+        "playlist": "Drive",
+        "provider": "YouTube Music",
+        "count": 1,
+        "evidence": (
+            'kept "Sound of Silence Original" — Disturbed; unresolved source track '
+            '"The Sound of Silence" — Disturbed'
+        ),
+    }]
+    songs.close()
+
+
 def test_held_removals_name_the_track_playlist_service_and_reason():
     from songmirror.engine.targets.base import held_removals
 
@@ -874,6 +1070,7 @@ def test_summary_detail_is_bounded_but_counts_are_not():
 def test_summary_entry_carries_detail_and_defaults_it_empty():
     assert runner._summary_entry("N-way", {})["held_removals"] == []
     assert runner._summary_entry("N-way", {})["change_diagnostics"] == []
+    assert runner._summary_entry("N-way", {})["uncertain_matches"] == 0
     entry = runner._summary_entry("N-way", {"held_removals": [{"track": "x"}]})
     assert entry["held_removals"] == [{"track": "x"}]
 


### PR DESCRIPTION
## Summary

- give one-way TIDAL and Spotify targets their worker-local archive connection so delisted or partially hydrated catalog entries can use known metadata
- separate title, artist, creative-version, and duration evidence when deciding whether an unresolved source track should protect an existing destination copy
- include the exact protected destination/source pair in dashboard diagnostics and preserve category-specific totals when evidence is capped

## Why

TIDAL can keep a playlist relationship after its `/tracks` catalog entry disappears. The archive already held the last-known metadata, but one-way targets were not connected to that archive, so the playlist read failed. Separately, the removal guard compared a combined title/artist string; a shared title could therefore make unrelated recordings look close enough to retain.

## Verification

- `uv run python -m pytest -q --tb=short` — 355 passed, 1 skipped
- `npm run lint` — passed
- `npm run build` — passed
- `npm run test:e2e` — 120 checks, 0 failures
- independent read-only verification — no remaining findings