### PR TITLE
feat(transfers): make order preservation explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ SongMirror keeps your playlists identical everywhere without manual re-adding, o
 - 🎯 **ISRC-accurate matching** — exact recording identity where available, with Unicode-aware fuzzy title/artist/duration fallbacks (feat-credit drift, "- 2015 Remaster" suffixes, non-Latin scripts, video-only uploads — all handled).
 - 🎛️ **Multiple named syncs** — set up as many independent syncs as you like, each with its own services, playlists, schedule, and safety caps.
 - ↪️ **One-off transfers** — copy any playlist from one service to another with a live progress bar; **pause, resume, or stop** mid-copy, and manually resolve unmatched tracks.
+- 🕒 **Append or preserve order** — copies land at the end of the destination by default, fast and additive. Switch on **Preserve Recently Added order** to rewrite the tracks after the oldest new one so date-added order matches the source.
 - 🔗 **Transfer from a link** — paste a public playlist URL from any connected service and copy it straight across. No need to save or follow it first.
 - 🌐 **Followed playlists** — sync and transfer playlists you follow but don't own, not just ones you created.
 - 📦 **Portable metadata backups** — download one playlist or a service's entire library as ordered, versioned JSON/XML; single playlists also export as import-ready Soundiiz JSON.
@@ -451,7 +452,8 @@ Removals are destructive, so they're guarded:
 - **Dry run is the default** — nothing changes without `--execute` (or the UI's real-sync action).
 - If the source returns 0 tracks for a playlist the target shows as non-empty, removals are skipped that pass (a transient API failure can't empty a playlist).
 - **Removals are off by default** — `MAX_REMOVALS=0` holds every removal back (logged, never applied), so a licensing takedown on one platform can't cascade a deletion to the rest. Opt in per sync with the "Mirror removals" toggle (or set `MAX_REMOVALS`), and even then more pending removals than the cap in one pass → all skipped and logged.
-- `MAX_ADDS` limits every timestamp-producing write, including chronology repair. If an older recovered match needs a larger suffix replay than the cap allows, SongMirror defers it rather than making it appear newest or causing a giant provider burst.
+- `MAX_ADDS` limits every timestamp-producing write in a **sync** pass, including chronology repair. If an older recovered match needs a larger suffix replay than the cap allows, SongMirror defers it to the next pass rather than making it appear newest or causing a giant provider burst. A **one-off transfer** has no next pass, so it never defers: it copies every requested track, appending in source order unless you switch on "Preserve Recently Added order" for that transfer, which spends whatever the repair costs.
+- A chronology repair stages a duplicate copy before retiring the original. On a service whose delete takes every copy of a song, that keeper count has to be right, so Apple Music re-reads until the staged copies are visible and refuses to retire anything against a read that still trails its own writes. Deezer skips the repair entirely and always appends: it has no positional insert either, so replaying an order it cannot express is not worth the risk to the destination. The transfer form greys its order switch out there and says why.
 - **Net-loss protection** — a target-side track resembling a source track that has no match on that service is held, not deleted.
 - Any provider authentication failure aborts that provider's pass immediately — no partial deletes on expired tokens.
 

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -32,6 +32,9 @@ The base class also supplies `replay_chronology()`. It stages duplicate copies o
 entry before retiring the old copies, so every replacement write succeeds before the original suffix is touched.
 If the provider's ordinary `add()` suppresses duplicates, override `add_chronology_copies()` with the same ordered,
 one-request-per-track behavior but with duplicate insertion enabled. Amazon Music and Qobuz are the reference adapters.
+Set `replay_chronology = None` on the class if the provider cannot perform the repair safely (no positional insert,
+a catalog-id-scoped delete, and reads that trail its own writes); the engine then appends in source order. `deezer.py`
+is the reference for that.
 
 **Override only if your dict shape differs from Spotify's** (`{"id", "name", "images", ...}`):
 `playlist_id`, `playlist_name`, `playlist_description`, `playlist_count`. See `apple.py`

--- a/docs/design/2026-08-14-competitor-account-connection-assessment.md
+++ b/docs/design/2026-08-14-competitor-account-connection-assessment.md
@@ -1,0 +1,127 @@
+# Competitor account-connection assessment
+
+- **Date:** 2026-08-14
+- **Scope:** TuneMyMusic and Soundiiz connection flows for Spotify, Apple Music,
+  YouTube Music, Deezer, TIDAL, Amazon Music, and Qobuz
+- **Status:** Research only; no implementation changes
+
+## Answer
+
+TuneMyMusic and Soundiiz do offer a no-extension, no-managed-browser experience,
+but they are not extracting cookies or DevTools traffic from an iframe. For the
+services in scope, their public flows use provider-owned OAuth/authorization pages
+and partner-issued application identities. Apple Music uses Apple's MusicKit web
+authorization model.
+
+That distinction matters for SongMirror: a popup is only sufficient when the music
+service cooperates by redirecting an authorization result to SongMirror. A popup or
+iframe cannot turn SongMirror's current private-web-session connectors into OAuth.
+Reproducing the competitors' experience therefore requires the same provider app or
+partner approval, not a different browser trick.
+
+## Evidence and methodology
+
+The findings below come from first-party pages, current public redirect endpoints,
+and the JavaScript currently served by the products. No account was used, no login
+was completed, and no credentials were submitted.
+
+TuneMyMusic publicly says that it connects through official APIs for nearly all
+supported platforms and specifically identifies Pandora and Yandex Music as the
+exceptions ([TuneMyMusic FAQ](https://www.tunemymusic.com/en)). Its current transfer
+page also describes account connection as an official OAuth login
+([TuneMyMusic transfer](https://www.tunemymusic.com/features/transfer)). A fresh
+anonymous TuneMyMusic session returned provider login URLs from its own user-data
+bootstrap endpoint. The current frontend classifies Spotify, YouTube Music, TIDAL,
+and Amazon as `partner`, and Apple and Deezer as `officialApi`; its direct
+username/password flag is set for services such as Yandex and Pandora, not for any
+of the seven services in this assessment
+([current TuneMyMusic platform bundle](https://www.tunemymusic.com/_next/static/chunks/2ch3brt-221gz.js)).
+
+Soundiiz says it uses provider-hosted OAuth whenever available: the provider sends
+Soundiiz an access token after authorization. It says that, for a service without
+OAuth, Soundiiz may host a credential form and immediately exchange the credentials
+for a token, retaining the token rather than the password
+([Soundiiz security explanation](https://support.soundiiz.com/hc/en-us/articles/360009868074-Is-Soundiiz-safe-What-type-of-security-Soundiiz-is-using)).
+The latter is a general fallback, but the live routes for the providers in scope use
+authorization redirects rather than that fallback. Soundiiz's connection guide also
+describes a popup followed by provider authorization
+([Soundiiz connection guide](https://support.soundiiz.com/hc/en-us/articles/360024694393-How-to-connect-your-music-accounts-to-Soundiiz)).
+
+## Provider-by-provider observations
+
+| Provider | TuneMyMusic, verified live behavior | Soundiiz, verified live behavior | What SongMirror would need |
+|---|---|---|---|
+| Spotify | Redirects to `accounts.spotify.com/authorize` using authorization code, PKCE, and playlist/library scopes. Its bundle labels the integration `partner`. | [`/connect/spotify`](https://soundiiz.com/connect/spotify) redirects to Spotify authorization-code consent with Soundiiz's registered client and playlist/library scopes. | The existing Spotify OAuth integration is already the equivalent mechanism. |
+| TIDAL | Redirects to `login.tidal.com/authorize` with TuneMyMusic's client ID, PKCE, and collection/playlist scopes; bundle label: `partner`. | [`/connect/tidal`](https://soundiiz.com/connect/tidal) redirects to the same TIDAL authorization endpoint with Soundiiz's client ID, PKCE, and playlist scopes. | This is reproducible with a registered TIDAL app and the required scopes. TIDAL documents app creation and OAuth authorization-code/refresh-token flows ([app management](https://developer.tidal.com/documentation/api-sdk/api-sdk-manage-apps), [authorization](https://developer.tidal.com/documentation/api-sdk/api-sdk-authorization)). |
+| Deezer | Redirects to `connect.deezer.com/oauth/auth.php` with TuneMyMusic's existing app ID and library-management permissions; bundle label: `officialApi`. | [`/connect/deezer`](https://soundiiz.com/connect/deezer) redirects to Deezer OAuth with Soundiiz's existing app ID and library/offline scopes. | An accepted Deezer application. The competitors' existing app IDs do not create an authorization path for an unregistered SongMirror app. |
+| Amazon Music | Redirects to Login with Amazon at `amazon.com/ap/oa`, requesting `profile` and `music::playlists`; bundle label: `partner`. | [`/connect/amazonmusic`](https://soundiiz.com/connect/amazonmusic) redirects to Login with Amazon with the same Music playlist scope. Soundiiz explicitly says Amazon controls the flow and Soundiiz does not receive Amazon credentials ([Soundiiz Amazon announcement](https://soundiiz.com/blog/import-your-playlists-to-amazon-music/)); its support page calls this the official Amazon API ([Amazon connection support](https://support.soundiiz.com/hc/en-us/articles/17006781766034-I-can-t-connect-my-Amazon-Music-account-to-Soundiiz)). | Amazon Music partner approval. Amazon currently says the API is a closed beta limited to already approved developers and requires an enabled security profile in addition to Login with Amazon ([Amazon Music Web API overview](https://www.developer.amazon.com/docs/music/API_web_overview.html)). |
+| Qobuz | Redirects to Qobuz's `signin/oauth` endpoint with a TuneMyMusic `ext_app_id` and a TuneMyMusic callback. | [`/connect/qobuz`](https://soundiiz.com/connect/qobuz) redirects to the same Qobuz OAuth surface with a Soundiiz `ext_app_id` and callback. Soundiiz describes this as a popup that closes after Qobuz login ([Qobuz connection support](https://support.soundiiz.com/hc/en-us/articles/360012086699-Can-t-connect-or-change-a-Qobuz-account-to-Soundiiz)). | A Qobuz-issued external application identity. This is a partner OAuth facility, not something SongMirror can substitute with Qobuz web-player cookies. Qobuz's API terms require credentials issued by Qobuz ([Qobuz API terms](https://static.qobuz.com/apps/api/QobuzAPI-TermsofUse.pdf)). |
+| YouTube Music | Redirects to Google OAuth with offline access and both YouTube and `auth/music` scopes; the URL explicitly sets `disallow_webview=true`. The bundle labels YouTube Music `partner`. | [`/connect/ytmusic`](https://soundiiz.com/connect/ytmusic) redirects to Google OAuth with offline access and the YouTube plus `auth/music` scopes. Soundiiz says it uses the official Google API, while separately noting that Google offers no public YouTube Music API ([Google connection support](https://support.soundiiz.com/hc/en-us/articles/10555980158610-Can-t-connect-Google-or-YouTube-YouTube-Music), [YouTube Music explanation](https://support.soundiiz.com/hc/en-us/articles/360009550574-What-about-YouTube-Music)). | Ordinary YouTube Data API OAuth can cover shared YouTube playlists. Matching the competitors' Music-specific partner behavior may require Google's non-public Music scope/access. |
+| Apple Music | Uses Apple's hosted MusicKit JS v3 SDK. The current bundle configures MusicKit with a developer token, calls `authorize()`, and sends the resulting Music User Token and storefront to TuneMyMusic's backend; bundle label: `officialApi` ([current Apple authorization bundle](https://www.tunemymusic.com/_next/static/chunks/3t146e6woujf3.js)). | Soundiiz's public support material identifies the flow as Apple Music API authentication and directs users to complete it in a normal browser ([Apple Music connection support](https://support.soundiiz.com/hc/en-us/articles/360009609854-I-can-t-connect-my-Apple-Music-account)). The exact frontend implementation is not exposed on the unauthenticated login page, so MusicKit JS is a strong inference rather than directly verified code. | This is the most realistic additional web-only improvement: register MusicKit, provide a developer token, and let MusicKit obtain/manage the user token. Apple documents informed-consent authorization and automatic Music User Token handling for web apps ([MusicKit](https://developer.apple.com/documentation/musickit), [user authentication](https://developer.apple.com/documentation/applemusicapi/user-authentication-for-musickit)). |
+
+## What is and is not demonstrated
+
+### Verified
+
+- Both products open provider-owned authorization surfaces for Spotify, TIDAL,
+  Deezer, Amazon Music, Qobuz, and Google/YouTube Music.
+- TuneMyMusic uses MusicKit JS for Apple Music.
+- Their server receives authorization codes/tokens through registered callbacks;
+  the parent page does not inspect a provider iframe's cookies or network traffic.
+- Neither product requires an extension or a locally automated browser for these
+  connection flows.
+- Their app IDs, callback registrations, scopes, and partner status are the enabling
+  capabilities.
+
+### Inference or not observable publicly
+
+- Public client IDs and redirect URLs establish the authorization mechanism but do
+  not reveal either company's private contracts, token encryption implementation,
+  refresh scheduling, or internal API clients.
+- TuneMyMusic's `partner` and `officialApi` labels are its own frontend metadata;
+  `partner` does not disclose the commercial terms of the relationship.
+- Soundiiz likely uses MusicKit on the web for Apple Music, but its unauthenticated
+  bundle and support material do not prove the exact SDK call sequence.
+
+### No evidence found
+
+- Cross-origin iframe cookie extraction
+- Browser-extension collection
+- Playwright/CDP or a desktop helper
+- Cookie-jar or copied-request import for any of the seven providers
+- A TuneMyMusic or Soundiiz form that receives the user's normal password for any of
+  these seven providers
+
+## Consequence for SongMirror
+
+There are web-only improvements available, but not one universal replacement for
+manual session capture:
+
+1. Keep Spotify OAuth.
+2. Implement TIDAL authorization code + PKCE using a SongMirror TIDAL app, then verify
+   that the issued scopes support every playlist operation SongMirror needs.
+3. Implement Apple MusicKit authorization if the project can provision an Apple
+   Music developer token.
+4. Use standard Google/YouTube OAuth for the operations covered by the public YouTube
+   API; do not assume that the partner `auth/music` capability will be granted.
+5. Apply for Deezer, Qobuz, and Amazon Music app/partner access. If accepted, replace
+   their compatibility connectors with the same popup/callback pattern used by the
+   competitors.
+6. Until that access exists, private web-player sessions still require manual import
+   or a privileged local collector such as an extension or managed browser. A normal
+   popup cannot return a token unless the provider has registered SongMirror as a
+   client.
+
+Public-playlist URLs, exported files, and user-uploaded backups can provide a fully
+web-only read/import experience without account authorization. They cannot enumerate
+private libraries, run durable bidirectional sync, or write playlists back to an
+account.
+
+## Bottom line
+
+The competitor experience is real, but the missing ingredient is provider approval,
+not an undocumented iframe technique. SongMirror can offer the same clean Connect
+button immediately for Spotify, potentially TIDAL and Apple Music, and for the other
+services only after obtaining the corresponding app or partner credentials. Without
+that cooperation, manual paste, an extension, or a locally managed browser are the
+only general ways to bootstrap SongMirror's current private-web-session connectors.

--- a/frontend/src/components/transfers/TransferSetupForm.tsx
+++ b/frontend/src/components/transfers/TransferSetupForm.tsx
@@ -14,6 +14,7 @@ import { Segmented } from '../ui/Segmented'
 import { SelectField } from '../ui/SelectField'
 import { ServiceLogo } from '../ui/ServiceLogo'
 import { TextField } from '../ui/TextField'
+import { Toggle } from '../ui/Toggle'
 
 interface Props {
   /** Connected accounts only — a transfer can't read from or write to a
@@ -52,6 +53,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
   const [destMode, setDestMode] = useState<'existing' | 'create'>('existing')
   const [destPlaylistId, setDestPlaylistId] = useState('')
   const [destName, setDestName] = useState('')
+  const [preserveOrder, setPreserveOrder] = useState(false)
   const [confirming, setConfirming] = useState(false)
   const [starting, setStarting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -86,6 +88,19 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
   // A transfer writes tracks, so an existing destination must be a playlist you
   // OWN — followed (read-only) playlists are excluded from the destination picker.
   const destPlaylists = (entries[destProvider]?.playlists ?? []).filter((p) => p.owned !== false)
+
+  // Order only needs repairing when tracks are copied into a playlist that
+  // already has newer ones, so "Create new" has nothing to preserve. Some
+  // services can't replay order at all (their writes can't express it).
+  const destSupportsOrder = accounts.find((a) => a.id === destProvider)?.preserves_order ?? false
+  const canPreserveOrder = destMode === 'existing' && destSupportsOrder
+  const preserveOrderHelp = !destProvider
+    ? 'Pick a destination service first.'
+    : destMode === 'create'
+      ? 'A new playlist has nothing to reorder — copies land in source order.'
+      : !destSupportsOrder
+        ? `${tagLabel(destProvider)} can't replay order safely, so copies land at the end of the playlist.`
+        : 'Slower, and writes every track after the oldest new one again. Off: copies land at the end.'
 
   // Copying a playlist into itself is a no-op — block only the exact same-provider,
   // same-id case; same-provider "Create new" (or a different existing list) is fine.
@@ -149,6 +164,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
         dest_provider: destProvider,
         dest_playlist_id: destMode === 'create' ? null : destPlaylistId,
         dest_name: destMode === 'create' ? destName.trim() : (destPlaylist?.name ?? ''),
+        preserve_order: canPreserveOrder && preserveOrder,
       }
       const res = await api.startTransfer(body)
       setConfirming(false)
@@ -341,6 +357,15 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                     onChange={(e) => setDestName(e.target.value)}
                   />
                 )}
+
+                <Toggle
+                  label="Preserve Recently Added order"
+                  description={preserveOrderHelp}
+                  checked={canPreserveOrder && preserveOrder}
+                  disabled={!canPreserveOrder}
+                  onChange={setPreserveOrder}
+                  className="border-t border-border pt-3"
+                />
               </div>
               <div className="flex items-center gap-2 border-t border-border px-4 py-2.5">
                 <span
@@ -348,7 +373,11 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                   aria-hidden="true"
                 />
                 <span className="font-mono text-[9px] tracking-[0.1em] text-text-3">
-                  {destMode === 'create' ? 'WRITE MODE · CREATE NEW · NAME FROM DECK A' : 'WRITE MODE · ADD TO EXISTING'}
+                  {destMode === 'create'
+                    ? 'WRITE MODE · CREATE NEW · NAME FROM DECK A'
+                    : canPreserveOrder && preserveOrder
+                      ? 'WRITE MODE · ADD TO EXISTING · REPLAY ORDER'
+                      : 'WRITE MODE · ADD TO EXISTING · APPEND'}
                 </span>
               </div>
             </div>
@@ -378,7 +407,11 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                 destMode === 'create'
                   ? `a new playlist named "${destName.trim()}"`
                   : `"${destPlaylist?.name ?? ''}"`
-              } on ${tagLabel(destProvider)}. Existing tracks on the destination are kept, this only adds.`
+              } on ${tagLabel(destProvider)}. Existing tracks on the destination are kept, this only adds.${
+                canPreserveOrder && preserveOrder
+                  ? ' Tracks already there will be rewritten to keep Recently Added order, which takes longer.'
+                  : ''
+              }`
             : 'This will start copying the selected playlist.'
         }
         confirmLabel="Copy playlist"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -29,6 +29,10 @@ export interface Account {
    * False for browse-only services like Jellyfin, which the download mirror
    * feeds — the sync and transfer pickers filter on this. */
   transferable: boolean
+  /** Whether this service can replay date-added order into an existing playlist.
+   * False where the provider's writes can't express the repair safely (Deezer),
+   * which greys out the transfer form's "preserve order" switch. */
+  preserves_order: boolean
 }
 
 /** Shared shape for the plain `{ok: true}` acks (config save, settings save,
@@ -394,6 +398,8 @@ export interface TransferJob {
   dest: TransferEndpoint
   added: number
   deferred: number
+  /** Whether this copy was asked to repair the destination's date-added order. */
+  preserve_order?: boolean
   /** Existing newer tracks replayed after a recovered earlier conflict. */
   chronology_replayed?: number
   /** Hidden source relationships skipped because the provider exposes no metadata. */
@@ -416,6 +422,9 @@ export interface StartTransferRequest {
   dest_provider: string
   dest_playlist_id: string | null
   dest_name: string
+  /** Repair the destination's date-added order when a copied track is older
+   * than tracks already there. Costs many extra writes; off by default. */
+  preserve_order: boolean
 }
 
 export interface StartTransferResponse {

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -909,6 +909,37 @@ class AppleMusicTarget(MirrorTarget):
                      params={"ids[library-songs]": track["relationship_id"], "mode": "all"})
         polite_sleep(0.4)
 
+    def _relationship_totals(self, playlist):
+        """{library song id: copies currently read in the playlist}."""
+        totals = {}
+        for t in self.playlist_tracks(playlist):
+            rid = t.get("relationship_id")
+            totals[rid] = totals.get(rid, 0) + 1
+        return totals
+
+    def _totals_covering_staged_copies(self, playlist, flagged):
+        """Re-read until the playlist accounts for a retire's staged copies.
+
+        A chronology retire stages one duplicate per entry it is about to retire,
+        so every flagged library song must read at least twice its flagged count.
+        A shorter read is Apple's write lag, not a shorter playlist, and trusting
+        it computes no keeper: the DELETE takes every copy of the song, so the
+        song would be dropped from the playlist instead of reordered. Refusing
+        before the first delete leaves the staged copies for a later pass.
+        """
+        totals = self._relationship_totals(playlist)
+        for attempt in range(3):
+            short = [rid for rid, n in flagged.items() if totals.get(rid, 0) < 2 * n]
+            if not short:
+                return totals
+            if attempt < 2:
+                time.sleep(1 + attempt)
+                totals = self._relationship_totals(playlist)
+        raise RuntimeError(
+            f"Apple has not indexed {len(short)} staged chronology copy(ies) yet; leaving the "
+            "playlist untouched so a later pass can repair its order"
+        )
+
     def _remove_occurrences(self, playlist, positioned, *, strict):
         """Apple's tracks-DELETE addresses the library SONG, not one entry —
         duplicate copies share one library id, so deleting a flagged copy would
@@ -917,10 +948,6 @@ class AppleMusicTarget(MirrorTarget):
         keeper lands at the playlist's end (Apple has no positional insert); if
         its catalog id is no longer addable (delisted release), the next sync
         pass restores the song via search."""
-        totals = {}
-        for t in self.playlist_tracks(playlist):
-            rid = t.get("relationship_id")
-            totals[rid] = totals.get(rid, 0) + 1
         flagged, catalog = {}, {}
         for _, raw in positioned:
             rid = raw.get("relationship_id")
@@ -928,6 +955,11 @@ class AppleMusicTarget(MirrorTarget):
                 continue
             flagged[rid] = flagged.get(rid, 0) + 1
             catalog.setdefault(rid, raw.get("catalog_id"))
+        # A chronology retire knows a keeper was staged for every flagged entry,
+        # so it can tell a lagging read from a real one. The lenient path cannot:
+        # removing every copy of a song is a legitimate playlist edit there.
+        totals = (self._totals_covering_staged_copies(playlist, flagged) if strict
+                  else self._relationship_totals(playlist))
         for rid, n in flagged.items():
             self.remove(playlist, {"relationship_id": rid})
             keep = totals.get(rid, n) - n

--- a/songmirror/engine/targets/deezer.py
+++ b/songmirror/engine/targets/deezer.py
@@ -503,9 +503,10 @@ class DeezerTarget(MirrorTarget):
             if keep:
                 self.add(playlist, [tid] * keep)
 
-    def chronology_replay_write_cost(self, ordered_entries):
-        # Deezer's delete is catalog-id scoped, so every retired old entry also
-        # needs one keeper append after the duplicate-capable staging pass.
-        return len(ordered_entries) + sum(
-            1 for _target_id, original in ordered_entries if original is not None
-        )
+    # Deezer has no positional insert, and its delete addresses the catalog
+    # track id, so an ordered repair would have to delete every copy of a song
+    # and re-append a keeper. Its playlist reads also trail its own writes, so
+    # that keeper count can be taken from a snapshot which has not indexed the
+    # staged copies yet, retiring the song outright instead of reordering it.
+    # Appending in source order is the only ordering write Deezer can survive.
+    replay_chronology = None

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -30,7 +30,8 @@ from .playlist_links import (
 )
 
 
-def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_progress=None, should_continue=None):
+def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, preserve_order=False,
+             on_progress=None, should_continue=None):
     """Copy `src_pl` (on `source`) into `dest_pl` (on `dest`). Returns
     {added, deferred, chronology_replayed, unavailable,
     not_found: [{name, artist, key}], completed}.
@@ -45,6 +46,15 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
     before each track and, on anything but "run", ends the copy early with
     `completed=False`. Adds gathered before the break are still written, so a
     later re-run skips them (its dedup rebuilds from the destination) and resumes.
+
+    `preserve_order` opts into repairing the destination's date-added order when
+    a copied track is older than tracks already there. It costs many extra writes
+    and only some services can do it safely, so it is off by default: the copy
+    then appends in source order.
+
+    A one-off copy has no following pass to drain a deferral, so it never defers.
+    `max_adds` therefore budgets a sync pass, not this: an opted-in repair spends
+    what it actually costs, and everything else is appended in full.
     """
     read_source = getattr(
         source,
@@ -144,32 +154,41 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, on_prog
         target_id_of,
         source_identity=id,
     )
-    can_replay = callable(getattr(dest, "replay_chronology", None))
+    can_replay = preserve_order and callable(getattr(dest, "replay_chronology", None))
     replay_write_cost = getattr(dest, "chronology_replay_write_cost", len)
-    additions, chronology_replay, deferred, full_write_cost = _fit_chronology_writes(
-        [id(track) for track in ordered_source],
-        current_by_source,
-        additions,
-        lambda item: id(item[1]),
-        max_adds,
-        replay_write_cost=replay_write_cost,
-        can_replay=can_replay,
-    )
+    ordered_keys = [id(track) for track in ordered_source]
+    requested = additions
+
+    def fit(budget, ordered):
+        return _fit_chronology_writes(
+            ordered_keys, current_by_source, requested, lambda item: id(item[1]),
+            budget, replay_write_cost=replay_write_cost, can_replay=ordered)
+
+    if can_replay:
+        additions, chronology_replay, deferred, ordered_cost = fit(max_adds, True)
+        if deferred:
+            # The write cap paces a sync pass, which has a next pass to finish
+            # the job. This copy has none, and it was asked to preserve order,
+            # so it spends what the repair costs instead of dropping additions.
+            log_note(
+                f"preserving Recently Added order needs {ordered_cost} ordered writes, past the "
+                f"{max_adds}-write budget; this copy asked to preserve order, so it will make them",
+                tag="transfer",
+            )
+            additions, chronology_replay, deferred, _cost = fit(ordered_cost, True)
+        if deferred:
+            # A destination entry the provider reports without an id cannot be
+            # replayed at any budget. Append rather than drop the additions.
+            log_warn(
+                f"the destination's order could not be replayed, so all {len(requested)} "
+                "addition(s) are being copied in source order instead",
+                tag="transfer",
+            )
+            additions, chronology_replay, deferred, _cost = fit(len(requested), False)
+    else:
+        additions, chronology_replay, deferred, _cost = fit(len(requested), False)
     chronology_replayed = sum(1 for _target_id, original in chronology_replay
                               if original is not None)
-    if deferred:
-        if full_write_cost > max_adds and can_replay:
-            log_warn(
-                f"preserving Recently Added order would require {full_write_cost} ordered writes; "
-                f"the limit is {max_adds}, so {deferred} addition(s) were deferred",
-                tag="transfer",
-            )
-        else:
-            log_warn(
-                f"{len(additions) + deferred} additions exceed the limit of {max_adds}; "
-                f"deferring {deferred}",
-                tag="transfer",
-            )
     if chronology_replay:
         log_note(
             f"replaying {chronology_replayed} newer track(s) after {len(additions)} recovered "
@@ -284,7 +303,8 @@ class TransferService:
 
     def submit(self, spec):
         """spec: {source_provider, source_playlist_id, dest_provider,
-        dest_playlist_id | None, dest_name}. Returns the job dict (with id)."""
+        dest_playlist_id | None, dest_name, preserve_order}. Returns the job
+        dict (with id)."""
         job = {
             "id": uuid.uuid4().hex[:8], "status": "queued",
             "source": {"provider": spec["source_provider"],
@@ -292,6 +312,7 @@ class TransferService:
             "dest": {"provider": spec["dest_provider"],
                      "playlist_id": spec.get("dest_playlist_id"),
                      "playlist_name": spec.get("dest_name", "")},
+            "preserve_order": bool(spec.get("preserve_order")),
             "added": 0, "deferred": 0, "chronology_replayed": 0,
             "unavailable": 0, "conflicts": [], "error": None,
             "total": 0, "processed": 0,  # live progress: source tracks examined / total
@@ -414,6 +435,7 @@ class TransferService:
                 job["processed"], job["total"], job["added"] = processed, total, base_added + added
 
             res = transfer(src, dst, src_pl, dest_pl, cache, execute=True, max_adds=opts.max_adds,
+                           preserve_order=job["preserve_order"],
                            on_progress=on_progress, should_continue=lambda: job.get("_control", "run"))
             save_cache(dst.cache_file, cache)
             return res

--- a/songmirror/web/routers/accounts.py
+++ b/songmirror/web/routers/accounts.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit, urlunsplit
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
-from ...engine.targets import is_peer
+from ...engine.targets import is_peer, target_class
 from ...services.accounts import CONNECTORS
 from ...services.accounts.base import ConnStatus, DeviceCode
 
@@ -18,6 +18,17 @@ router = APIRouter()
 
 def _conn(request: Request, cid: str):
     return CONNECTORS[cid](request.app.state.settings)
+
+
+def _preserves_order(cid):
+    """Whether a provider can repair date-added order in an existing playlist.
+
+    A target opts out by setting ``replay_chronology = None`` (Deezer, whose
+    writes cannot express the repair safely), so this asks the class rather than
+    keeping a second list the two could drift apart on.
+    """
+    cls = target_class(cid)
+    return cls is not None and callable(getattr(cls, "replay_chronology", None))
 
 
 def _redirect_uri(request: Request, cid: str) -> str:
@@ -91,6 +102,10 @@ def list_accounts(request: Request):
             # Browse-only services (Jellyfin) can't be a sync/transfer peer — the
             # UI filters its source/destination pickers on this.
             "transferable": is_peer(cid),
+            # Whether this service can replay date-added order into an existing
+            # playlist. Read off the target class (no credentials needed), so a
+            # provider that opts out stays opted out in the UI by construction.
+            "preserves_order": _preserves_order(cid),
         })
     return out
 

--- a/songmirror/web/routers/transfers.py
+++ b/songmirror/web/routers/transfers.py
@@ -31,6 +31,9 @@ async def start_transfer(request: Request, body: dict = Body(...)):
         "dest_provider": body["dest_provider"],
         "dest_playlist_id": body.get("dest_playlist_id"),
         "dest_name": body.get("dest_name", ""),
+        # Off unless asked for: the repair costs many extra writes and only
+        # applies when a copied track predates tracks already on the destination.
+        "preserve_order": bool(body.get("preserve_order")),
     })
     return JSONResponse({"job_id": job["id"]}, status_code=202)
 

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -637,7 +637,6 @@ def test_qobuz_only_allows_duplicate_adds_for_chronology_staging(monkeypatch):
 
 @pytest.mark.parametrize("module_name,class_name", [
     ("songmirror.engine.targets.apple", "AppleMusicTarget"),
-    ("songmirror.engine.targets.deezer", "DeezerTarget"),
 ])
 def test_catalog_scoped_removal_counts_keeper_readds_in_chronology_cap(module_name, class_name):
     import importlib
@@ -647,6 +646,14 @@ def test_catalog_scoped_removal_counts_keeper_readds_in_chronology_cap(module_na
     entries = [("b", None), ("c", (1, {})), ("d", (2, {}))]
 
     assert target.chronology_replay_write_cost(entries) == 5
+
+
+def test_deezer_never_replays_chronology():
+    """Deezer's delete is catalog-id scoped and its reads trail its own writes,
+    so a staged-copy replay can retire the only copy of a song. It appends."""
+    from songmirror.engine.targets.deezer import DeezerTarget
+
+    assert not callable(getattr(DeezerTarget, "replay_chronology", None))
 
 
 def test_apple_chronology_retirement_surfaces_a_failed_keeper_readd():
@@ -664,6 +671,61 @@ def test_apple_chronology_retirement_surfaces_a_failed_keeper_readd():
 
     with pytest.raises(RuntimeError, match="add failed"):
         target.retire_chronology_originals({"id": "playlist"}, [(0, row)])
+
+
+def test_apple_chronology_retirement_refuses_a_read_missing_its_staged_copies(monkeypatch):
+    """Apple's DELETE takes every copy of a library song. A read that has not
+    indexed the staged copy yet computes no keeper, so retiring against it would
+    drop the song instead of reordering it: delete nothing and let a pass retry."""
+    from songmirror.engine.targets.apple import AppleMusicTarget
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    row = {"relationship_id": "library-song", "catalog_id": "catalog-song"}
+    removed = []
+    target.playlist_tracks = lambda _playlist: [row]      # the staged copy is not visible yet
+    target.remove = lambda _playlist, track: removed.append(track)
+    target.add = lambda _playlist, _ids: None
+
+    with pytest.raises(RuntimeError, match="has not indexed"):
+        target.retire_chronology_originals({"id": "playlist"}, [(0, row)])
+    assert removed == []
+
+
+def test_apple_chronology_retirement_waits_out_a_lagging_read(monkeypatch):
+    from songmirror.engine.targets.apple import AppleMusicTarget
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    row = {"relationship_id": "library-song", "catalog_id": "catalog-song"}
+    reads, removed, added = [], [], []
+    # The first read trails the staging append; the second has caught up.
+    target.playlist_tracks = lambda _playlist: (
+        reads.append(1), [row] if len(reads) == 1 else [row, dict(row)])[1]
+    target.remove = lambda _playlist, track: removed.append(track)
+    target.add = lambda _playlist, ids: added.extend(ids)
+
+    target.retire_chronology_originals({"id": "playlist"}, [(0, row)])
+
+    assert removed == [{"relationship_id": "library-song"}]
+    assert added == ["catalog-song"]                      # the staged copy is put back
+
+
+def test_apple_remove_occurrences_still_allows_removing_every_copy():
+    """The lenient path serves playlist edits, where deleting every copy of a
+    song is what the user asked for. Only the chronology retire may refuse."""
+    from songmirror.engine.targets.apple import AppleMusicTarget
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    row = {"relationship_id": "library-song", "catalog_id": "catalog-song"}
+    removed, added = [], []
+    target.playlist_tracks = lambda _playlist: [row, dict(row)]
+    target.remove = lambda _playlist, track: removed.append(track)
+    target.add = lambda _playlist, ids: added.extend(ids)
+
+    target.remove_occurrences({"id": "playlist"}, [(0, row), (1, dict(row))])
+
+    assert removed == [{"relationship_id": "library-song"}] and added == []
 
 
 def test_qobuz_playlist_read_follows_total_across_short_pages(monkeypatch):

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -320,7 +320,7 @@ def test_resumed_transfer_replays_newer_tracks_after_a_resolved_conflict():
     result = transfer(
         Source(), destination, {"id": "source"}, {"id": "destination"},
         {"search": {}, "isrc": {}, "dirty": False},
-        execute=True, max_adds=200,
+        execute=True, max_adds=200, preserve_order=True,
     )
 
     assert destination.replayed == [[("b", None), ("c", 1), ("d", 2)]]
@@ -372,12 +372,121 @@ def test_transfer_replay_uses_a_resolved_existing_id_despite_metadata_drift():
     result = transfer(
         Source(), destination, {"id": "source"}, {"id": "destination"},
         {"search": {}, "isrc": {}, "dirty": False},
-        execute=True, max_adds=200,
+        execute=True, max_adds=200, preserve_order=True,
     )
 
     assert destination.replayed == [[("b", None), ("c", 1), ("d", 2)]]
     assert result["added"] == 1
     assert result["chronology_replayed"] == 2
+
+
+class _OrderedSource:
+    source = "spotify"
+
+    def playlist_tracks(self, playlist):
+        return [
+            {"id": f"s{index}", "name": f"T{index}", "artists": ["Artist"],
+             "duration_ms": 1, "added_at": f"2020-01-01T00:00:{index:02d}Z"}
+            for index in range(6)
+        ]
+
+
+class _OrderedDestination:
+    """Holds the two NEWEST source tracks, so filling the gap below them needs a
+    replay of the whole tail — more ordered writes than a small cap allows."""
+    source = "apple"
+
+    def __init__(self):
+        self.added, self.replayed = [], []
+
+    def playlist_tracks(self, playlist):
+        return [
+            {"id": f"s{index}", "name": f"T{index}", "artist": "Artist", "duration_ms": 1}
+            for index in (4, 5)
+        ]
+
+    def resolve(self, track, cache):
+        return f"s{track['name'][1:]}", "search"
+
+    def track_id(self, track):
+        return track["id"]
+
+    def replay_chronology(self, playlist, ordered_entries):
+        self.replayed.append([target_id for target_id, _original in ordered_entries])
+
+    def add(self, playlist, ids):
+        self.added.extend(ids)
+
+
+def test_transfer_appends_in_source_order_unless_asked_to_preserve_it():
+    """The ordered repair is opt-in: it rewrites tracks already on the
+    destination, so a plain copy appends even where the service could replay."""
+    destination = _OrderedDestination()
+    result = transfer(
+        _OrderedSource(), destination, {"id": "source"}, {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True, max_adds=2,
+    )
+
+    assert destination.replayed == []
+    assert destination.added == ["s0", "s1", "s2", "s3"]     # oldest-first, all of them
+    assert result["added"] == 4 and result["deferred"] == 0
+    assert result["chronology_replayed"] == 0
+
+
+def test_transfer_preserving_order_spends_past_the_write_budget():
+    """A one-off copy has no next pass to drain a deferral. Asked to preserve
+    order, it pays the repair's real cost instead of writing nothing."""
+    destination = _OrderedDestination()
+    result = transfer(
+        _OrderedSource(), destination, {"id": "source"}, {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True, max_adds=2, preserve_order=True,
+    )
+
+    assert destination.added == []
+    assert destination.replayed == [["s0", "s1", "s2", "s3", "s4", "s5"]]
+    assert result["added"] == 4 and result["deferred"] == 0
+    assert result["chronology_replayed"] == 2               # s4 and s5 were already there
+
+
+def test_transfer_does_not_truncate_a_copy_at_the_write_cap():
+    added = []
+    source_tracks = [
+        {"id": f"s{index}", "name": f"T{index}", "artists": ["Artist"],
+         "duration_ms": 1, "added_at": f"2020-01-01T00:00:{index:02d}Z"}
+        for index in range(5)
+    ]
+
+    class Source:
+        source = "spotify"
+
+        def playlist_tracks(self, playlist):
+            return source_tracks
+
+    class Destination:
+        source = "apple"
+
+        def playlist_tracks(self, playlist):
+            return []
+
+        def resolve(self, track, cache):
+            return f"s{track['name'][1:]}", "search"
+
+        def track_id(self, track):
+            return track["id"]
+
+        def add(self, playlist, ids):
+            added.extend(ids)
+
+    result = transfer(
+        Source(), Destination(), {"id": "source"}, {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True, max_adds=2,
+    )
+
+    assert added == ["s0", "s1", "s2", "s3", "s4"]
+    assert result["added"] == 5 and result["deferred"] == 0
 
 
 def test_transfer_dry_run_adds_nothing():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -84,6 +84,12 @@ def test_accounts_list_all_unconfigured(tmp_path):
             "spotify", "tidal", "qobuz", "deezer", "amazon", "apple", "ytmusic", "jellyfin"
         }
         assert all(a["state"] == "unconfigured" for a in accounts)
+        # The transfer form greys out its "preserve order" switch on a service
+        # whose writes can't replay date-added order.
+        by_id = {a["id"]: a for a in accounts}
+        assert by_id["apple"]["preserves_order"] is True
+        assert by_id["deezer"]["preserves_order"] is False
+        assert by_id["jellyfin"]["preserves_order"] is False   # browse-only, no target
 
 
 def test_settings_roundtrip_masks_secrets(tmp_path):
@@ -618,7 +624,20 @@ def test_transfers_start_and_status(tmp_path, monkeypatch):
         assert jid
         g = client.get(f"/api/transfers/{jid}").json()
         assert g["id"] == jid and "status" in g
+        assert g["preserve_order"] is False   # the ordered repair is opt-in
         assert "_dest_cache_file" not in g  # internal field hidden from the API
+
+
+def test_transfer_carries_the_preserve_order_choice(tmp_path, monkeypatch):
+    from songmirror.services.transfers import TransferService
+
+    monkeypatch.setattr(TransferService, "_build", lambda self, pid, opts: None)
+    with TestClient(_app(tmp_path)) as client:
+        r = client.post("/api/transfers", json={"source_provider": "apple", "source_playlist_id": "p1",
+                                                "dest_provider": "ytmusic", "dest_playlist_id": "p2",
+                                                "preserve_order": True})
+        job = client.get(f"/api/transfers/{r.json()['job_id']}").json()
+        assert job["preserve_order"] is True
 
 
 def test_sse_payload_format():


### PR DESCRIPTION
## Summary

- make one-off transfers append every requested match by default and add an opt-in, capability-aware control for preserving Recently Added order
- harden Apple chronology retirement against lagging reads and disable unsafe chronology replay for Deezer
- document transfer semantics and add a provider-by-provider assessment of competitor account-connection flows

## Test plan

- [x] `uv run python -m pytest` (522 passed, 1 skipped)
- [x] `uv lock --check`
- [x] `pnpm -C frontend lint`
- [x] `pnpm -C frontend build`
- [x] `$env:CI='true'; pnpm -C frontend test:e2e` (131 checks, 0 overflow failures)
- [x] `docker compose config --quiet`
- [x] `git diff --check origin/main...HEAD`