### PR TITLE
test(deezer): lock down append-only transfer safety

### DIFF
--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -450,6 +450,77 @@ def test_transfer_preserving_order_spends_past_the_write_budget():
     assert result["chronology_replayed"] == 2               # s4 and s5 were already there
 
 
+class _DeezerChronologySource:
+    source = "spotify"
+
+    def playlist_tracks(self, playlist):
+        return [
+            {"id": f"source-{name.lower()}", "name": name, "artists": ["Artist"],
+             "duration_ms": 1, "added_at": f"2020-01-01T00:00:0{index}Z"}
+            for index, name in enumerate(("A", "B", "C", "D"))
+        ]
+
+
+def _lagging_deezer_destination():
+    """A real Deezer adapter with provider I/O replaced by a stale read model."""
+    from songmirror.engine.targets.deezer import DeezerTarget
+
+    destination = DeezerTarget.__new__(DeezerTarget)
+    existing = [
+        {"id": name.lower(), "name": name, "artist": "Artist", "duration_ms": 1}
+        for name in ("C", "D")
+    ]
+    calls = {"adds": [], "removes": []}
+
+    def playlist_tracks(_playlist):
+        # Model Deezer's replication lag: even after an append, the next read
+        # still exposes only the two entries that preceded the transfer.
+        return existing
+
+    destination.playlist_tracks = playlist_tracks
+    destination.resolve = lambda track, _cache: (track["name"].lower(), "search")
+    destination.add = lambda _playlist, ids: calls["adds"].append(list(ids))
+    destination.remove = lambda _playlist, track: calls["removes"].append(track["id"])
+    return destination, calls
+
+
+def test_deezer_transfer_appends_every_match_past_the_sync_write_cap():
+    """A one-off Deezer copy has no next pass, so MAX_ADDS must not stall it."""
+    destination, calls = _lagging_deezer_destination()
+
+    result = transfer(
+        _DeezerChronologySource(), destination,
+        {"id": "source"}, {"id": "destination"},
+        {"search": {}, "isrc": {}, "dirty": False},
+        execute=True, max_adds=1,
+    )
+
+    assert calls["adds"] == [["a", "b"]]
+    assert calls["removes"] == []
+    assert result["added"] == 2 and result["deferred"] == 0
+    assert result["chronology_replayed"] == 0
+
+
+def test_deezer_transfer_never_replays_chronology_on_a_lagging_read():
+    """A stale Deezer read must never drive catalog-ID removal after staging."""
+    # Exercise both the safe default and a stale/direct API client that still
+    # asks for preservation. Provider capability wins in either case.
+    for options in ({}, {"preserve_order": True}):
+        destination, calls = _lagging_deezer_destination()
+
+        result = transfer(
+            _DeezerChronologySource(), destination,
+            {"id": "source"}, {"id": "destination"},
+            {"search": {}, "isrc": {}, "dirty": False},
+            execute=True, max_adds=100, **options,
+        )
+
+        assert calls["adds"] == [["a", "b"]]
+        assert calls["removes"] == []
+        assert result["added"] == 2 and result["deferred"] == 0
+        assert result["chronology_replayed"] == 0
+
+
 def test_transfer_does_not_truncate_a_copy_at_the_write_cap():
     added = []
     source_tracks = [


### PR DESCRIPTION
## Summary

- retain the append-only Deezer transfer behavior already shipped in #41 and cover it through the real `DeezerTarget` seam
- prove a one-off copy writes every missing match even when `MAX_ADDS` is lower than the transfer size
- model Deezer replication lag and prove neither the default path nor an explicit order-preservation request can stage existing tracks or invoke catalog-ID removal

## Behavior

Before #41, the regression fixture fails in both ways reported by the issue: a one-write cap leaves both additions deferred with no provider write, while a larger cap enters chronology replay and reads stale playlist membership before catalog-ID retirement. Main now appends the missing tracks, reports zero deferrals and zero chronology replays, and performs no removals. This PR locks those production safeguards together so they cannot drift independently.

## Verification

- `uv run python -m pytest tests/test_transfers.py -k "deezer_transfer" -q` (2 passed, 29 deselected)
- `uv run python -m pytest` (529 passed, 1 skipped)
- `uv lock --check` (resolved 39 packages successfully)
- `git diff --check origin/main...HEAD`

Closes #40