### PR TITLE
fix(sync): derive the N-way order authority from participants

### DIFF
--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -15,8 +15,8 @@ from dotenv import load_dotenv
 from . import archive, spotify, spotify_cookie
 from .config import spotify_write_backend
 from .logs import fmt_counts, fmt_secs, log, log_note, log_section, log_summary, log_warn, paint
-from .targets import (_SOURCE_ORDER, TargetAuthError, build_one, build_peers, build_targets,
-                      mirror_pair, reconcile)
+from .targets import (TargetAuthError, build_one, build_peers, build_targets, mirror_pair,
+                      nway_order_candidates, reconcile)
 from .targets.base import _normalize, reconcile_state_key
 
 
@@ -228,22 +228,13 @@ def _wanted_providers(opts):
     return {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
 
 
-def _nway_order_authority(opts, wanted=None):
-    """N-way's order authority: it supplies the playlist names run_pass mirrors
-    and the track sequence _run_peer_reconcile reconciles against.
-
-    One-way and group modes name their own authority; N-way has none, so this
-    defaults to Spotify for its catalogue coverage. A sync that leaves Spotify
-    out must fall back to a participating provider, otherwise the pass builds a
-    Spotify client for a service the user never connected and dies on its
-    missing credentials.
-    """
-    wanted = _wanted_providers(opts) if wanted is None else wanted
-    if not wanted or "spotify" in wanted:
-        return "spotify"
-    if opts.sync_source in wanted:
-        return opts.sync_source
-    return next((src for src in _SOURCE_ORDER if src in wanted), "spotify")
+def _build_nway_order_authority(opts, sp):
+    """Build the first configured provider in N-way authority preference order."""
+    for provider_id in nway_order_candidates(opts):
+        authority = build_one(provider_id, opts, sp)
+        if authority is not None:
+            return authority
+    return None
 
 
 def run_pass(opts, should_continue=None):
@@ -260,8 +251,7 @@ def run_pass(opts, should_continue=None):
     spotify_requested = not wanted_providers or "spotify" in wanted_providers
     # Group mode's order authority also supplies playlist names and ordering.
     # It remains writable because additions from another authority flow back.
-    source_provider = (opts.sync_source if opts.sync_mode in {"oneway", "group"}
-                       else _nway_order_authority(opts, wanted_providers))
+    source_provider = opts.sync_source if opts.sync_mode in {"oneway", "group"} else None
     # Spotify needs a writable client whenever it's a write destination: any
     # N-way/group execute, or a one-way execute where another provider is the
     # source and Spotify is one of the targets.
@@ -281,11 +271,18 @@ def run_pass(opts, should_continue=None):
                     raise
                 log_note(f"Spotify skipped: {exc}", tag="spotify")
 
-    # The library whose playlists drive this pass: Spotify for N-way; the chosen
-    # source/order authority for one-way and authoritative-group modes.
-    source = build_one(source_provider, opts, sp)
+    # The library whose playlists drive this pass: a configured participant for
+    # N-way; the chosen source/order authority for one-way and group modes.
+    if opts.sync_mode == "nway":
+        source = _build_nway_order_authority(opts, sp)
+        source_provider = source.source if source is not None else None
+    else:
+        source = build_one(source_provider, opts, sp)
     if source is None:
-        log_warn(f"sync source '{source_provider}' is not connected", indent="  ")
+        if opts.sync_mode == "nway":
+            log_warn("no configured N-way provider can supply playlist names and ordering", indent="  ")
+        else:
+            log_warn(f"sync source '{source_provider}' is not connected", indent="  ")
         return _summary(opts, [], pass_started)
     src_by_name = source.list_playlists()
 
@@ -508,10 +505,12 @@ def _run_peer_reconcile(opts, sp, selected, songs, should_continue=None, *,
                         label, authority_sources):
     """Shared ordered playlist loop for N-way and authoritative-group syncs."""
     peers = build_peers(opts, sp, songs=songs)
-    order_source = (opts.sync_source if authority_sources is not None
-                    else _nway_order_authority(opts))
-    peers.sort(key=lambda peer: (peer.source != order_source))
     peer_sources = {peer.source for peer in peers}
+    order_source = (opts.sync_source if authority_sources is not None else next(
+        (source for source in nway_order_candidates(opts) if source in peer_sources),
+        None,
+    ))
+    peers.sort(key=lambda peer: (peer.source != order_source))
     if authority_sources is not None:
         error = None
         if len(authority_sources) < 2:
@@ -532,7 +531,8 @@ def _run_peer_reconcile(opts, sp, selected, songs, should_continue=None, *,
         return []
     order_peer = next((peer for peer in peers if peer.source == order_source), None)
     if order_peer is None:
-        error = f"order provider '{order_source}' is not connected"
+        error = (f"order provider '{order_source}' is not connected" if order_source else
+                 "no configured provider can supply N-way playlist names and ordering")
         log_warn(error, indent="  ")
         return [_summary_entry(label, {
             "failed": 1,

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -15,7 +15,8 @@ from dotenv import load_dotenv
 from . import archive, spotify, spotify_cookie
 from .config import spotify_write_backend
 from .logs import fmt_counts, fmt_secs, log, log_note, log_section, log_summary, log_warn, paint
-from .targets import TargetAuthError, build_one, build_peers, build_targets, mirror_pair, reconcile
+from .targets import (_SOURCE_ORDER, TargetAuthError, build_one, build_peers, build_targets,
+                      mirror_pair, reconcile)
 from .targets.base import _normalize, reconcile_state_key
 
 
@@ -222,6 +223,29 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
     return agg
 
 
+def _wanted_providers(opts):
+    """The providers this job opted into; empty means every configured one."""
+    return {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
+
+
+def _nway_order_authority(opts, wanted=None):
+    """N-way's order authority: it supplies the playlist names run_pass mirrors
+    and the track sequence _run_peer_reconcile reconciles against.
+
+    One-way and group modes name their own authority; N-way has none, so this
+    defaults to Spotify for its catalogue coverage. A sync that leaves Spotify
+    out must fall back to a participating provider, otherwise the pass builds a
+    Spotify client for a service the user never connected and dies on its
+    missing credentials.
+    """
+    wanted = _wanted_providers(opts) if wanted is None else wanted
+    if not wanted or "spotify" in wanted:
+        return "spotify"
+    if opts.sync_source in wanted:
+        return opts.sync_source
+    return next((src for src in _SOURCE_ORDER if src in wanted), "spotify")
+
+
 def run_pass(opts, should_continue=None):
     pass_started = time.monotonic()
     # Pause/Stop hook: should_continue() returns "run" | "pause" | "stop"; the pass
@@ -232,11 +256,12 @@ def run_pass(opts, should_continue=None):
     # saves win; the headless CLI falls back to a plain .env. Either way this
     # picks up re-captured tokens without a restart.
     load_dotenv(os.getenv("SONGMIRROR_ENV_FILE") or ".env", override=True)
+    wanted_providers = _wanted_providers(opts)
+    spotify_requested = not wanted_providers or "spotify" in wanted_providers
     # Group mode's order authority also supplies playlist names and ordering.
     # It remains writable because additions from another authority flow back.
-    source_provider = opts.sync_source if opts.sync_mode in {"oneway", "group"} else "spotify"
-    wanted_providers = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
-    spotify_requested = not wanted_providers or "spotify" in wanted_providers
+    source_provider = (opts.sync_source if opts.sync_mode in {"oneway", "group"}
+                       else _nway_order_authority(opts, wanted_providers))
     # Spotify needs a writable client whenever it's a write destination: any
     # N-way/group execute, or a one-way execute where another provider is the
     # source and Spotify is one of the targets.
@@ -483,7 +508,8 @@ def _run_peer_reconcile(opts, sp, selected, songs, should_continue=None, *,
                         label, authority_sources):
     """Shared ordered playlist loop for N-way and authoritative-group syncs."""
     peers = build_peers(opts, sp, songs=songs)
-    order_source = opts.sync_source if authority_sources is not None else "spotify"
+    order_source = (opts.sync_source if authority_sources is not None
+                    else _nway_order_authority(opts))
     peers.sort(key=lambda peer: (peer.source != order_source))
     peer_sources = {peer.source for peer in peers}
     if authority_sources is not None:

--- a/songmirror/engine/targets/__init__.py
+++ b/songmirror/engine/targets/__init__.py
@@ -20,7 +20,8 @@ from . import ytmusic
 
 __all__ = ["AppleMusicTarget", "AmazonMusicTarget", "DeezerTarget", "QobuzTarget",
            "SpotifyTarget", "TidalTarget", "MirrorTarget", "TargetAuthError", "TargetTransientError",
-           "mirror_pair", "reconcile", "build_targets", "build_peers", "build_one", "is_peer"]
+           "mirror_pair", "reconcile", "build_targets", "build_peers", "build_one", "is_peer",
+           "nway_order_candidates"]
 
 
 def _apple(opts):
@@ -72,6 +73,23 @@ _REGISTRY = {
     "ytmusic": lambda opts, sp, sync_peer=False, songs=None: ytmusic.build(),
 }
 _SOURCE_ORDER = ["spotify", "tidal", "qobuz", "deezer", "amazon", "apple", "ytmusic"]
+
+
+def nway_order_candidates(opts):
+    """Provider ids to try for N-way order authority, in preference order.
+
+    The caller still decides whether a candidate is configured. Empty
+    ``opts.providers`` therefore expands to every known provider rather than
+    assuming Spotify is available. Spotify keeps priority when it can be built,
+    followed by the job's former source when it participates, then registry
+    source order.
+    """
+    wanted = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
+    participants = [src for src in _SOURCE_ORDER if not wanted or src in wanted]
+    preferred = ("spotify", getattr(opts, "sync_source", None))
+    return tuple(dict.fromkeys(
+        src for src in (*preferred, *participants) if src in participants
+    ))
 
 
 def build_targets(opts, sp=None):

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -162,6 +162,58 @@ def test_nway_order_authority_falls_back_when_spotify_is_absent(monkeypatch):
     assert not any("order provider" in e for e in errors), errors
 
 
+@pytest.mark.parametrize(
+    ("providers", "sync_source"),
+    [
+        pytest.param("", "deezer", id="automatic-providers"),
+        pytest.param("tidal,deezer,ytmusic", "spotify", id="unavailable-first-candidate"),
+    ],
+)
+def test_nway_uses_a_configured_order_authority(monkeypatch, providers, sync_source):
+    """Playlist names and ordering come from a provider participating this pass."""
+
+    class Source:
+        source, name = "deezer", "Deezer"
+
+        @staticmethod
+        def list_playlists():
+            return {}
+
+    class Peer:
+        def __init__(self, source):
+            self.source, self.name, self.tag = source, source.title(), source
+            self.cache_file = "no-such-cache.json"
+
+        @staticmethod
+        def list_playlists():
+            return {}
+
+    def unavailable_spotify(**kwargs):
+        raise RuntimeError("Spotify is not configured")
+
+    monkeypatch.setattr(runner, "spotify_write_backend", lambda: "oauth")
+    monkeypatch.setattr(runner.spotify_cookie, "configured", lambda: False)
+    monkeypatch.setattr(runner.spotify, "client", unavailable_spotify)
+    monkeypatch.setattr(
+        runner, "build_one",
+        lambda provider, *args, **kwargs: Source() if provider == "deezer" else None,
+    )
+    monkeypatch.setattr(
+        runner, "build_peers",
+        lambda *args, **kwargs: [Peer("deezer"), Peer("ytmusic")],
+    )
+
+    summary = runner.run_pass(_opts(
+        sync_mode="nway",
+        providers=providers,
+        sync_source=sync_source,
+    ))
+
+    assert [(entry["name"], entry["failed"]) for entry in summary["per_target"]] == [
+        ("N-way", 0)
+    ]
+
+
 def test_oneway_target_workers_have_independent_archive_connections(monkeypatch, tmp_path):
     """Parallel providers must not operate on one sqlite3.Connection.
 

--- a/tests/test_runner_summary.py
+++ b/tests/test_runner_summary.py
@@ -87,6 +87,81 @@ def test_non_spotify_oneway_skips_unconfigured_spotify_when_providers_are_auto(m
     assert summary["per_target"] == []
 
 
+def test_nway_does_not_require_an_unselected_spotify_account(monkeypatch):
+    """N-way pinned its playlist source to Spotify, so a Deezer/YT Music sync
+    still built a Spotify client and died on its missing credentials."""
+
+    class Source:
+        source, name = "deezer", "Deezer"
+
+        @staticmethod
+        def list_playlists():
+            return {}
+
+    def unexpected_spotify(*args, **kwargs):
+        raise AssertionError("Spotify should not be initialized when it is not participating")
+
+    monkeypatch.setattr(runner.spotify, "client", unexpected_spotify)
+    monkeypatch.setattr(runner, "build_one", lambda *args, **kwargs: Source())
+    monkeypatch.setattr(runner, "_run_nway", lambda *args, **kwargs: [])
+
+    summary = runner.run_pass(_opts(sync_mode="nway", providers="deezer,ytmusic"))
+
+    assert summary["ok"] is True
+    assert summary["per_target"] == []
+
+
+def test_nway_keeps_spotify_as_source_when_it_participates(monkeypatch):
+    """The default must not shift for existing syncs that do include Spotify."""
+    seen = []
+
+    class Source:
+        source, name = "spotify", "Spotify"
+
+        @staticmethod
+        def list_playlists():
+            return {}
+
+    def record(provider, *args, **kwargs):
+        seen.append(provider)
+        return Source()
+
+    monkeypatch.setattr(runner.spotify, "client", lambda writable=False: object())
+    monkeypatch.setattr(runner, "build_one", record)
+    monkeypatch.setattr(runner, "_run_nway", lambda *args, **kwargs: [])
+
+    runner.run_pass(_opts(sync_mode="nway", providers="spotify,deezer"))
+
+    assert seen == ["spotify"]
+
+
+def test_nway_order_authority_falls_back_when_spotify_is_absent(monkeypatch):
+    """N-way also pinned its order authority to Spotify, so a Deezer/YT Music
+    sync failed the configuration check with an unconnected order provider.
+    """
+
+    class Peer:
+        def __init__(self, source, name):
+            self.source, self.name, self.tag = source, name, source
+            self.cache_file = "no-such-cache.json"
+
+        @staticmethod
+        def list_playlists():
+            return {}
+
+    monkeypatch.setattr(runner, "build_peers",
+                        lambda *args, **kwargs: [Peer("deezer", "Deezer"),
+                                                 Peer("ytmusic", "YouTube Music")])
+    monkeypatch.setattr(runner, "save_cache", lambda *args, **kwargs: None)
+
+    entries = runner._run_peer_reconcile(
+        _opts(sync_mode="nway", providers="deezer,ytmusic"), None, [], None,
+        label="N-way", authority_sources=None)
+
+    errors = [f["error"] for entry in entries for f in entry.get("failures", [])]
+    assert not any("order provider" in e for e in errors), errors
+
+
 def test_oneway_target_workers_have_independent_archive_connections(monkeypatch, tmp_path):
     """Parallel providers must not operate on one sqlite3.Connection.
 


### PR DESCRIPTION
An N-way sync between two providers that do not include Spotify cannot run: the pass aborts with `Missing required environment variable: SPOTIFY_CLIENT_ID`, and once that is worked around by connecting an unused Spotify account, it fails again with `order provider 'spotify' is not connected`.

## Cause

N-way pins its order authority to Spotify in two places.

`run_pass` picks the provider that enumerates the playlists a pass mirrors:

```python
source_provider = opts.sync_source if opts.sync_mode in {"oneway", "group"} else "spotify"
```

`_run_peer_reconcile` picks the provider whose track sequence is canonical:

```python
order_source = opts.sync_source if authority_sources is not None else "spotify"
```

Neither consults `opts.providers`, so a job that opted out of Spotify still builds a Spotify client for it. `run_pass` already has a graceful path for an unconfigured Spotify — it logs `Spotify skipped` and continues — but that path is guarded by `if source_provider == "spotify": raise`, which is always true in N-way mode and therefore unreachable.

One-way already handles this correctly, and its two regression tests are the direct precedent for this change.

## Change

Both sites now resolve the authority through a shared `_nway_order_authority(opts)`: Spotify whenever it participates, then the configured `sync_source` if it participates, then the first participant in `_SOURCE_ORDER`. Selecting Spotify remains the default for every existing sync, so ordering does not shift for anyone already running one.

## Tests

Three regression tests, each failing on `main`:

- an N-way pass no longer constructs a Spotify client when Spotify is not a participant
- Spotify stays the authority when it does participate, so current behaviour is pinned
- `_run_peer_reconcile` no longer rejects the pass with an unconnected order provider

Full suite: 352 passed, 1 skipped.

I also ran this on my own self-hosted instance, syncing Deezer to YouTube Music with no Spotify account connected. The pass now reports `source: Deezer` and `peers: Deezer, YouTube Music`, and reconciles normally.

## One note for review

`runner.py` imports `_SOURCE_ORDER` from `targets`, a private name. There is precedent in the file (`from .targets.base import _normalize, reconcile_state_key`), but if you would rather not widen that, I am happy to expose a small public accessor in `targets/__init__.py` instead.
