### PR TITLE
fix(auth): refresh Amazon web sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ SongMirror refreshes credentials **just in time**, not with a separate token-ref
 | **TIDAL** | A pasted web-player Bearer cannot be renewed and must be captured again after expiry. The optional developer OAuth fallback refreshes automatically when a refresh token is available. |
 | **Qobuz** | The pasted `X-User-Auth-Token` is used until Qobuz rejects it, then must be captured again. |
 | **Deezer** | The short-lived Pipe JWT renews automatically from the saved `refresh-token` before use and once after a `401/403`; rotated renewal state is persisted. |
-| **Amazon Music** | The web access token renews from the allowlisted signed-in browser cookies shortly before known expiry and once after a `401/403`; refreshed device context and rotated cookies are persisted. Logout, security changes, or server-side revocation still require a fresh capture. |
+| **Amazon Music** | The web access token renews from allowlisted browser cookies. When the one-hour Music session expires, SongMirror uses Amazon's signed-in SSO handoff to recreate it, then persists the rotated cookies and device context. Logout, security changes, or server-side revocation still require a fresh capture. |
 | **Apple Music** | The pasted Bearer and Media-User-Token cannot be renewed by SongMirror and must be captured again after rejection. |
 | **YouTube Music** | Data API OAuth refreshes automatically within 60 seconds of expiry. Browser mode attempts Google's cookie rotation whenever a sync target is built; an already-expired browser session must be exported again. |
 | **Jellyfin** | The API key has no access-token refresh cycle; replace it only if it is revoked or deleted. |
@@ -356,10 +356,10 @@ No developer approval is required for the default connector. It uses the same au
 
 1. Sign in at <https://music.amazon.com> and open DevTools → **Network**.
 2. Reload the page, filter for `config.json`, and select the signed-in request. (`pandaToken` works too when it appears, but it is not required.)
-3. Choose **Copy request headers** or **Copy as cURL**, then paste it into the renewal field.
+3. Choose **Copy request headers** or **Copy as cURL**, then paste it into the renewal field. Keep the complete `Cookie` header so the `sst-main` SSO cookie is included.
 4. Optionally copy the signed-in `config.json` **Response** into the bootstrap field; SongMirror can normally fetch that device context using the renewal session.
 
-SongMirror derives the same `AmznMusic` authorization value locally and refreshes it through `music.amazon.com/pandaToken` before expiry or once after an authentication rejection. It stores only a named allowlist of Amazon authentication/session cookies plus limited Music-client device context; analytics, experiment, AWS-console, CSRF, and other unrelated browser data are discarded. Those retained cookies are still sensitive, so keep SongMirror private on your LAN. A logout, password/security change, or Amazon-side revocation can still require one fresh capture.
+SongMirror derives the same `AmznMusic` authorization value locally and refreshes it through `music.amazon.com/pandaToken` before expiry or once after an authentication rejection. During connection it removes the one-hour Music cookies and verifies that Amazon's signed-in SSO handoff can recreate them, so **Connected** proves more than the temporary bootstrap token. It stores only a named allowlist of Amazon authentication/session cookies plus limited Music-client device context; analytics, experiment, AWS-console, CSRF, and other unrelated browser data are discarded. Those retained cookies are still sensitive, so keep SongMirror private on your LAN. A logout, password/security change, or Amazon-side revocation can still require one fresh capture.
 
 This is an unsupported first-party web-client interface and Amazon can change it without notice. The documented [Amazon Music Web API](https://developer.amazon.com/docs/music/API_web_overview.html) is still a closed beta; approved partner credentials remain an optional fallback when configured through environment variables.
 
@@ -475,7 +475,7 @@ frontend/       # React + Vite SPA (built and served by the API in production)
 - **`Missing required environment variable`** — fill in `.env` (CLI) or connect the service in the UI.
 - **TIDAL, Qobuz, or Apple reports `Expired` / `401` / `403`** — these pasted sessions have no renewable secret; capture a fresh signed-in request or token in Accounts.
 - **Deezer renewal fails** — capture a fresh `auth.deezer.com/login/renew` request (or its `refresh-token` cookie). A current Pipe Bearer alone is only a temporary bootstrap.
-- **Amazon Music renewal fails** — capture a fresh signed-in `config.json` request. The response JSON is optional; the request's allowlisted authentication cookies are the durable renewal material.
+- **Amazon Music renewal fails** — capture a fresh signed-in `config.json` request with its complete `Cookie` header. The response JSON is optional; the request must include the `sst-main` SSO cookie that recreates Amazon's one-hour Music session.
 - **YouTube Music browser mode expires** — export fresh browser request headers. For the most durable unattended setup, use Data API OAuth with an in-production consent screen.
 - **Spotify reports Expired** — sign in again at `open.spotify.com` and paste a fresh `sp_dc` cookie in Accounts.
 - **A playlist isn't syncing** — confirm it's in the sync's playlist scope and exists on the source (targets are auto-created on a real pass).

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ SongMirror refreshes credentials **just in time**, not with a separate token-ref
 | **TIDAL** | A pasted web-player Bearer cannot be renewed and must be captured again after expiry. The optional developer OAuth fallback refreshes automatically when a refresh token is available. |
 | **Qobuz** | The pasted `X-User-Auth-Token` is used until Qobuz rejects it, then must be captured again. |
 | **Deezer** | The short-lived Pipe JWT renews automatically from the saved `refresh-token` before use and once after a `401/403`; rotated renewal state is persisted. |
-| **Amazon Music** | The web access token renews from allowlisted browser cookies. When the one-hour Music session expires, SongMirror uses Amazon's signed-in SSO handoff to recreate it, then persists the rotated cookies and device context. Logout, security changes, or server-side revocation still require a fresh capture. |
+| **Amazon Music** | The web access token renews through `/pandaToken` using the captured browser user agent, referer, and allowlisted cookies. The current `POST config.json?skipToken=false` flow bootstraps device context when needed, and rotated cookies are persisted. Logout, security changes, or server-side revocation still require a fresh capture. |
 | **Apple Music** | The pasted Bearer and Media-User-Token cannot be renewed by SongMirror and must be captured again after rejection. |
 | **YouTube Music** | Data API OAuth refreshes automatically within 60 seconds of expiry. Browser mode attempts Google's cookie rotation whenever a sync target is built; an already-expired browser session must be exported again. |
 | **Jellyfin** | The API key has no access-token refresh cycle; replace it only if it is revoked or deleted. |
@@ -356,10 +356,10 @@ No developer approval is required for the default connector. It uses the same au
 
 1. Sign in at <https://music.amazon.com> and open DevTools → **Network**.
 2. Reload the page, filter for `config.json`, and select the signed-in request. (`pandaToken` works too when it appears, but it is not required.)
-3. Choose **Copy request headers** or **Copy as cURL**, then paste it into the renewal field. Keep the complete `Cookie` header so the `sst-main` SSO cookie is included.
+3. Choose **Copy request headers** or **Copy as cURL**, then paste it into the renewal field. Keep the complete `User-Agent`, `Referer`, and `Cookie` headers so SongMirror can replay the same browser context.
 4. Optionally copy the signed-in `config.json` **Response** into the bootstrap field; SongMirror can normally fetch that device context using the renewal session.
 
-SongMirror derives the same `AmznMusic` authorization value locally and refreshes it through `music.amazon.com/pandaToken` before expiry or once after an authentication rejection. During connection it removes the one-hour Music cookies and verifies that Amazon's signed-in SSO handoff can recreate them, so **Connected** proves more than the temporary bootstrap token. It stores only a named allowlist of Amazon authentication/session cookies plus limited Music-client device context; analytics, experiment, AWS-console, CSRF, and other unrelated browser data are discarded. Those retained cookies are still sensitive, so keep SongMirror private on your LAN. A logout, password/security change, or Amazon-side revocation can still require one fresh capture.
+SongMirror derives the same `AmznMusic` authorization value locally and refreshes it through `music.amazon.com/pandaToken` before expiry or once after an authentication rejection. During connection it uses the current browser-style config request when device context is needed, requires `/pandaToken` to mint an access token, and rejects the connection if Amazon revokes the Music renewal cookie. It stores only the browser user agent, language, Music referer, a named allowlist of Amazon authentication/session cookies, and limited Music-client device context; analytics, experiment, AWS-console, CSRF, and other unrelated browser data are discarded. Those retained cookies are still sensitive, so keep SongMirror private on your LAN. A logout, password/security change, or Amazon-side revocation can still require one fresh capture.
 
 This is an unsupported first-party web-client interface and Amazon can change it without notice. The documented [Amazon Music Web API](https://developer.amazon.com/docs/music/API_web_overview.html) is still a closed beta; approved partner credentials remain an optional fallback when configured through environment variables.
 
@@ -475,7 +475,7 @@ frontend/       # React + Vite SPA (built and served by the API in production)
 - **`Missing required environment variable`** — fill in `.env` (CLI) or connect the service in the UI.
 - **TIDAL, Qobuz, or Apple reports `Expired` / `401` / `403`** — these pasted sessions have no renewable secret; capture a fresh signed-in request or token in Accounts.
 - **Deezer renewal fails** — capture a fresh `auth.deezer.com/login/renew` request (or its `refresh-token` cookie). A current Pipe Bearer alone is only a temporary bootstrap.
-- **Amazon Music renewal fails** — capture a fresh signed-in `config.json` request with its complete `Cookie` header. The response JSON is optional; the request must include the `sst-main` SSO cookie that recreates Amazon's one-hour Music session.
+- **Amazon Music renewal fails** — capture a fresh signed-in `POST /config.json?skipToken=false` request with its complete `User-Agent`, `Referer`, and `Cookie` headers. The response JSON is optional.
 - **YouTube Music browser mode expires** — export fresh browser request headers. For the most durable unattended setup, use Data API OAuth with an in-production consent screen.
 - **Spotify reports Expired** — sign in again at `open.spotify.com` and paste a fresh `sp_dc` cookie in Accounts.
 - **A playlist isn't syncing** — confirm it's in the sync's playlist scope and exists on the source (targets are auto-created on a real pass).

--- a/frontend/src/components/accounts/ConnectWizardModal.tsx
+++ b/frontend/src/components/accounts/ConnectWizardModal.tsx
@@ -153,14 +153,14 @@ const CONNECT_GUIDES: Record<string, ConnectGuideContent> = {
       </>,
       <>
         Choose <strong>Copy request headers</strong> or <strong>Copy as cURL</strong>, then paste it into the renewal
-        field below.
+        field below. Keep the complete <Code>Cookie</Code> header so the <Code>sst-main</Code> SSO cookie is included.
       </>,
       <>
         Paste those <strong>request</strong> headers into the renewal field. Its <strong>Response</strong> JSON is only
         an optional bootstrap in the first field.
       </>,
     ],
-    note: 'A /pandaToken request works too when it appears, but it is not required. SongMirror keeps only a named allowlist of authentication cookies, renews internally through /pandaToken, and drops unrelated browser data.',
+    note: 'SongMirror verifies Amazon’s SSO handoff without relying on the one-hour Music cookie, then renews internally through /pandaToken. Only a named allowlist of authentication cookies is retained.',
   },
   apple: {
     intro: 'No developer account needed. Copy two tokens the Apple Music web player already uses.',
@@ -249,7 +249,7 @@ const RAW_SESSION_PLACEHOLDERS: Record<string, string> = {
   DEEZER_WEB_HEADERS: 'authorization: Bearer …\n—or paste Copy as cURL—',
   DEEZER_REFRESH_TOKEN: 'Cookie: refresh-token=…\n—or paste the auth.deezer.com request as cURL—',
   AMAZON_MUSIC_WEB_HEADERS: '{\n  "accessToken": "…",\n  "deviceId": "…",\n  "deviceType": "…"\n}',
-  AMAZON_MUSIC_RENEWAL_REQUEST: 'Cookie: at-main-music=…; session-id=…\n—or paste config.json Copy as cURL—',
+  AMAZON_MUSIC_RENEWAL_REQUEST: 'Cookie: at-main-music=…; sst-main=…; session-id=…\n—or paste config.json Copy as cURL—',
 }
 
 /** Parses a raw "copy request headers" block (case-insensitive, line-based

--- a/frontend/src/components/accounts/ConnectWizardModal.tsx
+++ b/frontend/src/components/accounts/ConnectWizardModal.tsx
@@ -153,14 +153,14 @@ const CONNECT_GUIDES: Record<string, ConnectGuideContent> = {
       </>,
       <>
         Choose <strong>Copy request headers</strong> or <strong>Copy as cURL</strong>, then paste it into the renewal
-        field below. Keep the complete <Code>Cookie</Code> header so the <Code>sst-main</Code> SSO cookie is included.
+        field below. Keep the complete <Code>User-Agent</Code>, <Code>Referer</Code>, and <Code>Cookie</Code> headers.
       </>,
       <>
         Paste those <strong>request</strong> headers into the renewal field. Its <strong>Response</strong> JSON is only
         an optional bootstrap in the first field.
       </>,
     ],
-    note: 'SongMirror verifies Amazon’s SSO handoff without relying on the one-hour Music cookie, then renews internally through /pandaToken. Only a named allowlist of authentication cookies is retained.',
+    note: 'SongMirror replays the captured browser context against /pandaToken and rejects a connection if Amazon revokes its Music renewal cookie. Only three safe request headers and a named allowlist of authentication cookies are retained.',
   },
   apple: {
     intro: 'No developer account needed. Copy two tokens the Apple Music web player already uses.',
@@ -249,7 +249,7 @@ const RAW_SESSION_PLACEHOLDERS: Record<string, string> = {
   DEEZER_WEB_HEADERS: 'authorization: Bearer …\n—or paste Copy as cURL—',
   DEEZER_REFRESH_TOKEN: 'Cookie: refresh-token=…\n—or paste the auth.deezer.com request as cURL—',
   AMAZON_MUSIC_WEB_HEADERS: '{\n  "accessToken": "…",\n  "deviceId": "…",\n  "deviceType": "…"\n}',
-  AMAZON_MUSIC_RENEWAL_REQUEST: 'Cookie: at-main-music=…; sst-main=…; session-id=…\n—or paste config.json Copy as cURL—',
+  AMAZON_MUSIC_RENEWAL_REQUEST: 'User-Agent: Mozilla/5.0 …\nCookie: at-main-music=…; session-id=…\n—or paste config.json Copy as cURL—',
 }
 
 /** Parses a raw "copy request headers" block (case-insensitive, line-based

--- a/songmirror/amazon_music_web.py
+++ b/songmirror/amazon_music_web.py
@@ -3,7 +3,8 @@
 Amazon's documented Music Web API is a closed beta.  The consumer web player
 uses a separate GraphQL endpoint, authenticated by short-lived request headers
 from the signed-in browser.  The web player renews those headers through its
-same-origin ``/pandaToken`` route.  This module persists only the minimal
+same-origin ``/pandaToken`` route and recreates expired Music sessions through
+Amazon's signed-in SSO handoff.  This module persists only the minimal
 GraphQL context plus a named allowlist of cookies needed by that renewal route;
 analytics, experiment, AWS-console, and other unrelated cookies are discarded.
 
@@ -18,6 +19,7 @@ import json
 import random
 import re
 import time
+from urllib.parse import urlsplit
 
 import requests
 
@@ -27,7 +29,14 @@ from .oauth import read_token, write_token
 ENDPOINT = "https://gql.music.amazon.dev"
 CONFIG_ENDPOINT = "https://music.amazon.com/config.json"
 PANDA_TOKEN_ENDPOINT = "https://music.amazon.com/pandaToken"
+FORCE_SIGN_IN_ENDPOINT = "https://music.amazon.com/forceSignIn"
+MUSIC_HOME_URL = "https://music.amazon.com/"
 DEFAULT_WEB_SESSION_FILE = "data/amazon_music_web_session.json"
+
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+)
 
 # Public identifier embedded in Amazon Music's first-party Firefly web bundle.
 # It identifies the web client; it is not a customer secret.  The signed-in
@@ -66,13 +75,24 @@ _ALLOWED_RENEWAL_COOKIES = {
     "session-id",
     "session-id-time",
     "session-token",
+    "sso-state-main",
+    "sst-main",
     "ubid-main",
     "x-main",
 }
 
+# These cookies belong to the Music web session and expire with the one-hour
+# access token.  They must not be allowed to prove that the retail SSO session
+# can recreate Music authentication during a new connection check.
+_SHORT_LIVED_MUSIC_COOKIES = {"am-token", "at-main-music", "sid"}
+
 
 class AmazonMusicWebAuthError(RuntimeError):
     """The pasted web-player session is missing, expired, or rejected."""
+
+
+class _AmazonMusicRenewalRejected(AmazonMusicWebAuthError):
+    """A token endpoint rejected cookies that may still be recoverable via SSO."""
 
 
 def _header_pairs(raw: str):
@@ -279,10 +299,12 @@ class AmazonMusicWebClient:
         endpoint: str = ENDPOINT,
         config_endpoint: str = CONFIG_ENDPOINT,
         panda_token_endpoint: str = PANDA_TOKEN_ENDPOINT,
+        force_sign_in_endpoint: str = FORCE_SIGN_IN_ENDPOINT,
     ):
         self.endpoint = endpoint
         self.config_endpoint = config_endpoint
         self.panda_token_endpoint = panda_token_endpoint
+        self.force_sign_in_endpoint = force_sign_in_endpoint
         self.session = session or requests.Session()
         self._token_file = str(token_file or "")
 
@@ -311,6 +333,7 @@ class AmazonMusicWebClient:
             if prefer_persisted and stored_cookies
             else supplied_cookies or stored_cookies
         )
+        self._seed_session_cookies()
 
         if not self.headers and not self.renewal_cookies:
             raise ValueError(
@@ -335,19 +358,93 @@ class AmazonMusicWebClient:
             raise AmazonMusicWebAuthError(f"Amazon Music {label} returned an invalid response.")
         return body
 
-    def _merge_response_cookies(self, response) -> None:
-        jar = getattr(response, "cookies", None)
+    @staticmethod
+    def _cookie_domain(name: str) -> str:
+        return ".music.amazon.com" if name in _SHORT_LIVED_MUSIC_COOKIES else ".amazon.com"
+
+    def _session_cookie_jar(self):
+        jar = getattr(self.session, "cookies", None)
+        return jar if hasattr(jar, "set") and hasattr(jar, "clear") else None
+
+    @staticmethod
+    def _clear_jar_cookie(jar, cookie) -> None:
+        try:
+            jar.clear(domain=cookie.domain, path=cookie.path, name=cookie.name)
+        except (KeyError, ValueError):
+            pass
+
+    def _seed_session_cookies(self) -> None:
+        jar = self._session_cookie_jar()
         if jar is None:
             return
-        try:
-            values = jar.get_dict()
-        except AttributeError:
+        for cookie in list(jar):
+            if str(cookie.name).casefold() in _ALLOWED_RENEWAL_COOKIES:
+                self._clear_jar_cookie(jar, cookie)
+        for name, value in self.renewal_cookies.items():
+            jar.set(
+                name,
+                value,
+                domain=self._cookie_domain(name),
+                path="/",
+                secure=True,
+            )
+
+    def _sync_response_cookies(self, response) -> None:
+        session_jar = self._session_cookie_jar()
+        if session_jar is not None:
+            refreshed: dict[str, str] = {}
+            for cookie in session_jar:
+                name = str(cookie.name).casefold()
+                value = str(cookie.value or "").strip()
+                if name not in _ALLOWED_RENEWAL_COOKIES or not value:
+                    continue
+                expected_domain = self._cookie_domain(name).lstrip(".")
+                actual_domain = str(cookie.domain or "").lstrip(".").casefold()
+                # Redirect targets must never be able to smuggle a familiar
+                # cookie name into persisted state and have it widened onto an
+                # Amazon domain the next time the session jar is seeded.
+                if actual_domain != expected_domain:
+                    continue
+                refreshed[name] = value
+            self.renewal_cookies = refreshed
+            return
+
+        # Lightweight test doubles may not expose a session jar. Preserve the
+        # previous response-cookie fallback for those callers, including empty
+        # values that explicitly revoke an existing cookie.
+        for item in [*getattr(response, "history", []), response]:
+            jar = getattr(item, "cookies", None)
+            if jar is None:
+                continue
             try:
-                values = dict(jar)
-            except (TypeError, ValueError):
-                return
-        for name, value in values.items():
-            _add_cookie(self.renewal_cookies, name, value)
+                values = jar.get_dict()
+            except AttributeError:
+                try:
+                    values = dict(jar)
+                except (TypeError, ValueError):
+                    continue
+            for name, value in values.items():
+                key = str(name).strip().casefold()
+                if key not in _ALLOWED_RENEWAL_COOKIES:
+                    continue
+                if value is None or not str(value).strip():
+                    self.renewal_cookies.pop(key, None)
+                else:
+                    _add_cookie(self.renewal_cookies, key, value)
+
+    def _cookie_kwargs(self) -> dict:
+        if self._session_cookie_jar() is not None:
+            return {}
+        return {"cookies": self.renewal_cookies}
+
+    def _drop_short_lived_music_cookies(self) -> None:
+        jar = self._session_cookie_jar()
+        for name in _SHORT_LIVED_MUSIC_COOKIES:
+            self.renewal_cookies.pop(name, None)
+            if jar is not None:
+                for cookie in list(jar):
+                    if str(cookie.name).casefold() == name:
+                        self._clear_jar_cookie(jar, cookie)
 
     def _persist_session(self) -> None:
         if not self._token_file:
@@ -370,7 +467,111 @@ class AmazonMusicWebClient:
         except (ValueError, TypeError, json.JSONDecodeError):
             return {}
 
-    def _renew(self, *, persist: bool = True, require_panda_token: bool = False) -> None:
+    @staticmethod
+    def _api_browser_headers() -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Origin": MUSIC_HOME_URL.rstrip("/"),
+            "Referer": MUSIC_HOME_URL,
+            "User-Agent": _BROWSER_USER_AGENT,
+        }
+
+    @staticmethod
+    def _navigation_browser_headers() -> dict[str, str]:
+        return {
+            "Accept": (
+                "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                "image/avif,image/webp,*/*;q=0.8"
+            ),
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": MUSIC_HOME_URL,
+            "User-Agent": _BROWSER_USER_AGENT,
+        }
+
+    def _refresh_music_session(self) -> None:
+        if not self.renewal_cookies.get("sst-main"):
+            raise AmazonMusicWebAuthError(
+                "Amazon Music renewal is missing the sst-main SSO cookie; reconnect and copy "
+                "the complete signed-in config.json request headers or cURL."
+            )
+
+        # Prove the retail SSO state can recreate Music authentication instead
+        # of letting a still-valid one-hour Music cookie satisfy validation.
+        self._drop_short_lived_music_cookies()
+        try:
+            response = self.session.get(
+                self.force_sign_in_endpoint,
+                headers=self._navigation_browser_headers(),
+                params={"webplayerDetailPagePath": MUSIC_HOME_URL},
+                timeout=REQUEST_TIMEOUT,
+                allow_redirects=True,
+                **self._cookie_kwargs(),
+            )
+        except requests.RequestException as exc:
+            raise AmazonMusicWebAuthError(
+                f"Amazon Music SSO renewal failed ({exc!r})."
+            ) from exc
+        self._sync_response_cookies(response)
+
+        final_host = str(urlsplit(str(getattr(response, "url", "") or "")).hostname or "")
+        if final_host.casefold() != "music.amazon.com":
+            raise AmazonMusicWebAuthError(
+                "Amazon Music SSO renewal reached the sign-in page; reconnect and copy the "
+                "complete signed-in config.json request headers or cURL."
+            )
+        if response.status_code in (401, 403):
+            raise AmazonMusicWebAuthError(
+                "Amazon Music SSO renewal was rejected; reconnect with a fresh signed-in request."
+            )
+        response.raise_for_status()
+
+    def _request_renewal(self) -> tuple[dict, dict]:
+        browser_headers = self._api_browser_headers()
+        try:
+            config_response = self.session.get(
+                self.config_endpoint,
+                headers=browser_headers,
+                timeout=REQUEST_TIMEOUT,
+                **self._cookie_kwargs(),
+            )
+        except requests.RequestException as exc:
+            raise AmazonMusicWebAuthError(f"Amazon Music config renewal failed ({exc!r}).") from exc
+        self._sync_response_cookies(config_response)
+        if config_response.status_code in (401, 403):
+            raise _AmazonMusicRenewalRejected(
+                "Amazon Music renewal session expired or was revoked; reconnect with a fresh "
+                "config.json or /pandaToken request."
+            )
+        config_response.raise_for_status()
+        config = self._response_json(config_response, "config renewal")
+
+        try:
+            token_response = self.session.get(
+                self.panda_token_endpoint,
+                headers=browser_headers,
+                timeout=REQUEST_TIMEOUT,
+                **self._cookie_kwargs(),
+            )
+        except requests.RequestException as exc:
+            raise AmazonMusicWebAuthError(f"Amazon Music token renewal failed ({exc!r}).") from exc
+        self._sync_response_cookies(token_response)
+        if token_response.status_code in (400, 401, 403):
+            raise _AmazonMusicRenewalRejected(
+                "Amazon Music renewal session expired or was revoked; reconnect with a fresh "
+                "config.json or /pandaToken request."
+            )
+        token_response.raise_for_status()
+        token = self._response_json(token_response, "token renewal")
+        return config, token
+
+    def _renew(
+        self,
+        *,
+        persist: bool = True,
+        require_panda_token: bool = False,
+        prove_sso: bool = False,
+    ) -> None:
         if not self.renewal_cookies:
             raise AmazonMusicWebAuthError(
                 "Amazon Music access token expired; reconnect once with a signed-in config.json or "
@@ -378,51 +579,48 @@ class AmazonMusicWebClient:
                 "to enable automatic renewal."
             )
 
-        browser_headers = {
-            "Accept": "application/json",
-            "Origin": "https://music.amazon.com",
-            "Referer": "https://music.amazon.com/",
-        }
+        used_sso = prove_sso
+        if used_sso:
+            self._refresh_music_session()
         try:
-            config_response = self.session.get(
-                self.config_endpoint,
-                headers=browser_headers,
-                cookies=self.renewal_cookies,
-                timeout=REQUEST_TIMEOUT,
-            )
-        except requests.RequestException as exc:
-            raise AmazonMusicWebAuthError(f"Amazon Music config renewal failed ({exc!r}).") from exc
-        if config_response.status_code in (401, 403):
-            raise AmazonMusicWebAuthError(
-                "Amazon Music renewal session expired or was revoked; reconnect with a fresh "
-                "config.json or /pandaToken request."
-            )
-        config_response.raise_for_status()
-        config = self._response_json(config_response, "config renewal")
-        self._merge_response_cookies(config_response)
-
-        try:
-            token_response = self.session.get(
-                self.panda_token_endpoint,
-                headers=browser_headers,
-                cookies=self.renewal_cookies,
-                timeout=REQUEST_TIMEOUT,
-            )
-        except requests.RequestException as exc:
-            raise AmazonMusicWebAuthError(f"Amazon Music token renewal failed ({exc!r}).") from exc
-        if token_response.status_code in (400, 401, 403):
-            raise AmazonMusicWebAuthError(
-                "Amazon Music renewal session expired or was revoked; reconnect with a fresh "
-                "config.json or /pandaToken request."
-            )
-        token_response.raise_for_status()
-        token = self._response_json(token_response, "token renewal")
-        self._merge_response_cookies(token_response)
+            config, token = self._request_renewal()
+        except _AmazonMusicRenewalRejected as exc:
+            if used_sso:
+                raise AmazonMusicWebAuthError(
+                    "Amazon Music rejected token renewal after the SSO handoff; reconnect with "
+                    "a fresh signed-in request."
+                ) from exc
+            self._refresh_music_session()
+            used_sso = True
+            try:
+                config, token = self._request_renewal()
+            except _AmazonMusicRenewalRejected as retry_exc:
+                raise AmazonMusicWebAuthError(
+                    "Amazon Music rejected token renewal after the SSO handoff; reconnect with "
+                    "a fresh signed-in request."
+                ) from retry_exc
 
         panda_access_token = str(
             token.get("accessToken") or token.get("access_token") or ""
         ).strip()
         config_access_token = str(config.get("accessToken") or "").strip()
+        if not panda_access_token and not config_access_token and not used_sso:
+            # The one-hour Music cookies have expired. Use Amazon's own web
+            # sign-in handoff to recreate them from the durable SSO session,
+            # then retry the token endpoints once.
+            self._refresh_music_session()
+            used_sso = True
+            try:
+                config, token = self._request_renewal()
+            except _AmazonMusicRenewalRejected as exc:
+                raise AmazonMusicWebAuthError(
+                    "Amazon Music rejected token renewal after the SSO handoff; reconnect with "
+                    "a fresh signed-in request."
+                ) from exc
+            panda_access_token = str(
+                token.get("accessToken") or token.get("access_token") or ""
+            ).strip()
+            config_access_token = str(config.get("accessToken") or "").strip()
         access_token = (
             panda_access_token
             if require_panda_token
@@ -437,7 +635,8 @@ class AmazonMusicWebClient:
         ).strip()
         if not access_token:
             raise AmazonMusicWebAuthError(
-                "Amazon Music /pandaToken did not return an access token; reconnect after signing in."
+                "Amazon Music /pandaToken did not return an access token after SSO renewal; "
+                "reconnect after signing in."
             )
         if not device_id or not device_type:
             raise AmazonMusicWebAuthError(
@@ -577,7 +776,7 @@ class AmazonMusicWebClient:
             # response and the signed-in GraphQL identity have been proven.
             # Disabling execute's normal retry also prevents a hidden second
             # renewal from persisting before that identity check completes.
-            self._renew(persist=False, require_panda_token=True)
+            self._renew(persist=False, require_panda_token=True, prove_sso=True)
         data = self.execute(
             "SongMirrorAmazonSession",
             SESSION_QUERY,

--- a/songmirror/amazon_music_web.py
+++ b/songmirror/amazon_music_web.py
@@ -3,8 +3,7 @@
 Amazon's documented Music Web API is a closed beta.  The consumer web player
 uses a separate GraphQL endpoint, authenticated by short-lived request headers
 from the signed-in browser.  The web player renews those headers through its
-same-origin ``/pandaToken`` route and recreates expired Music sessions through
-Amazon's signed-in SSO handoff.  This module persists only the minimal
+same-origin ``/pandaToken`` route.  This module persists only the minimal
 GraphQL context plus a named allowlist of cookies needed by that renewal route;
 analytics, experiment, AWS-console, and other unrelated cookies are discarded.
 
@@ -29,11 +28,10 @@ from .oauth import read_token, write_token
 ENDPOINT = "https://gql.music.amazon.dev"
 CONFIG_ENDPOINT = "https://music.amazon.com/config.json"
 PANDA_TOKEN_ENDPOINT = "https://music.amazon.com/pandaToken"
-FORCE_SIGN_IN_ENDPOINT = "https://music.amazon.com/forceSignIn"
 MUSIC_HOME_URL = "https://music.amazon.com/"
 DEFAULT_WEB_SESSION_FILE = "data/amazon_music_web_session.json"
 
-_BROWSER_USER_AGENT = (
+_DEFAULT_BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
 )
@@ -81,10 +79,10 @@ _ALLOWED_RENEWAL_COOKIES = {
     "x-main",
 }
 
-# These cookies belong to the Music web session and expire with the one-hour
-# access token.  They must not be allowed to prove that the retail SSO session
-# can recreate Music authentication during a new connection check.
-_SHORT_LIVED_MUSIC_COOKIES = {"am-token", "at-main-music", "sid"}
+# These cookies are scoped to music.amazon.com; the remaining allowlisted
+# cookies use Amazon's parent domain so redirects cannot widen their scope.
+_MUSIC_SCOPED_COOKIES = {"am-token", "at-main-music", "sid"}
+_ALLOWED_RENEWAL_BROWSER_HEADERS = {"accept-language", "referer", "user-agent"}
 
 
 class AmazonMusicWebAuthError(RuntimeError):
@@ -92,7 +90,7 @@ class AmazonMusicWebAuthError(RuntimeError):
 
 
 class _AmazonMusicRenewalRejected(AmazonMusicWebAuthError):
-    """A token endpoint rejected cookies that may still be recoverable via SSO."""
+    """A token endpoint rejected cookies that may recover after config bootstrap."""
 
 
 def _header_pairs(raw: str):
@@ -278,6 +276,54 @@ def serialize_renewal_cookies(raw: str) -> str:
     return json.dumps(parse_renewal_cookies(raw), separators=(",", ":"), sort_keys=True)
 
 
+def _add_renewal_browser_header(out: dict[str, str], name, value) -> None:
+    key = str(name).strip().casefold()
+    if key not in _ALLOWED_RENEWAL_BROWSER_HEADERS or value is None:
+        return
+    normalized = str(value).strip()
+    if not normalized:
+        return
+    if any(char in normalized for char in "\r\n"):
+        raise ValueError(f"{key} request header contains a line break")
+    if len(normalized) > 1024:
+        raise ValueError(f"{key} request header is too long")
+    if key == "referer":
+        parsed = urlsplit(normalized)
+        if parsed.scheme != "https" or parsed.hostname != "music.amazon.com":
+            raise ValueError("Amazon Music referer must use https://music.amazon.com")
+    out[key] = normalized
+
+
+def parse_renewal_browser_headers(raw: str) -> dict[str, str]:
+    """Extract non-secret browser context needed to replay Music requests."""
+
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    out: dict[str, str] = {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        parsed = None
+    if isinstance(parsed, dict):
+        nested = parsed.get("browser_headers")
+        if isinstance(nested, dict):
+            for name, value in nested.items():
+                _add_renewal_browser_header(out, name, value)
+    for name, value in _header_pairs(raw):
+        _add_renewal_browser_header(out, name, value)
+    return out
+
+
+def serialize_renewal_request(raw: str) -> str:
+    payload: dict[str, dict[str, str]] = {
+        "renewal_cookies": parse_renewal_cookies(raw),
+    }
+    browser_headers = parse_renewal_browser_headers(raw)
+    if browser_headers:
+        payload["browser_headers"] = browser_headers
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
 SESSION_QUERY = """
 query SongMirrorAmazonSession {
   user { id }
@@ -299,12 +345,10 @@ class AmazonMusicWebClient:
         endpoint: str = ENDPOINT,
         config_endpoint: str = CONFIG_ENDPOINT,
         panda_token_endpoint: str = PANDA_TOKEN_ENDPOINT,
-        force_sign_in_endpoint: str = FORCE_SIGN_IN_ENDPOINT,
     ):
         self.endpoint = endpoint
         self.config_endpoint = config_endpoint
         self.panda_token_endpoint = panda_token_endpoint
-        self.force_sign_in_endpoint = force_sign_in_endpoint
         self.session = session or requests.Session()
         self._token_file = str(token_file or "")
 
@@ -333,6 +377,21 @@ class AmazonMusicWebClient:
             if prefer_persisted and stored_cookies
             else supplied_cookies or stored_cookies
         )
+        supplied_browser_headers = parse_renewal_browser_headers(renewal_request)
+        stored_browser_headers = persisted.get("browser_headers")
+        if not isinstance(stored_browser_headers, dict):
+            stored_browser_headers = {}
+        else:
+            stored_browser_headers = parse_renewal_browser_headers(
+                json.dumps({"browser_headers": stored_browser_headers})
+            )
+        self.browser_headers = (
+            stored_browser_headers
+            if prefer_persisted and stored_browser_headers
+            else supplied_browser_headers or stored_browser_headers
+        )
+        self.browser_headers.setdefault("user-agent", _DEFAULT_BROWSER_USER_AGENT)
+        self.browser_headers.setdefault("referer", MUSIC_HOME_URL)
         self._seed_session_cookies()
 
         if not self.headers and not self.renewal_cookies:
@@ -360,7 +419,7 @@ class AmazonMusicWebClient:
 
     @staticmethod
     def _cookie_domain(name: str) -> str:
-        return ".music.amazon.com" if name in _SHORT_LIVED_MUSIC_COOKIES else ".amazon.com"
+        return ".music.amazon.com" if name in _MUSIC_SCOPED_COOKIES else ".amazon.com"
 
     def _session_cookie_jar(self):
         jar = getattr(self.session, "cookies", None)
@@ -437,21 +496,13 @@ class AmazonMusicWebClient:
             return {}
         return {"cookies": self.renewal_cookies}
 
-    def _drop_short_lived_music_cookies(self) -> None:
-        jar = self._session_cookie_jar()
-        for name in _SHORT_LIVED_MUSIC_COOKIES:
-            self.renewal_cookies.pop(name, None)
-            if jar is not None:
-                for cookie in list(jar):
-                    if str(cookie.name).casefold() == name:
-                        self._clear_jar_cookie(jar, cookie)
-
     def _persist_session(self) -> None:
         if not self._token_file:
             return
         state = {
             "headers": self.headers,
             "renewal_cookies": self.renewal_cookies,
+            "browser_headers": self.browser_headers,
         }
         if self._expires_at:
             state["expires_at"] = self._expires_at
@@ -467,110 +518,59 @@ class AmazonMusicWebClient:
         except (ValueError, TypeError, json.JSONDecodeError):
             return {}
 
-    @staticmethod
-    def _api_browser_headers() -> dict[str, str]:
-        return {
-            "Accept": "application/json",
-            "Accept-Language": "en-US,en;q=0.9",
+    def _api_browser_headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "*/*",
             "Origin": MUSIC_HOME_URL.rstrip("/"),
-            "Referer": MUSIC_HOME_URL,
-            "User-Agent": _BROWSER_USER_AGENT,
+            "Referer": self.browser_headers.get("referer", MUSIC_HOME_URL),
+            "User-Agent": self.browser_headers.get("user-agent", _DEFAULT_BROWSER_USER_AGENT),
         }
+        if self.browser_headers.get("accept-language"):
+            headers["Accept-Language"] = self.browser_headers["accept-language"]
+        return headers
 
-    @staticmethod
-    def _navigation_browser_headers() -> dict[str, str]:
-        return {
-            "Accept": (
-                "text/html,application/xhtml+xml,application/xml;q=0.9,"
-                "image/avif,image/webp,*/*;q=0.8"
-            ),
-            "Accept-Language": "en-US,en;q=0.9",
-            "Referer": MUSIC_HOME_URL,
-            "User-Agent": _BROWSER_USER_AGENT,
-        }
-
-    def _refresh_music_session(self) -> None:
-        if not self.renewal_cookies.get("sst-main"):
-            raise AmazonMusicWebAuthError(
-                "Amazon Music renewal is missing the sst-main SSO cookie; reconnect and copy "
-                "the complete signed-in config.json request headers or cURL."
-            )
-
-        # Prove the retail SSO state can recreate Music authentication instead
-        # of letting a still-valid one-hour Music cookie satisfy validation.
-        self._drop_short_lived_music_cookies()
+    def _request_config(self) -> dict:
         try:
-            response = self.session.get(
-                self.force_sign_in_endpoint,
-                headers=self._navigation_browser_headers(),
-                params={"webplayerDetailPagePath": MUSIC_HOME_URL},
-                timeout=REQUEST_TIMEOUT,
-                allow_redirects=True,
-                **self._cookie_kwargs(),
-            )
-        except requests.RequestException as exc:
-            raise AmazonMusicWebAuthError(
-                f"Amazon Music SSO renewal failed ({exc!r})."
-            ) from exc
-        self._sync_response_cookies(response)
-
-        final_host = str(urlsplit(str(getattr(response, "url", "") or "")).hostname or "")
-        if final_host.casefold() != "music.amazon.com":
-            raise AmazonMusicWebAuthError(
-                "Amazon Music SSO renewal reached the sign-in page; reconnect and copy the "
-                "complete signed-in config.json request headers or cURL."
-            )
-        if response.status_code in (401, 403):
-            raise AmazonMusicWebAuthError(
-                "Amazon Music SSO renewal was rejected; reconnect with a fresh signed-in request."
-            )
-        response.raise_for_status()
-
-    def _request_renewal(self) -> tuple[dict, dict]:
-        browser_headers = self._api_browser_headers()
-        try:
-            config_response = self.session.get(
+            response = self.session.post(
                 self.config_endpoint,
-                headers=browser_headers,
+                params={"skipToken": "false"},
+                headers=self._api_browser_headers(),
                 timeout=REQUEST_TIMEOUT,
                 **self._cookie_kwargs(),
             )
         except requests.RequestException as exc:
             raise AmazonMusicWebAuthError(f"Amazon Music config renewal failed ({exc!r}).") from exc
-        self._sync_response_cookies(config_response)
-        if config_response.status_code in (401, 403):
+        self._sync_response_cookies(response)
+        if response.status_code in (400, 401, 403):
             raise _AmazonMusicRenewalRejected(
-                "Amazon Music renewal session expired or was revoked; reconnect with a fresh "
-                "config.json or /pandaToken request."
+                "Amazon Music config renewal rejected the copied browser session."
             )
-        config_response.raise_for_status()
-        config = self._response_json(config_response, "config renewal")
+        response.raise_for_status()
+        return self._response_json(response, "config renewal")
 
+    def _request_panda_token(self) -> dict:
         try:
-            token_response = self.session.get(
+            response = self.session.get(
                 self.panda_token_endpoint,
-                headers=browser_headers,
+                headers=self._api_browser_headers(),
                 timeout=REQUEST_TIMEOUT,
                 **self._cookie_kwargs(),
             )
         except requests.RequestException as exc:
             raise AmazonMusicWebAuthError(f"Amazon Music token renewal failed ({exc!r}).") from exc
-        self._sync_response_cookies(token_response)
-        if token_response.status_code in (400, 401, 403):
+        self._sync_response_cookies(response)
+        if response.status_code in (400, 401, 403):
             raise _AmazonMusicRenewalRejected(
-                "Amazon Music renewal session expired or was revoked; reconnect with a fresh "
-                "config.json or /pandaToken request."
+                "Amazon Music /pandaToken rejected the copied browser session."
             )
-        token_response.raise_for_status()
-        token = self._response_json(token_response, "token renewal")
-        return config, token
+        response.raise_for_status()
+        return self._response_json(response, "token renewal")
 
     def _renew(
         self,
         *,
         persist: bool = True,
         require_panda_token: bool = False,
-        prove_sso: bool = False,
     ) -> None:
         if not self.renewal_cookies:
             raise AmazonMusicWebAuthError(
@@ -579,43 +579,57 @@ class AmazonMusicWebClient:
                 "to enable automatic renewal."
             )
 
-        used_sso = prove_sso
-        if used_sso:
-            self._refresh_music_session()
-        try:
-            config, token = self._request_renewal()
-        except _AmazonMusicRenewalRejected as exc:
-            if used_sso:
-                raise AmazonMusicWebAuthError(
-                    "Amazon Music rejected token renewal after the SSO handoff; reconnect with "
-                    "a fresh signed-in request."
-                ) from exc
-            self._refresh_music_session()
-            used_sso = True
+        current = self._authorization_context(self.headers)
+        has_device_context = bool(
+            (self.headers.get("device-id") or current.get("deviceId"))
+            and (self.headers.get("device-type") or current.get("deviceType"))
+        )
+        config: dict = {}
+        config_requested = False
+        # A newly connected session must prove the config bootstrap as well as
+        # panda-token minting.  Otherwise a still-live one-hour Music cookie
+        # could satisfy validation while the recovery path is already broken.
+        if require_panda_token or not has_device_context:
             try:
-                config, token = self._request_renewal()
+                config = self._request_config()
+            except _AmazonMusicRenewalRejected as exc:
+                raise AmazonMusicWebAuthError(
+                    "Amazon Music rejected the signed-in config.json request; reconnect with "
+                    "a fresh complete request."
+                ) from exc
+            config_requested = True
+
+        try:
+            token = self._request_panda_token()
+        except _AmazonMusicRenewalRejected as exc:
+            if config_requested:
+                raise AmazonMusicWebAuthError(
+                    "Amazon Music rejected /pandaToken after replaying the signed-in browser "
+                    "context; reconnect with a fresh complete config.json request."
+                ) from exc
+            try:
+                config = self._request_config()
+                config_requested = True
+                token = self._request_panda_token()
             except _AmazonMusicRenewalRejected as retry_exc:
                 raise AmazonMusicWebAuthError(
-                    "Amazon Music rejected token renewal after the SSO handoff; reconnect with "
-                    "a fresh signed-in request."
+                    "Amazon Music rejected renewal after replaying the signed-in browser context; "
+                    "reconnect with a fresh complete config.json request."
                 ) from retry_exc
 
         panda_access_token = str(
             token.get("accessToken") or token.get("access_token") or ""
         ).strip()
         config_access_token = str(config.get("accessToken") or "").strip()
-        if not panda_access_token and not config_access_token and not used_sso:
-            # The one-hour Music cookies have expired. Use Amazon's own web
-            # sign-in handoff to recreate them from the durable SSO session,
-            # then retry the token endpoints once.
-            self._refresh_music_session()
-            used_sso = True
+        if not panda_access_token and not config_requested:
             try:
-                config, token = self._request_renewal()
+                config = self._request_config()
+                config_requested = True
+                token = self._request_panda_token()
             except _AmazonMusicRenewalRejected as exc:
                 raise AmazonMusicWebAuthError(
-                    "Amazon Music rejected token renewal after the SSO handoff; reconnect with "
-                    "a fresh signed-in request."
+                    "Amazon Music rejected renewal after replaying the signed-in browser context; "
+                    "reconnect with a fresh complete config.json request."
                 ) from exc
             panda_access_token = str(
                 token.get("accessToken") or token.get("access_token") or ""
@@ -626,7 +640,6 @@ class AmazonMusicWebClient:
             if require_panda_token
             else panda_access_token or config_access_token
         )
-        current = self._authorization_context(self.headers)
         device_id = str(
             config.get("deviceId") or self.headers.get("device-id") or current.get("deviceId") or ""
         ).strip()
@@ -635,8 +648,13 @@ class AmazonMusicWebClient:
         ).strip()
         if not access_token:
             raise AmazonMusicWebAuthError(
-                "Amazon Music /pandaToken did not return an access token after SSO renewal; "
-                "reconnect after signing in."
+                "Amazon Music /pandaToken did not return an access token with the copied browser "
+                "context; reconnect after signing in."
+            )
+        if require_panda_token and not self.renewal_cookies.get("at-main-music"):
+            raise AmazonMusicWebAuthError(
+                "Amazon Music revoked the Music renewal cookie during validation; reconnect and "
+                "copy the complete config.json request from the same signed-in browser."
             )
         if not device_id or not device_type:
             raise AmazonMusicWebAuthError(
@@ -664,7 +682,14 @@ class AmazonMusicWebClient:
         return json.dumps(self.headers, separators=(",", ":"), sort_keys=True)
 
     def serialized_renewal(self) -> str:
-        return json.dumps(self.renewal_cookies, separators=(",", ":"), sort_keys=True)
+        return json.dumps(
+            {
+                "browser_headers": self.browser_headers,
+                "renewal_cookies": self.renewal_cookies,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
 
     @staticmethod
     def _auth_error(message: str) -> bool:
@@ -768,15 +793,15 @@ class AmazonMusicWebClient:
 
     def validate(self, *, require_renewal: bool = False) -> None:
         if require_renewal:
-            # A fresh config.json response proves only that its one-hour
-            # bootstrap token works. Exercise the cookie-authenticated renewal
-            # route before accepting a newly pasted session so "connected"
-            # also means SongMirror can survive that bootstrap expiring.
+            # Exercise the same browser-context config/panda flow used by the
+            # web player before accepting a newly pasted session. The session
+            # jar must retain its Music renewal cookie and mint a distinct
+            # panda token before "connected" is reported.
             # Keep the candidate session off disk until both the panda-token
             # response and the signed-in GraphQL identity have been proven.
             # Disabling execute's normal retry also prevents a hidden second
             # renewal from persisting before that identity check completes.
-            self._renew(persist=False, require_panda_token=True, prove_sso=True)
+            self._renew(persist=False, require_panda_token=True)
         data = self.execute(
             "SongMirrorAmazonSession",
             SESSION_QUERY,

--- a/songmirror/services/accounts/amazon_music.py
+++ b/songmirror/services/accounts/amazon_music.py
@@ -29,9 +29,12 @@ class AmazonMusicConnector(Connector):
         ),
         Field(
             "AMAZON_MUSIC_RENEWAL_REQUEST",
-            "Signed-in renewal request",
+            "Signed-in request with SSO cookies",
             secret=True,
-            help="Copy a signed-in config.json or /pandaToken request's headers or cURL",
+            help=(
+                "Copy the complete headers or cURL for a signed-in config.json request; "
+                "SongMirror verifies that its sst-main cookie can recreate the Music session"
+            ),
         ),
     ]
 

--- a/songmirror/services/accounts/amazon_music.py
+++ b/songmirror/services/accounts/amazon_music.py
@@ -6,7 +6,7 @@ from ...amazon_music_web import (
     DEFAULT_WEB_SESSION_FILE,
     AmazonMusicWebAuthError,
     AmazonMusicWebClient,
-    serialize_renewal_cookies,
+    serialize_renewal_request,
     serialize_web_headers,
 )
 from ...oauth import read_token, token_path, write_token
@@ -29,11 +29,11 @@ class AmazonMusicConnector(Connector):
         ),
         Field(
             "AMAZON_MUSIC_RENEWAL_REQUEST",
-            "Signed-in request with SSO cookies",
+            "Signed-in browser request",
             secret=True,
             help=(
                 "Copy the complete headers or cURL for a signed-in config.json request; "
-                "SongMirror verifies that its sst-main cookie can recreate the Music session"
+                "SongMirror preserves its browser context and verifies /pandaToken renewal"
             ),
         ),
     ]
@@ -132,7 +132,7 @@ class AmazonMusicConnector(Connector):
         renewal_raw = values.get("AMAZON_MUSIC_RENEWAL_REQUEST") or ""
         try:
             minimized = serialize_web_headers(raw) if raw.strip() else ""
-            renewal = serialize_renewal_cookies(renewal_raw)
+            renewal = serialize_renewal_request(renewal_raw)
         except ValueError as exc:
             return ConnStatus("error", str(exc))
 

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -909,7 +909,8 @@ def test_amazon_renewal_parser_keeps_only_known_auth_cookies():
     raw = (
         "curl 'https://music.amazon.com/pandaToken' "
         "-H 'cookie: session-id=session; at-main-music=music-auth; "
-        "session-token=retail-session; sid=music-session; AMCV_AdobeOrg=analytics; "
+        "session-token=retail-session; sid=music-session; sst-main=sso-auth; "
+        "sso-state-main=sso-state; AMCV_AdobeOrg=analytics; "
         "aws-userInfo=console-profile; am-loader-experiment=bucket'"
     )
 
@@ -918,6 +919,8 @@ def test_amazon_renewal_parser_keeps_only_known_auth_cookies():
         "session-id": "session",
         "session-token": "retail-session",
         "sid": "music-session",
+        "sso-state-main": "sso-state",
+        "sst-main": "sso-auth",
     }
     minimized = serialize_renewal_cookies(raw)
     assert json.loads(minimized) == {
@@ -925,6 +928,8 @@ def test_amazon_renewal_parser_keeps_only_known_auth_cookies():
         "session-id": "session",
         "session-token": "retail-session",
         "sid": "music-session",
+        "sso-state-main": "sso-state",
+        "sst-main": "sso-auth",
     }
     assert "analytics" not in minimized
     assert "console-profile" not in minimized
@@ -1051,6 +1056,378 @@ def test_amazon_web_client_renews_rejected_token_and_retries_mutation_once(tmp_p
     assert persisted["expires_at"] > 0
 
 
+def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp_path):
+    import requests
+
+    from songmirror.amazon_music_web import (
+        CONFIG_ENDPOINT,
+        ENDPOINT,
+        PANDA_TOKEN_ENDPOINT,
+        AmazonMusicWebClient,
+    )
+
+    force_sign_in_endpoint = "https://music.amazon.com/forceSignIn"
+
+    class Response:
+        headers = {}
+
+        def __init__(self, status_code, body, *, url):
+            self.status_code = status_code
+            self._body = body
+            self.url = url
+            self.history = []
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise AssertionError(f"unexpected HTTP {self.status_code}")
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+        def get(self, url, **kwargs):
+            self.calls.append(("GET", url, kwargs))
+            if url == force_sign_in_endpoint:
+                available = self.cookies.get_dict()
+                assert available["sst-main"] == "durable-sso"
+                assert "at-main-music" not in available
+                assert "am-token" not in available
+                assert "sid" not in available
+                self.cookies.set(
+                    "at-main-music",
+                    "rotated-music-auth",
+                    domain=".music.amazon.com",
+                    path="/",
+                )
+                return Response(200, {}, url="https://music.amazon.com/")
+            if url == CONFIG_ENDPOINT:
+                assert self.cookies.get_dict()["at-main-music"] == "rotated-music-auth"
+                return Response(
+                    200,
+                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                    url=url,
+                )
+            assert url == PANDA_TOKEN_ENDPOINT
+            return Response(
+                200,
+                {"accessToken": "fresh-access", "expiresIn": 3600},
+                url=url,
+            )
+
+        def post(self, url, **kwargs):
+            self.calls.append(("POST", url, kwargs))
+            assert url == ENDPOINT
+            return Response(200, {"data": {"user": {"id": "customer-1"}}}, url=url)
+
+    session = Session()
+    client = AmazonMusicWebClient(
+        json.dumps(
+            {
+                "accessToken": "one-hour-bootstrap",
+                "deviceId": "device-7",
+                "deviceType": "A16ZV8BU3SN1N3",
+            }
+        ),
+        renewal_request=(
+            "Cookie: at-main-music=one-hour-music; am-token=one-hour-access; "
+            "sid=one-hour-session; sst-main=durable-sso; session-id=session"
+        ),
+        token_file=str(tmp_path / "amazon-session.json"),
+        prefer_persisted=False,
+        session=session,
+    )
+
+    client.validate(require_renewal=True)
+
+    assert [url for _, url, _ in session.calls] == [
+        force_sign_in_endpoint,
+        CONFIG_ENDPOINT,
+        PANDA_TOKEN_ENDPOINT,
+        ENDPOINT,
+    ]
+    renewal = json.loads(client.serialized_renewal())
+    assert renewal["sst-main"] == "durable-sso"
+    assert renewal["at-main-music"] == "rotated-music-auth"
+    assert "am-token" not in renewal
+    assert "sid" not in renewal
+
+
+def test_amazon_connection_rejects_temporary_cookie_without_sso_state():
+    import requests
+
+    from songmirror.amazon_music_web import AmazonMusicWebAuthError, AmazonMusicWebClient
+
+    class Session:
+        def __init__(self):
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+        def get(self, url, **kwargs):
+            raise AssertionError(f"unexpected request to {url}")
+
+    client = AmazonMusicWebClient(
+        json.dumps(
+            {
+                "accessToken": "one-hour-bootstrap",
+                "deviceId": "device-7",
+                "deviceType": "A16ZV8BU3SN1N3",
+            }
+        ),
+        renewal_request="Cookie: at-main-music=temporary-music; session-id=session",
+        prefer_persisted=False,
+        session=Session(),
+    )
+
+    with pytest.raises(AmazonMusicWebAuthError, match="sst-main SSO cookie"):
+        client.validate(require_renewal=True)
+
+
+def test_amazon_session_does_not_rescope_foreign_cookie_names_to_amazon():
+    import requests
+
+    from songmirror.amazon_music_web import AmazonMusicWebClient
+
+    class Session:
+        def __init__(self):
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+    session = Session()
+    client = AmazonMusicWebClient(
+        json.dumps(
+            {
+                "accessToken": "temporary-access",
+                "deviceId": "device-7",
+                "deviceType": "A16ZV8BU3SN1N3",
+            }
+        ),
+        renewal_request="Cookie: session-id=amazon-session",
+        prefer_persisted=False,
+        session=session,
+    )
+    session.cookies.set("sst-main", "foreign-value", domain=".example.test", path="/")
+
+    client._sync_response_cookies(object())
+
+    renewal = json.loads(client.serialized_renewal())
+    assert renewal == {"session-id": "amazon-session"}
+
+
+def test_amazon_web_client_recreates_music_session_after_one_hour_cookie_expires():
+    import requests
+
+    from songmirror.amazon_music_web import (
+        CONFIG_ENDPOINT,
+        FORCE_SIGN_IN_ENDPOINT,
+        PANDA_TOKEN_ENDPOINT,
+        AmazonMusicWebClient,
+    )
+
+    class Response:
+        headers = {}
+
+        def __init__(self, body, *, url):
+            self.status_code = 200
+            self._body = body
+            self.url = url
+            self.history = []
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+            self.cookies = requests.cookies.RequestsCookieJar()
+            self.config_calls = 0
+            self.panda_calls = 0
+
+        def get(self, url, **kwargs):
+            assert "cookies" not in kwargs
+            self.calls.append(url)
+            if url == CONFIG_ENDPOINT:
+                self.config_calls += 1
+                if self.config_calls == 1:
+                    self.cookies.clear(
+                        domain=".music.amazon.com",
+                        path="/",
+                        name="at-main-music",
+                    )
+                    return Response(
+                        {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                        url=url,
+                    )
+                assert self.cookies.get_dict()["at-main-music"] == "restored-music-auth"
+                return Response(
+                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                    url=url,
+                )
+            if url == PANDA_TOKEN_ENDPOINT:
+                self.panda_calls += 1
+                body = (
+                    {"accessToken": "", "expiresIn": 0}
+                    if self.panda_calls == 1
+                    else {"accessToken": "renewed-access", "expiresIn": 3600}
+                )
+                return Response(body, url=url)
+            assert url == FORCE_SIGN_IN_ENDPOINT
+            available = self.cookies.get_dict()
+            assert available["sst-main"] == "durable-sso"
+            assert "at-main-music" not in available
+            assert "am-token" not in available
+            assert "sid" not in available
+            self.cookies.set(
+                "at-main-music",
+                "restored-music-auth",
+                domain=".music.amazon.com",
+                path="/",
+            )
+            return Response({}, url="https://music.amazon.com/")
+
+    session = Session()
+    client = AmazonMusicWebClient(
+        json.dumps(
+            {
+                "accessToken": "expired-access",
+                "deviceId": "device-7",
+                "deviceType": "A16ZV8BU3SN1N3",
+            }
+        ),
+        renewal_request=(
+            "Cookie: at-main-music=expired-music; am-token=expired-access; "
+            "sid=expired-session; sst-main=durable-sso; session-id=session"
+        ),
+        prefer_persisted=False,
+        session=session,
+    )
+
+    client._renew(persist=False)
+
+    assert session.calls == [
+        CONFIG_ENDPOINT,
+        PANDA_TOKEN_ENDPOINT,
+        FORCE_SIGN_IN_ENDPOINT,
+        CONFIG_ENDPOINT,
+        PANDA_TOKEN_ENDPOINT,
+    ]
+    assert client._authorization_context(client.headers)["access_token"] == "renewed-access"
+    assert json.loads(client.serialized_renewal())["at-main-music"] == "restored-music-auth"
+
+
+@pytest.mark.parametrize(
+    ("rejected_endpoint", "rejected_status", "expected_calls"),
+    [
+        (
+            "config",
+            403,
+            ["config", "force-sign-in", "config", "panda"],
+        ),
+        (
+            "panda",
+            401,
+            ["config", "panda", "force-sign-in", "config", "panda"],
+        ),
+    ],
+)
+def test_amazon_web_client_retries_auth_rejection_through_sso(
+    rejected_endpoint,
+    rejected_status,
+    expected_calls,
+):
+    import requests
+
+    from songmirror.amazon_music_web import (
+        CONFIG_ENDPOINT,
+        FORCE_SIGN_IN_ENDPOINT,
+        PANDA_TOKEN_ENDPOINT,
+        AmazonMusicWebClient,
+    )
+
+    class Response:
+        headers = {}
+
+        def __init__(self, status_code, body, *, url):
+            self.status_code = status_code
+            self._body = body
+            self.url = url
+            self.history = []
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise AssertionError(f"HTTP {self.status_code} bypassed the SSO retry")
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+            self.cookies = requests.cookies.RequestsCookieJar()
+            self.rejected = False
+
+        def get(self, url, **kwargs):
+            assert "cookies" not in kwargs
+            if url == CONFIG_ENDPOINT:
+                self.calls.append("config")
+                if rejected_endpoint == "config" and not self.rejected:
+                    self.rejected = True
+                    return Response(rejected_status, {}, url=url)
+                return Response(
+                    200,
+                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                    url=url,
+                )
+            if url == PANDA_TOKEN_ENDPOINT:
+                self.calls.append("panda")
+                if rejected_endpoint == "panda" and not self.rejected:
+                    self.rejected = True
+                    return Response(rejected_status, {}, url=url)
+                return Response(
+                    200,
+                    {"accessToken": "renewed-access", "expiresIn": 3600},
+                    url=url,
+                )
+            assert url == FORCE_SIGN_IN_ENDPOINT
+            self.calls.append("force-sign-in")
+            self.cookies.set(
+                "at-main-music",
+                "restored-music-auth",
+                domain=".music.amazon.com",
+                path="/",
+            )
+            return Response(200, {}, url="https://music.amazon.com/")
+
+    session = Session()
+    client = AmazonMusicWebClient(
+        json.dumps(
+            {
+                "accessToken": "expired-access",
+                "deviceId": "device-7",
+                "deviceType": "A16ZV8BU3SN1N3",
+            }
+        ),
+        renewal_request=(
+            "Cookie: at-main-music=expired-music; sst-main=durable-sso; "
+            "session-id=session"
+        ),
+        prefer_persisted=False,
+        session=session,
+    )
+
+    client._renew(persist=False)
+
+    assert session.calls == expected_calls
+    assert client._authorization_context(client.headers)["access_token"] == "renewed-access"
+
+
 def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(tmp_path, monkeypatch):
     import songmirror.amazon_music_web as amazon_web
     from songmirror.services.accounts.amazon_music import AmazonMusicConnector
@@ -1064,9 +1441,11 @@ def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(t
         headers = {}
         cookies = Cookies()
 
-        def __init__(self, status_code, body):
+        def __init__(self, status_code, body, *, url=""):
             self.status_code = status_code
             self._body = body
+            self.url = url
+            self.history = []
 
         def raise_for_status(self):
             if self.status_code >= 400:
@@ -1081,6 +1460,8 @@ def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(t
 
         def get(self, url, **kwargs):
             self.calls.append(("GET", url))
+            if url == amazon_web.FORCE_SIGN_IN_ENDPOINT:
+                return Response(200, {}, url="https://music.amazon.com/")
             if url == amazon_web.CONFIG_ENDPOINT:
                 return Response(
                     200,
@@ -1114,13 +1495,16 @@ def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(t
                     "deviceType": "A16ZV8BU3SN1N3",
                 }
             ),
-            "AMAZON_MUSIC_RENEWAL_REQUEST": "Cookie: at-main-music=stale-session",
+            "AMAZON_MUSIC_RENEWAL_REQUEST": (
+                "Cookie: at-main-music=stale-session; sst-main=durable-sso"
+            ),
         }
     )
 
     assert status.state == "error"
     assert "/pandaToken did not return an access token" in status.detail
     assert session.calls == [
+        ("GET", amazon_web.FORCE_SIGN_IN_ENDPOINT),
         ("GET", amazon_web.CONFIG_ENDPOINT),
         ("GET", amazon_web.PANDA_TOKEN_ENDPOINT),
     ]
@@ -1142,9 +1526,11 @@ def test_amazon_connector_persists_renewal_only_after_user_validation(tmp_path, 
         headers = {}
         cookies = Cookies()
 
-        def __init__(self, status_code, body):
+        def __init__(self, status_code, body, *, url=""):
             self.status_code = status_code
             self._body = body
+            self.url = url
+            self.history = []
 
         def raise_for_status(self):
             if self.status_code >= 400:
@@ -1159,6 +1545,8 @@ def test_amazon_connector_persists_renewal_only_after_user_validation(tmp_path, 
 
         def get(self, url, **kwargs):
             self.calls.append(("GET", url))
+            if url == amazon_web.FORCE_SIGN_IN_ENDPOINT:
+                return Response(200, {}, url="https://music.amazon.com/")
             if url == amazon_web.CONFIG_ENDPOINT:
                 return Response(200, {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"})
             assert url == amazon_web.PANDA_TOKEN_ENDPOINT
@@ -1186,13 +1574,16 @@ def test_amazon_connector_persists_renewal_only_after_user_validation(tmp_path, 
                     "deviceType": "A16ZV8BU3SN1N3",
                 }
             ),
-            "AMAZON_MUSIC_RENEWAL_REQUEST": "Cookie: at-main-music=candidate-session",
+            "AMAZON_MUSIC_RENEWAL_REQUEST": (
+                "Cookie: at-main-music=candidate-session; sst-main=durable-sso"
+            ),
         }
     )
 
     assert status.state == "error"
     assert "did not recognize a signed-in user" in status.detail
     assert session.calls == [
+        ("GET", amazon_web.FORCE_SIGN_IN_ENDPOINT),
         ("GET", amazon_web.CONFIG_ENDPOINT),
         ("GET", amazon_web.PANDA_TOKEN_ENDPOINT),
         ("POST", amazon_web.ENDPOINT),

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -993,7 +993,17 @@ def test_amazon_web_client_renews_rejected_token_and_retries_mutation_once(tmp_p
 
         def get(self, url, **kwargs):
             self.calls.append(("GET", url, kwargs))
+            assert url == PANDA_TOKEN_ENDPOINT
+            assert kwargs["cookies"] == {
+                "at-main-music": "rotated-music-auth",
+                "session-id": "session",
+            }
+            return Response(200, {"accessToken": "fresh-access", "expiresIn": 3600})
+
+        def post(self, url, **kwargs):
+            self.calls.append(("POST", url, kwargs))
             if url == CONFIG_ENDPOINT:
+                assert kwargs["params"] == {"skipToken": "false"}
                 assert kwargs["cookies"] == {
                     "at-main-music": "initial-music-auth",
                     "session-id": "session",
@@ -1007,16 +1017,7 @@ def test_amazon_web_client_renews_rejected_token_and_retries_mutation_once(tmp_p
                     },
                     cookies={"at-main-music": "rotated-music-auth", "tracking": "discard"},
                 )
-            assert url == PANDA_TOKEN_ENDPOINT
-            assert kwargs["cookies"] == {
-                "at-main-music": "rotated-music-auth",
-                "session-id": "session",
-            }
-            return Response(200, {"accessToken": "fresh-access", "expiresIn": 3600})
-
-        def post(self, url, **kwargs):
             assert url == ENDPOINT
-            self.calls.append(("POST", url, kwargs))
             self.graphql_calls += 1
             if self.graphql_calls == 1:
                 return Response(401, {"errors": [{"message": "expired"}]})
@@ -1056,7 +1057,7 @@ def test_amazon_web_client_renews_rejected_token_and_retries_mutation_once(tmp_p
     assert persisted["expires_at"] > 0
 
 
-def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp_path):
+def test_amazon_connection_replays_browser_context_and_proves_panda_renewal(tmp_path):
     import requests
 
     from songmirror.amazon_music_web import (
@@ -1066,7 +1067,11 @@ def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp
         AmazonMusicWebClient,
     )
 
-    force_sign_in_endpoint = "https://music.amazon.com/forceSignIn"
+    browser_user_agent = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) "
+        "Gecko/20100101 Firefox/154.0"
+    )
+    browser_referer = "https://music.amazon.com/profiles/profile-7"
 
     class Response:
         headers = {}
@@ -1092,27 +1097,10 @@ def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp
 
         def get(self, url, **kwargs):
             self.calls.append(("GET", url, kwargs))
-            if url == force_sign_in_endpoint:
-                available = self.cookies.get_dict()
-                assert available["sst-main"] == "durable-sso"
-                assert "at-main-music" not in available
-                assert "am-token" not in available
-                assert "sid" not in available
-                self.cookies.set(
-                    "at-main-music",
-                    "rotated-music-auth",
-                    domain=".music.amazon.com",
-                    path="/",
-                )
-                return Response(200, {}, url="https://music.amazon.com/")
-            if url == CONFIG_ENDPOINT:
-                assert self.cookies.get_dict()["at-main-music"] == "rotated-music-auth"
-                return Response(
-                    200,
-                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
-                    url=url,
-                )
             assert url == PANDA_TOKEN_ENDPOINT
+            assert kwargs["headers"]["User-Agent"] == browser_user_agent
+            assert kwargs["headers"]["Referer"] == browser_referer
+            assert "cookies" not in kwargs
             return Response(
                 200,
                 {"accessToken": "fresh-access", "expiresIn": 3600},
@@ -1121,6 +1109,16 @@ def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp
 
         def post(self, url, **kwargs):
             self.calls.append(("POST", url, kwargs))
+            if url == CONFIG_ENDPOINT:
+                assert kwargs["params"] == {"skipToken": "false"}
+                assert kwargs["headers"]["User-Agent"] == browser_user_agent
+                assert kwargs["headers"]["Referer"] == browser_referer
+                assert "cookies" not in kwargs
+                return Response(
+                    200,
+                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                    url=url,
+                )
             assert url == ENDPOINT
             return Response(200, {"data": {"user": {"id": "customer-1"}}}, url=url)
 
@@ -1134,8 +1132,13 @@ def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp
             }
         ),
         renewal_request=(
-            "Cookie: at-main-music=one-hour-music; am-token=one-hour-access; "
-            "sid=one-hour-session; sst-main=durable-sso; session-id=session"
+            "POST /config.json?skipToken=false HTTP/2\n"
+            "Host: music.amazon.com\n"
+            f"User-Agent: {browser_user_agent}\n"
+            "Accept-Language: en-US,en;q=0.9\n"
+            f"Referer: {browser_referer}\n"
+            "Cookie: at-main-music=renewable-music; sst-main=durable-sso; "
+            "session-id=session"
         ),
         token_file=str(tmp_path / "amazon-session.json"),
         prefer_persisted=False,
@@ -1144,46 +1147,19 @@ def test_amazon_connection_proves_sso_handoff_without_one_hour_music_cookies(tmp
 
     client.validate(require_renewal=True)
 
-    assert [url for _, url, _ in session.calls] == [
-        force_sign_in_endpoint,
-        CONFIG_ENDPOINT,
-        PANDA_TOKEN_ENDPOINT,
-        ENDPOINT,
+    assert [(method, url) for method, url, _ in session.calls] == [
+        ("POST", CONFIG_ENDPOINT),
+        ("GET", PANDA_TOKEN_ENDPOINT),
+        ("POST", ENDPOINT),
     ]
     renewal = json.loads(client.serialized_renewal())
-    assert renewal["sst-main"] == "durable-sso"
-    assert renewal["at-main-music"] == "rotated-music-auth"
-    assert "am-token" not in renewal
-    assert "sid" not in renewal
-
-
-def test_amazon_connection_rejects_temporary_cookie_without_sso_state():
-    import requests
-
-    from songmirror.amazon_music_web import AmazonMusicWebAuthError, AmazonMusicWebClient
-
-    class Session:
-        def __init__(self):
-            self.cookies = requests.cookies.RequestsCookieJar()
-
-        def get(self, url, **kwargs):
-            raise AssertionError(f"unexpected request to {url}")
-
-    client = AmazonMusicWebClient(
-        json.dumps(
-            {
-                "accessToken": "one-hour-bootstrap",
-                "deviceId": "device-7",
-                "deviceType": "A16ZV8BU3SN1N3",
-            }
-        ),
-        renewal_request="Cookie: at-main-music=temporary-music; session-id=session",
-        prefer_persisted=False,
-        session=Session(),
-    )
-
-    with pytest.raises(AmazonMusicWebAuthError, match="sst-main SSO cookie"):
-        client.validate(require_renewal=True)
+    assert renewal["browser_headers"] == {
+        "accept-language": "en-US,en;q=0.9",
+        "referer": browser_referer,
+        "user-agent": browser_user_agent,
+    }
+    assert renewal["renewal_cookies"]["sst-main"] == "durable-sso"
+    assert renewal["renewal_cookies"]["at-main-music"] == "renewable-music"
 
 
 def test_amazon_session_does_not_rescope_foreign_cookie_names_to_amazon():
@@ -1213,139 +1189,24 @@ def test_amazon_session_does_not_rescope_foreign_cookie_names_to_amazon():
     client._sync_response_cookies(object())
 
     renewal = json.loads(client.serialized_renewal())
-    assert renewal == {"session-id": "amazon-session"}
-
-
-def test_amazon_web_client_recreates_music_session_after_one_hour_cookie_expires():
-    import requests
-
-    from songmirror.amazon_music_web import (
-        CONFIG_ENDPOINT,
-        FORCE_SIGN_IN_ENDPOINT,
-        PANDA_TOKEN_ENDPOINT,
-        AmazonMusicWebClient,
-    )
-
-    class Response:
-        headers = {}
-
-        def __init__(self, body, *, url):
-            self.status_code = 200
-            self._body = body
-            self.url = url
-            self.history = []
-            self.cookies = requests.cookies.RequestsCookieJar()
-
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return self._body
-
-    class Session:
-        def __init__(self):
-            self.calls = []
-            self.cookies = requests.cookies.RequestsCookieJar()
-            self.config_calls = 0
-            self.panda_calls = 0
-
-        def get(self, url, **kwargs):
-            assert "cookies" not in kwargs
-            self.calls.append(url)
-            if url == CONFIG_ENDPOINT:
-                self.config_calls += 1
-                if self.config_calls == 1:
-                    self.cookies.clear(
-                        domain=".music.amazon.com",
-                        path="/",
-                        name="at-main-music",
-                    )
-                    return Response(
-                        {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
-                        url=url,
-                    )
-                assert self.cookies.get_dict()["at-main-music"] == "restored-music-auth"
-                return Response(
-                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
-                    url=url,
-                )
-            if url == PANDA_TOKEN_ENDPOINT:
-                self.panda_calls += 1
-                body = (
-                    {"accessToken": "", "expiresIn": 0}
-                    if self.panda_calls == 1
-                    else {"accessToken": "renewed-access", "expiresIn": 3600}
-                )
-                return Response(body, url=url)
-            assert url == FORCE_SIGN_IN_ENDPOINT
-            available = self.cookies.get_dict()
-            assert available["sst-main"] == "durable-sso"
-            assert "at-main-music" not in available
-            assert "am-token" not in available
-            assert "sid" not in available
-            self.cookies.set(
-                "at-main-music",
-                "restored-music-auth",
-                domain=".music.amazon.com",
-                path="/",
-            )
-            return Response({}, url="https://music.amazon.com/")
-
-    session = Session()
-    client = AmazonMusicWebClient(
-        json.dumps(
-            {
-                "accessToken": "expired-access",
-                "deviceId": "device-7",
-                "deviceType": "A16ZV8BU3SN1N3",
-            }
-        ),
-        renewal_request=(
-            "Cookie: at-main-music=expired-music; am-token=expired-access; "
-            "sid=expired-session; sst-main=durable-sso; session-id=session"
-        ),
-        prefer_persisted=False,
-        session=session,
-    )
-
-    client._renew(persist=False)
-
-    assert session.calls == [
-        CONFIG_ENDPOINT,
-        PANDA_TOKEN_ENDPOINT,
-        FORCE_SIGN_IN_ENDPOINT,
-        CONFIG_ENDPOINT,
-        PANDA_TOKEN_ENDPOINT,
-    ]
-    assert client._authorization_context(client.headers)["access_token"] == "renewed-access"
-    assert json.loads(client.serialized_renewal())["at-main-music"] == "restored-music-auth"
+    assert renewal["renewal_cookies"] == {"session-id": "amazon-session"}
 
 
 @pytest.mark.parametrize(
-    ("rejected_endpoint", "rejected_status", "expected_calls"),
+    ("first_status", "first_body"),
     [
-        (
-            "config",
-            403,
-            ["config", "force-sign-in", "config", "panda"],
-        ),
-        (
-            "panda",
-            401,
-            ["config", "panda", "force-sign-in", "config", "panda"],
-        ),
+        (200, {"accessToken": "", "expiresIn": 0}),
+        (401, {}),
     ],
 )
-def test_amazon_web_client_retries_auth_rejection_through_sso(
-    rejected_endpoint,
-    rejected_status,
-    expected_calls,
+def test_amazon_web_client_bootstraps_config_after_panda_renewal_fails(
+    first_status,
+    first_body,
 ):
     import requests
 
     from songmirror.amazon_music_web import (
         CONFIG_ENDPOINT,
-        FORCE_SIGN_IN_ENDPOINT,
         PANDA_TOKEN_ENDPOINT,
         AmazonMusicWebClient,
     )
@@ -1362,7 +1223,7 @@ def test_amazon_web_client_retries_auth_rejection_through_sso(
 
         def raise_for_status(self):
             if self.status_code >= 400:
-                raise AssertionError(f"HTTP {self.status_code} bypassed the SSO retry")
+                raise AssertionError(f"HTTP {self.status_code} bypassed the config retry")
 
         def json(self):
             return self._body
@@ -1371,39 +1232,31 @@ def test_amazon_web_client_retries_auth_rejection_through_sso(
         def __init__(self):
             self.calls = []
             self.cookies = requests.cookies.RequestsCookieJar()
-            self.rejected = False
+            self.panda_calls = 0
 
         def get(self, url, **kwargs):
             assert "cookies" not in kwargs
-            if url == CONFIG_ENDPOINT:
-                self.calls.append("config")
-                if rejected_endpoint == "config" and not self.rejected:
-                    self.rejected = True
-                    return Response(rejected_status, {}, url=url)
-                return Response(
-                    200,
-                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
-                    url=url,
-                )
-            if url == PANDA_TOKEN_ENDPOINT:
-                self.calls.append("panda")
-                if rejected_endpoint == "panda" and not self.rejected:
-                    self.rejected = True
-                    return Response(rejected_status, {}, url=url)
-                return Response(
-                    200,
-                    {"accessToken": "renewed-access", "expiresIn": 3600},
-                    url=url,
-                )
-            assert url == FORCE_SIGN_IN_ENDPOINT
-            self.calls.append("force-sign-in")
-            self.cookies.set(
-                "at-main-music",
-                "restored-music-auth",
-                domain=".music.amazon.com",
-                path="/",
+            assert url == PANDA_TOKEN_ENDPOINT
+            self.calls.append(("GET", url))
+            self.panda_calls += 1
+            if self.panda_calls == 1:
+                return Response(first_status, first_body, url=url)
+            return Response(
+                200,
+                {"accessToken": "renewed-access", "expiresIn": 3600},
+                url=url,
             )
-            return Response(200, {}, url="https://music.amazon.com/")
+
+        def post(self, url, **kwargs):
+            assert url == CONFIG_ENDPOINT
+            assert kwargs["params"] == {"skipToken": "false"}
+            assert "cookies" not in kwargs
+            self.calls.append(("POST", url))
+            return Response(
+                200,
+                {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                url=url,
+            )
 
     session = Session()
     client = AmazonMusicWebClient(
@@ -1415,7 +1268,7 @@ def test_amazon_web_client_retries_auth_rejection_through_sso(
             }
         ),
         renewal_request=(
-            "Cookie: at-main-music=expired-music; sst-main=durable-sso; "
+            "Cookie: at-main-music=renewable-music; sst-main=durable-sso; "
             "session-id=session"
         ),
         prefer_persisted=False,
@@ -1424,7 +1277,11 @@ def test_amazon_web_client_retries_auth_rejection_through_sso(
 
     client._renew(persist=False)
 
-    assert session.calls == expected_calls
+    assert session.calls == [
+        ("GET", PANDA_TOKEN_ENDPOINT),
+        ("POST", CONFIG_ENDPOINT),
+        ("GET", PANDA_TOKEN_ENDPOINT),
+    ]
     assert client._authorization_context(client.headers)["access_token"] == "renewed-access"
 
 
@@ -1457,11 +1314,16 @@ def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(t
     class Session:
         def __init__(self):
             self.calls = []
+            self.panda_calls = 0
 
         def get(self, url, **kwargs):
             self.calls.append(("GET", url))
-            if url == amazon_web.FORCE_SIGN_IN_ENDPOINT:
-                return Response(200, {}, url="https://music.amazon.com/")
+            assert url == amazon_web.PANDA_TOKEN_ENDPOINT
+            self.panda_calls += 1
+            return Response(200, {"accessToken": "", "expiresIn": 0})
+
+        def post(self, url, **kwargs):
+            self.calls.append(("POST", url))
             if url == amazon_web.CONFIG_ENDPOINT:
                 return Response(
                     200,
@@ -1471,11 +1333,6 @@ def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(t
                         "deviceType": "A16ZV8BU3SN1N3",
                     },
                 )
-            assert url == amazon_web.PANDA_TOKEN_ENDPOINT
-            return Response(200, {"accessToken": "", "expiresIn": 0})
-
-        def post(self, url, **kwargs):
-            self.calls.append(("POST", url))
             assert url == amazon_web.ENDPOINT
             return Response(200, {"data": {"user": {"id": "customer-1"}}})
 
@@ -1504,8 +1361,7 @@ def test_amazon_connector_rejects_a_bootstrap_when_renewal_cannot_mint_a_token(t
     assert status.state == "error"
     assert "/pandaToken did not return an access token" in status.detail
     assert session.calls == [
-        ("GET", amazon_web.FORCE_SIGN_IN_ENDPOINT),
-        ("GET", amazon_web.CONFIG_ENDPOINT),
+        ("POST", amazon_web.CONFIG_ENDPOINT),
         ("GET", amazon_web.PANDA_TOKEN_ENDPOINT),
     ]
     assert not connector._store.get("AMAZON_MUSIC_WEB_HEADERS")
@@ -1545,15 +1401,16 @@ def test_amazon_connector_persists_renewal_only_after_user_validation(tmp_path, 
 
         def get(self, url, **kwargs):
             self.calls.append(("GET", url))
-            if url == amazon_web.FORCE_SIGN_IN_ENDPOINT:
-                return Response(200, {}, url="https://music.amazon.com/")
-            if url == amazon_web.CONFIG_ENDPOINT:
-                return Response(200, {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"})
             assert url == amazon_web.PANDA_TOKEN_ENDPOINT
             return Response(200, {"accessToken": "fresh-access", "expiresIn": 3600})
 
         def post(self, url, **kwargs):
             self.calls.append(("POST", url))
+            if url == amazon_web.CONFIG_ENDPOINT:
+                return Response(
+                    200,
+                    {"deviceId": "device-7", "deviceType": "A16ZV8BU3SN1N3"},
+                )
             assert url == amazon_web.ENDPOINT
             return Response(200, {"data": {"user": None}})
 
@@ -1583,8 +1440,7 @@ def test_amazon_connector_persists_renewal_only_after_user_validation(tmp_path, 
     assert status.state == "error"
     assert "did not recognize a signed-in user" in status.detail
     assert session.calls == [
-        ("GET", amazon_web.FORCE_SIGN_IN_ENDPOINT),
-        ("GET", amazon_web.CONFIG_ENDPOINT),
+        ("POST", amazon_web.CONFIG_ENDPOINT),
         ("GET", amazon_web.PANDA_TOKEN_ENDPOINT),
         ("POST", amazon_web.ENDPOINT),
     ]
@@ -1635,7 +1491,7 @@ def test_amazon_connector_accepts_web_session_without_beta_approval(tmp_path, mo
     stored = json.loads(connector._store.get("AMAZON_MUSIC_WEB_HEADERS"))
     assert set(stored) == {"authorization", "x-api-key"}
     assert json.loads(connector._store.get("AMAZON_MUSIC_RENEWAL_REQUEST")) == {
-        "at-main-music": "renew-me"
+        "renewal_cookies": {"at-main-music": "renew-me"}
     }
 
 


### PR DESCRIPTION
## Summary

- retain only the captured Amazon Music browser user agent, language, referer, and allowlisted renewal cookies
- replace the interactive `/forceSignIn` probe with the current `POST /config.json?skipToken=false` bootstrap and direct `/pandaToken` renewal flow
- require config bootstrap, a panda-issued access token, the Music renewal cookie, and signed-in GraphQL identity before reporting a new connection as connected
- retry routine renewal once through config when panda returns an empty token or rejects the session, while preserving domain-scoped cookie rotation and legacy stored state

## Root cause

Amazon's `/forceSignIn` route explicitly requests active reauthentication, so it reaches the login page even when a copied request is complete. The previous client also replayed a generic browser identity and the wrong config request method. That made valid reconnects fail without proving the path used after the one-hour access token expires.

## Verification

- `353 passed, 1 skipped`
- frontend lint passed
- production frontend build passed
- independent review passed