### PR TITLE
fix(tidal): persist the web-player OAuth client ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,9 @@ SPOTIFY_WRITE_BACKEND=cookie
 #SPOTIFY_CLIENT_ID=
 #SPOTIFY_CLIENT_SECRET=
 
-# TIDAL signed-in web-player oauth2/token Response JSON (normally saved in Accounts).
-# Includes the refresh token so SongMirror can renew the access token automatically.
+# TIDAL signed-in web-player oauth2/token request client_id and Response JSON
+# (normally saved together in Accounts). Both are required for automatic renewal.
+TIDAL_WEB_CLIENT_ID=
 TIDAL_WEB_HEADERS=
 TIDAL_COUNTRY_CODE=US
 TIDAL_TOKEN_FILE=data/tidal_oauth.json

--- a/README.md
+++ b/README.md
@@ -363,10 +363,11 @@ That single signed-in web session handles library browsing, playlist reads and w
 
 1. Open [TIDAL's web player](https://listen.tidal.com), open DevTools → **Network**, and enable **Preserve log**.
 2. Sign out and sign back in, then filter the Network list for `oauth2/token`.
-3. Select the successful `auth.tidal.com/v1/oauth2/token` request, open **Response**, and copy its complete JSON.
-4. In SongMirror, open **Accounts → TIDAL** and paste that response. It should include both `access_token` and `refresh_token`.
+3. Select the successful `auth.tidal.com/v1/oauth2/token` request. In **Payload** (Chrome/Edge) or **Request** (Firefox), copy the `client_id` form value into SongMirror's **Web-player client ID** field.
+4. Open the request's **Response** tab and copy its complete JSON into **Web-player token response**. It should include both `access_token` and `refresh_token`.
+5. Connect. SongMirror immediately exercises the refresh grant and refuses to report success if that client ID cannot renew it.
 
-SongMirror extracts only the access token, refresh token, client ID, scopes, expiry, and catalog country; unrelated response data is discarded. It renews just before expiry and once after an authentication rejection through `https://auth.tidal.com/v1/oauth2/token`, preserving refresh-token rotation. The older OpenAPI request-header paste remains compatible, but because it contains no refresh token it still needs to be re-pasted after expiry. Only catalog metadata and the signed-in user's playlists are used—playback assets stay outside this integration.
+The OAuth client ID is request metadata and is not the numeric `cid` claim inside TIDAL's access token. SongMirror extracts only the access token, refresh token, client ID, scopes, expiry, and catalog country; unrelated response data is discarded. It renews just before expiry and once after an authentication rejection through `https://auth.tidal.com/v1/oauth2/token`, preserving refresh-token rotation. The older OpenAPI request-header paste remains compatible, but because it contains no refresh token it still needs to be re-pasted after expiry. Only catalog metadata and the signed-in user's playlists are used—playback assets stay outside this integration.
 
 ### Qobuz
 
@@ -523,7 +524,7 @@ frontend/       # React + Vite SPA (built and served by the API in production)
 ## 🩺 Troubleshooting
 
 - **`Missing required environment variable`** — fill in `.env` (CLI) or connect the service in the UI.
-- **TIDAL reports `Expired`** — sign out and back in at `listen.tidal.com`, then paste the complete `oauth2/token` Response JSON in Accounts. A copied OpenAPI request has only the short-lived Bearer and cannot renew.
+- **TIDAL reports `Expired`** — sign out and back in at `listen.tidal.com`, then paste both the `client_id` from the `oauth2/token` request payload and its complete Response JSON in Accounts. A copied OpenAPI request has only the short-lived Bearer and cannot renew.
 - **TIDAL reports HTTP 429** — this is a temporary rate limit, not an expired sign-in. SongMirror honors the provider retry delay and caches account health checks instead of repeatedly probing the API.
 - **Qobuz or Apple reports `Expired` / `401` / `403`** — these pasted sessions have no renewable secret; capture a fresh signed-in request or token in Accounts.
 - **TIDAL says the token lacks liked-track access** — capture a fresh signed-in web-player token response carrying `r_usr` and `w_usr`.

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -44,7 +44,10 @@ const ACCOUNTS = [
     id: 'tidal',
     name: 'TIDAL',
     auth_kind: 'token_paste',
-    fields: [{ key: 'TIDAL_WEB_HEADERS', label: 'Web-player token response', secret: true, help: 'Copy the oauth2/token Response JSON', required: true }],
+    fields: [
+      { key: 'TIDAL_WEB_CLIENT_ID', label: 'Web-player client ID', secret: false, help: 'Copy client_id from the oauth2/token request payload', required: false },
+      { key: 'TIDAL_WEB_HEADERS', label: 'Web-player token response', secret: true, help: 'Copy the oauth2/token Response JSON', required: true },
+    ],
     state: 'unconfigured',
     detail: null,
     transferable: true,
@@ -2027,17 +2030,20 @@ async function main() {
       await shot(page, `connect-wizard-device-${width}`)
       await page.getByRole('dialog').getByRole('button', { name: 'Close', exact: true }).click()
 
-      // TIDAL imports the web player's complete token response so the refresh
-      // token—not just the short-lived bearer—is available for renewal.
+      // TIDAL imports both halves needed for renewal: client_id comes from the
+      // request payload, while the refresh token comes from the response.
       await page
         .locator('h3', { hasText: 'TIDAL' })
         .locator('xpath=ancestor::div[contains(@class,"rounded-card")][1]')
         .getByRole('button', { name: 'Connect', exact: true })
         .click()
       const tidalDialog = page.getByRole('dialog')
+      const tidalClientId = tidalDialog.getByLabel('Web-player client ID')
       const tidalSession = tidalDialog.locator('#browser-session-TIDAL_WEB_HEADERS')
       const tidalRequirementsOk =
         (await tidalSession.evaluate((node) => node.required)) &&
+        (await tidalClientId.count()) === 1 &&
+        (await tidalDialog.getByText('client_id', { exact: false }).count()) > 0 &&
         (await tidalDialog.getByText('oauth2/token', { exact: false }).count()) > 0 &&
         (await tidalDialog.getByText('refresh_token', { exact: false }).count()) > 0 &&
         (await tidalDialog.locator('textarea').count()) === 1
@@ -2045,6 +2051,7 @@ async function main() {
         `${tidalRequirementsOk ? 'ok        ' : 'FAIL      '} TIDAL requests a renewable web-player token response`,
       )
       if (!tidalRequirementsOk) results.push({ label: 'TIDAL field requirements', overflow: true })
+      await tidalClientId.fill('public-web-client')
       await tidalSession.fill('{"access_token":"token","refresh_token":"refresh"}')
       await tidalDialog.getByRole('button', { name: 'Connect', exact: true }).click()
       const tidalSuccess = tidalDialog.getByRole('status')

--- a/frontend/src/components/accounts/ConnectWizardModal.tsx
+++ b/frontend/src/components/accounts/ConnectWizardModal.tsx
@@ -98,13 +98,15 @@ const CONNECT_GUIDES: Record<string, ConnectGuideContent> = {
         Sign out of TIDAL and sign back in, then filter the Network list for <Code>oauth2/token</Code>.
       </>,
       <>
-        Select the successful <Code>auth.tidal.com/v1/oauth2/token</Code> request and open its{' '}
-        <strong>Response</strong> tab.
+        Select the successful <Code>auth.tidal.com/v1/oauth2/token</Code> request. Open <strong>Payload</strong>{' '}
+        (Chrome/Edge) or <strong>Request</strong> (Firefox), then copy its <Code>client_id</Code> form value.
       </>,
-      <>Copy the complete JSON response and paste it below. It should contain both <Code>access_token</Code> and{' '}
-        <Code>refresh_token</Code>.</>,
+      <>
+        Open <strong>Response</strong>, then copy the complete JSON into the token-response field. It should contain
+        both <Code>access_token</Code> and <Code>refresh_token</Code>.
+      </>,
     ],
-    note: 'Treat this response like a password. SongMirror discards profile data, keeps only the access token, refresh token, client ID, scopes, and country, then automatically persists token rotation. Older OpenAPI request-header pastes still work but cannot renew.',
+    note: 'Treat the response like a password. The request client_id is public metadata; it is not the numeric cid inside the access token. SongMirror proves renewal before reporting success, discards profile data, and automatically persists token rotation. Older OpenAPI request-header pastes still work but cannot renew.',
     link: { href: 'https://listen.tidal.com', label: 'Open TIDAL web player' },
   },
   qobuz: {

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -56,11 +56,16 @@ class TidalTarget(MirrorTarget):
         # catalog entries TIDAL has since delisted (see playlist_tracks).
         self._songs = songs
         self._web_headers = (os.getenv("TIDAL_WEB_HEADERS") or "").strip()
+        self._web_client_id = (os.getenv("TIDAL_WEB_CLIENT_ID") or "").strip()
         if not self._web_headers:
             raise RuntimeError("Missing TIDAL web-player session; connect TIDAL in Accounts")
         self._token_file = token_path("TIDAL_TOKEN_FILE", DEFAULT_TOKEN_FILE)
         try:
-            self._tok = ensure_web_access_token(self._web_headers, self._token_file)
+            self._tok = ensure_web_access_token(
+                self._web_headers,
+                self._token_file,
+                client_id=self._web_client_id,
+            )
         except TidalWebRejected as exc:
             raise TargetAuthError(str(exc)) from exc
         except TidalWebUnavailable as exc:
@@ -77,7 +82,12 @@ class TidalTarget(MirrorTarget):
     # -- auth / HTTP ---------------------------------------------------------
     def _access(self, force=False):
         try:
-            self._tok = ensure_web_access_token(self._web_headers, self._token_file, force=force)
+            self._tok = ensure_web_access_token(
+                self._web_headers,
+                self._token_file,
+                force=force,
+                client_id=self._web_client_id,
+            )
         except TidalWebRejected as exc:
             raise TargetAuthError(str(exc)) from exc
         except TidalWebUnavailable as exc:

--- a/songmirror/services/accounts/tidal.py
+++ b/songmirror/services/accounts/tidal.py
@@ -61,6 +61,15 @@ class TidalConnector(Connector):
     auth_kind = "token_paste"
     config_fields = [
         Field(
+            "TIDAL_WEB_CLIENT_ID",
+            "Web-player client ID",
+            help=(
+                "From the same oauth2/token request: Payload (or Form Data) → client_id; "
+                "this is not the numeric cid inside the access token"
+            ),
+            required=False,
+        ),
+        Field(
             "TIDAL_WEB_HEADERS",
             "Web-player token response",
             secret=True,
@@ -80,6 +89,13 @@ class TidalConnector(Connector):
     def _raw(self):
         return self._store.get("TIDAL_WEB_HEADERS") or os.getenv("TIDAL_WEB_HEADERS") or ""
 
+    def _client_id(self):
+        return (
+            self._store.get("TIDAL_WEB_CLIENT_ID")
+            or os.getenv("TIDAL_WEB_CLIENT_ID")
+            or ""
+        )
+
     def _token_file(self):
         return os.getenv("TIDAL_TOKEN_FILE") or self._store.get("TIDAL_TOKEN_FILE") or DEFAULT_TOKEN_FILE
 
@@ -95,15 +111,25 @@ class TidalConnector(Connector):
             timeout=REQUEST_TIMEOUT,
         )
 
-    def _validate(self, raw=None):
+    def _validate(self, raw=None, *, client_id=None):
         source = raw if raw is not None else self._raw()
         if not str(source).strip():
             return ConnStatus("unconfigured", "capture a signed-in TIDAL web-player token response")
         try:
-            token = ensure_web_access_token(source, self._token_file())
+            client_id = self._client_id() if client_id is None else client_id
+            token = ensure_web_access_token(
+                source,
+                self._token_file(),
+                client_id=client_id,
+            )
             response = self._check(token["access_token"], token.get("country_code") or "US")
             if response.status_code in (401, 403):
-                token = ensure_web_access_token(source, self._token_file(), force=True)
+                token = ensure_web_access_token(
+                    source,
+                    self._token_file(),
+                    force=True,
+                    client_id=client_id,
+                )
                 response = self._check(token["access_token"], token.get("country_code") or "US")
             if response.ok:
                 return ConnStatus("connected", _scope_detail(token))
@@ -160,9 +186,12 @@ class TidalConnector(Connector):
         return status
 
     def submit(self, values):
-        raw = str(values.get("TIDAL_WEB_HEADERS") or "").strip()
+        # Reconnect forms never echo a stored secret back to the browser. Let a
+        # user repair an older capture by supplying only the missing client ID.
+        raw = str(values.get("TIDAL_WEB_HEADERS") or self._raw()).strip()
+        client_id = str(values.get("TIDAL_WEB_CLIENT_ID") or self._client_id()).strip()
         try:
-            minimized = serialize_web_headers(raw)
+            minimized = serialize_web_headers(raw, client_id=client_id)
             context = parse_web_headers(minimized)
         except ValueError as exc:
             return ConnStatus("error", str(exc))
@@ -171,7 +200,21 @@ class TidalConnector(Connector):
         previous = read_token(token_file)
         try:
             seed_web_session(minimized, token_file)
-            status = self._validate(minimized)
+            # A live access token only proves that the paste works right now.
+            # Exercise the refresh grant before claiming automatic renewal, so
+            # an internal JWT cid can never produce a false "connected" state.
+            if context.get("refresh_token"):
+                ensure_web_access_token(minimized, token_file, force=True)
+            status = self._validate(minimized, client_id=context.get("client_id", ""))
+        except (TidalWebError, ValueError) as exc:
+            if previous:
+                write_token(token_file, previous)
+            else:
+                try:
+                    os.remove(token_file)
+                except FileNotFoundError:
+                    pass
+            return ConnStatus("error", str(exc))
         except Exception:
             if previous:
                 write_token(token_file, previous)
@@ -193,6 +236,7 @@ class TidalConnector(Connector):
 
         self._store.save({
             "TIDAL_WEB_HEADERS": minimized,
+            "TIDAL_WEB_CLIENT_ID": context.get("client_id", ""),
             "TIDAL_COUNTRY_CODE": context["country_code"],
             # The web player is now authoritative. Retire the development-app
             # config and incomplete callback state so no fallback can silently
@@ -212,6 +256,7 @@ class TidalConnector(Connector):
     def disconnect(self):
         self._store.save({
             "TIDAL_WEB_HEADERS": "",
+            "TIDAL_WEB_CLIENT_ID": "",
             "TIDAL_CLIENT_ID": "",
             "TIDAL_OAUTH_STATE": "",
             "TIDAL_OAUTH_VERIFIER": "",

--- a/songmirror/tidal_web.py
+++ b/songmirror/tidal_web.py
@@ -79,7 +79,7 @@ def _epoch_seconds(value, *, milliseconds=False) -> int | None:
     return int(number) if number > 0 else None
 
 
-def parse_web_headers(raw: str) -> dict:
+def parse_web_headers(raw: str, *, client_id: str = "") -> dict:
     """Minimize a web token response or a legacy OpenAPI request.
 
     Current captures should be the JSON response from the web player's
@@ -107,15 +107,19 @@ def parse_web_headers(raw: str) -> dict:
     claims = _jwt_claims(access_token)
     refresh_token = str(direct.get("refresh_token") or direct.get("refreshToken") or "").strip()
     client_id = str(
-        direct.get("client_id")
+        client_id
+        or direct.get("client_id")
         or direct.get("clientId")
         or nested.get("clientId")
-        or claims.get("cid")
-        or claims.get("client_id")
         or ""
     ).strip()
     if any(char in refresh_token + client_id for char in "\r\n"):
         raise ValueError("TIDAL renewal credentials are malformed")
+    if refresh_token and re.fullmatch(r"\d+", client_id):
+        raise ValueError(
+            f"TIDAL client ID {client_id} is the access token's internal cid, not the "
+            "OAuth client_id; copy client_id from the oauth2/token request's Payload tab"
+        )
 
     headers = selected_headers(raw, {"x-tidal-country-code", "tidal-country-code"})
     query = query_values(raw)
@@ -154,8 +158,8 @@ def parse_web_headers(raw: str) -> dict:
         )
     if refresh_token and not client_id:
         raise ValueError(
-            "the TIDAL token response did not expose its client id; paste the complete "
-            "oauth2/token Response JSON"
+            "the TIDAL token response does not contain its OAuth client ID; copy client_id "
+            "from the same oauth2/token request's Payload tab"
         )
 
     result = {
@@ -173,16 +177,23 @@ def parse_web_headers(raw: str) -> dict:
     return result
 
 
-def serialize_web_headers(raw: str) -> str:
+def serialize_web_headers(raw: str, *, client_id: str = "") -> str:
     """Return the allowlisted, durable subset of a browser capture."""
 
-    return json.dumps(parse_web_headers(raw), separators=(",", ":"), sort_keys=True)
+    return json.dumps(
+        parse_web_headers(raw, client_id=client_id),
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def _session_from_context(context: dict) -> dict:
     access_token = context["authorization"].split(None, 1)[1]
     fingerprint = hashlib.sha256(
-        f"{access_token}\0{context.get('refresh_token', '')}".encode()
+        (
+            f"{access_token}\0{context.get('refresh_token', '')}"
+            f"\0{context.get('client_id', '')}"
+        ).encode()
     ).hexdigest()
     token = {
         "auth_mode": AUTH_MODE,
@@ -196,10 +207,10 @@ def _session_from_context(context: dict) -> dict:
     return token
 
 
-def seed_web_session(raw: str, token_file: str) -> dict:
+def seed_web_session(raw: str, token_file: str, *, client_id: str = "") -> dict:
     """Replace the on-disk session with an explicitly pasted browser grant."""
 
-    token = _session_from_context(parse_web_headers(raw))
+    token = _session_from_context(parse_web_headers(raw, client_id=client_id))
     write_token(token_file, token)
     return token
 
@@ -214,11 +225,17 @@ def _refresh_error(response) -> str:
     return str(payload.get("error_description") or payload.get("error") or f"HTTP {response.status_code}")
 
 
-def ensure_web_access_token(raw: str, token_file: str, *, force: bool = False) -> dict:
+def ensure_web_access_token(
+    raw: str,
+    token_file: str,
+    *,
+    force: bool = False,
+    client_id: str = "",
+) -> dict:
     """Return a live web-player token, refreshing and persisting when needed."""
 
     with _TOKEN_LOCK:
-        bootstrap = _session_from_context(parse_web_headers(raw))
+        bootstrap = _session_from_context(parse_web_headers(raw, client_id=client_id))
         token = read_token(token_file)
         if (
             token.get("auth_mode") != AUTH_MODE

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -285,23 +285,116 @@ def _tidal_web_token(*, exp=4_102_444_800, scopes="r_usr w_usr", country="US", c
     return f"header.{payload}.signature"
 
 
+def test_tidal_refresh_response_does_not_use_internal_jwt_cid_as_oauth_client_id():
+    from songmirror.tidal_web import parse_web_headers
+
+    raw = json.dumps({
+        "access_token": _tidal_web_token(client="8049"),
+        "refresh_token": "web-refresh",
+        "scope": "r_usr w_usr",
+    })
+
+    with pytest.raises(ValueError, match="Payload tab"):
+        parse_web_headers(raw)
+
+
+def test_tidal_refresh_response_rejects_an_explicit_numeric_internal_cid():
+    from songmirror.tidal_web import parse_web_headers
+
+    raw = json.dumps({
+        "access_token": _tidal_web_token(client="8049"),
+        "refresh_token": "web-refresh",
+        "client_id": "8049",
+        "scope": "r_usr w_usr",
+    })
+
+    with pytest.raises(ValueError, match="internal cid"):
+        parse_web_headers(raw)
+
+
+def test_tidal_client_id_change_reseeds_the_saved_browser_grant(tmp_path, monkeypatch):
+    from songmirror.oauth import read_token
+    from songmirror.tidal_web import ensure_web_access_token, seed_web_session
+
+    token_file = tmp_path / "tidal-web-session.json"
+    raw = json.dumps({
+        "access_token": _tidal_web_token(client="8049"),
+        "refresh_token": "web-refresh",
+        "scope": "r_usr w_usr",
+    })
+    seed_web_session(raw, str(token_file), client_id="stale-client")
+
+    class RefreshResponse:
+        ok = True
+        status_code = 200
+
+        def json(self):
+            return {
+                "access_token": _tidal_web_token(client="8049"),
+                "refresh_token": "rotated-refresh",
+                "expires_in": 86_400,
+                "scope": "r_usr w_usr",
+            }
+
+    requests = []
+    monkeypatch.setattr(
+        "songmirror.tidal_web.requests.post",
+        lambda *args, **kwargs: requests.append(kwargs["data"]) or RefreshResponse(),
+    )
+
+    ensure_web_access_token(
+        raw,
+        str(token_file),
+        force=True,
+        client_id="public-web-client",
+    )
+
+    assert requests[0]["client_id"] == "public-web-client"
+    assert read_token(str(token_file))["client_id"] == "public-web-client"
+
+
 def test_tidal_connector_accepts_renewable_web_player_token_response(tmp_path, monkeypatch):
     from songmirror.services.accounts.tidal import TidalConnector
+    from songmirror.tidal_web import TOKEN_URL
 
     token_file = tmp_path / "tidal-web-session.json"
     monkeypatch.setenv("TIDAL_TOKEN_FILE", str(token_file))
     monkeypatch.setenv("TIDAL_WEB_HEADERS", "")
+    monkeypatch.setenv("TIDAL_WEB_CLIENT_ID", "")
+    refresh_calls = []
 
-    class Response:
+    class CheckResponse:
         ok = True
         status_code = 200
 
-    monkeypatch.setattr("songmirror.services.accounts.tidal.requests.get", lambda *a, **k: Response())
+    class RefreshResponse:
+        ok = True
+        status_code = 200
+
+        def json(self):
+            return {
+                "access_token": _tidal_web_token(client="8049"),
+                "refresh_token": "rotated-refresh",
+                "expires_in": 86_400,
+                "scope": "r_usr w_usr",
+            }
+
+    monkeypatch.setattr(
+        "songmirror.services.accounts.tidal.requests.get",
+        lambda *a, **k: CheckResponse(),
+    )
+    monkeypatch.setattr(
+        "songmirror.tidal_web.requests.post",
+        lambda url, **kwargs: refresh_calls.append((url, kwargs)) or RefreshResponse(),
+    )
     store = SettingsStore(dir=tmp_path / "settings")
     connector = TidalConnector(store)
     status = connector.submit({
+        "TIDAL_WEB_CLIENT_ID": "public-web-client",
         "TIDAL_WEB_HEADERS": json.dumps({
-            "access_token": _tidal_web_token(),
+            # The JWT's numeric cid is an internal database id, not the OAuth
+            # client_id from the token request.
+            "access_token": _tidal_web_token(client="8049"),
             "refresh_token": "web-refresh",
             "expires_in": 86_400,
             "scope": "r_usr w_usr",
@@ -310,18 +403,33 @@ def test_tidal_connector_accepts_renewable_web_player_token_response(tmp_path, m
     })
 
     assert connector.auth_kind == "token_paste"
-    assert [field.key for field in connector.config_fields] == ["TIDAL_WEB_HEADERS"]
+    assert [field.key for field in connector.config_fields] == [
+        "TIDAL_WEB_CLIENT_ID",
+        "TIDAL_WEB_HEADERS",
+    ]
     assert status.state == "connected"
     assert "automatic token renewal" in status.detail
+    assert refresh_calls == [(
+        TOKEN_URL,
+        {
+            "data": {
+                "client_id": "public-web-client",
+                "grant_type": "refresh_token",
+                "refresh_token": "web-refresh",
+                "scope": "r_usr w_usr",
+            },
+            "timeout": 30,
+        },
+    )]
     stored = json.loads(store.get("TIDAL_WEB_HEADERS"))
     assert stored["authorization"].startswith("Bearer ")
     assert stored["refresh_token"] == "web-refresh"
-    assert stored["client_id"] == "web-client"
+    assert stored["client_id"] == "public-web-client"
     assert stored["country_code"] == "US"
     assert "email" not in stored
     persisted = json.loads(token_file.read_text(encoding="utf-8"))
     assert persisted["auth_mode"] == "tidal_web"
-    assert persisted["refresh_token"] == "web-refresh"
+    assert persisted["refresh_token"] == "rotated-refresh"
 
 
 def test_tidal_connector_still_accepts_legacy_openapi_headers(tmp_path, monkeypatch):
@@ -353,11 +461,12 @@ def test_tidal_target_renews_web_token_and_keeps_rotated_refresh(tmp_path, monke
 
     token_file = tmp_path / "tidal-web-session.json"
     raw = json.dumps({
-        "access_token": _tidal_web_token(exp=1),
+        "access_token": _tidal_web_token(exp=1, client="8049"),
         "refresh_token": "initial-refresh",
         "scope": "r_usr w_usr",
     })
     monkeypatch.setenv("TIDAL_WEB_HEADERS", raw)
+    monkeypatch.setenv("TIDAL_WEB_CLIENT_ID", "public-web-client")
     monkeypatch.setenv("TIDAL_TOKEN_FILE", str(token_file))
     calls = []
 
@@ -387,7 +496,7 @@ def test_tidal_target_renews_web_token_and_keeps_rotated_refresh(tmp_path, monke
         TOKEN_URL,
         {
             "data": {
-                "client_id": "web-client",
+                "client_id": "public-web-client",
                 "grant_type": "refresh_token",
                 "refresh_token": "initial-refresh",
                 "scope": "r_usr w_usr",
@@ -409,6 +518,7 @@ def test_tidal_connector_reports_rate_limit_as_temporary_error_and_caches_it(tmp
         "scope": "r_usr w_usr",
     })
     monkeypatch.setenv("TIDAL_WEB_HEADERS", raw)
+    monkeypatch.setenv("TIDAL_WEB_CLIENT_ID", "public-web-client")
     monkeypatch.setenv("TIDAL_TOKEN_FILE", str(tmp_path / "tidal-web-session.json"))
     calls = []
 
@@ -432,6 +542,85 @@ def test_tidal_connector_reports_rate_limit_as_temporary_error_and_caches_it(tmp
     assert len(calls) == 1
 
 
+def test_tidal_connector_repairs_a_saved_response_with_client_id_only(tmp_path, monkeypatch):
+    from songmirror.services.accounts.tidal import TidalConnector
+
+    token_file = tmp_path / "tidal-web-session.json"
+    monkeypatch.setenv("TIDAL_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("TIDAL_WEB_HEADERS", "")
+    monkeypatch.setenv("TIDAL_WEB_CLIENT_ID", "")
+    store = SettingsStore(dir=tmp_path / "settings")
+    store.save({
+        "TIDAL_WEB_HEADERS": json.dumps({
+            "access_token": _tidal_web_token(client="8049"),
+            "refresh_token": "web-refresh",
+            "client_id": "8049",
+            "scope": "r_usr w_usr",
+        }),
+    })
+
+    class RefreshResponse:
+        ok = True
+        status_code = 200
+
+        def json(self):
+            return {
+                "access_token": _tidal_web_token(client="8049"),
+                "expires_in": 86_400,
+                "scope": "r_usr w_usr",
+            }
+
+    class CheckResponse:
+        ok = True
+        status_code = 200
+
+    monkeypatch.setattr("songmirror.tidal_web.requests.post", lambda *a, **k: RefreshResponse())
+    monkeypatch.setattr("songmirror.services.accounts.tidal.requests.get", lambda *a, **k: CheckResponse())
+
+    status = TidalConnector(store).submit({"TIDAL_WEB_CLIENT_ID": "public-web-client"})
+
+    assert status.state == "connected"
+    assert json.loads(store.get("TIDAL_WEB_HEADERS"))["client_id"] == "public-web-client"
+    assert store.get("TIDAL_WEB_CLIENT_ID") == "public-web-client"
+
+
+def test_tidal_connector_rejects_a_live_token_when_renewal_proof_fails(tmp_path, monkeypatch):
+    from songmirror.oauth import read_token, write_token
+    from songmirror.services.accounts.tidal import TidalConnector
+
+    token_file = tmp_path / "tidal-web-session.json"
+    previous = {"access_token": "previous-access", "refresh_token": "previous-refresh"}
+    write_token(str(token_file), previous)
+    monkeypatch.setenv("TIDAL_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("TIDAL_WEB_HEADERS", "")
+    monkeypatch.setenv("TIDAL_WEB_CLIENT_ID", "")
+
+    class RejectedRefresh:
+        ok = False
+        status_code = 401
+
+        def json(self):
+            return {"error_description": "Client with token 8049 not found"}
+
+    monkeypatch.setattr("songmirror.tidal_web.requests.post", lambda *a, **k: RejectedRefresh())
+    connector = TidalConnector(SettingsStore(dir=tmp_path / "settings"))
+
+    status = connector.submit({
+        "TIDAL_WEB_CLIENT_ID": "public-web-client",
+        "TIDAL_WEB_HEADERS": json.dumps({
+            "access_token": _tidal_web_token(client="8049"),
+            "refresh_token": "new-refresh",
+            "expires_in": 86_400,
+            "scope": "r_usr w_usr",
+        }),
+    })
+
+    assert status.state == "error"
+    assert "rejected" in status.detail.lower()
+    assert read_token(str(token_file)) == previous
+    assert connector._store.get("TIDAL_WEB_HEADERS") is None
+
+
 def test_tidal_disconnect_removes_web_and_developer_credentials(tmp_path, monkeypatch):
     from songmirror.oauth import read_token, write_token
     from songmirror.services.accounts.tidal import TidalConnector
@@ -443,6 +632,7 @@ def test_tidal_disconnect_removes_web_and_developer_credentials(tmp_path, monkey
     store = SettingsStore(dir=tmp_path / "settings")
     store.save({
         "TIDAL_WEB_HEADERS": "stored-browser-session",
+        "TIDAL_WEB_CLIENT_ID": "public-web-client",
         "TIDAL_OAUTH_STATE": "state",
         "TIDAL_OAUTH_VERIFIER": "verifier",
     })
@@ -451,6 +641,7 @@ def test_tidal_disconnect_removes_web_and_developer_credentials(tmp_path, monkey
     connector.disconnect()
 
     assert store.get("TIDAL_WEB_HEADERS") == ""
+    assert store.get("TIDAL_WEB_CLIENT_ID") == ""
     assert store.get("TIDAL_OAUTH_STATE") == ""
     assert store.get("TIDAL_OAUTH_VERIFIER") == ""
     assert not token_file.exists()


### PR DESCRIPTION
## Summary

- store the TIDAL web player's public OAuth `client_id` separately from the token response and use it for every refresh
- reject the access token's numeric internal `cid` and prove renewal before reporting a connection as durable
- preserve legacy bearer-only imports while updating the Accounts UI, documentation, and regression coverage

## Test plan

- [x] `uv run python -m pytest` — 527 passed, 1 skipped
- [x] `pnpm -C frontend lint`
- [x] `pnpm -C frontend build` — 127 modules
- [x] `$env:CI='true'; pnpm -C frontend test:e2e` — 131 checks, no horizontal overflow
- [x] `docker compose config --quiet`
- [x] `uv lock --check`
- [x] forced a live TIDAL refresh in the rebuilt container and verified the renewed session remained connected after restart