### PR TITLE
fix(matching): normalize YouTube playlist metadata

### DIFF
--- a/songmirror/engine/matching.py
+++ b/songmirror/engine/matching.py
@@ -106,10 +106,18 @@ def tracks_oldest_first(tracks):
 def normalize_text(value):
     """Unicode-aware: keeps letters/digits in ANY script (Cyrillic, CJK,
     Bengali, ...). A Latin-only character class silently empties non-Latin
-    titles, which breaks matching and can delete real tracks."""
+    titles, which breaks matching and can delete real tracks.
+
+    Casefolding can itself produce a decomposed sequence. Recompose that output
+    before punctuation removal, and collapse the redundant combining dot from
+    Turkish capital dotted I. Otherwise ``İki`` becomes ``i ki`` when the mark
+    is mistaken for punctuation. Do not discard combining marks wholesale:
+    doing so would conflate accent-distinct canonical keys in every language.
+    """
     if not value:
         return ""
     normalized = unicodedata.normalize("NFKC", str(value)).casefold()
+    normalized = unicodedata.normalize("NFKC", normalized.replace("i\u0307", "i"))
     normalized = re.sub(r"[\W_]+", " ", normalized)
     return " ".join(normalized.split())
 

--- a/songmirror/engine/targets/ytmusic.py
+++ b/songmirror/engine/targets/ytmusic.py
@@ -37,6 +37,55 @@ DEFAULT_AUTH_FILE = "ytmusic_oauth.json"
 API = "https://www.googleapis.com/youtube/v3"
 
 _TOPIC_RE = re.compile(r"\s*-\s*Topic$")
+_CHANNEL_DECORATION_RE = re.compile(
+    r"(?:\s*vevo|\s+official(?:\s+channel)?)$",
+    re.IGNORECASE,
+)
+_TITLE_SEPARATOR = r"(?:\s+-\s+|\s*[–—]\s*|\s+\|\s+|:\s+)"
+_TITLE_PREFIX_RE = re.compile(
+    rf"^(?P<prefix>.+?){_TITLE_SEPARATOR}(?P<title>.+)$"
+)
+_TRAILING_BRACKET_RE = re.compile(
+    r"\s*(?:\((?P<paren>[^()]*)\)|\[(?P<bracket>[^\[\]]*)\]|\{(?P<brace>[^{}]*)\})\s*$"
+)
+_TRAILING_SEPARATOR_RE = re.compile(
+    rf"^(?P<title>.+){_TITLE_SEPARATOR}(?P<tag>.+)$"
+)
+_VIDEO_PRODUCTION_TAGS = {
+    "audio",
+    "audio video",
+    "clip",
+    "lyrics",
+    "lyric video",
+    "lyrics video",
+    "m v",
+    "music clip",
+    "music video",
+    "mv",
+    "official audio",
+    "official audio video",
+    "official clip",
+    "official lyrics",
+    "official lyric video",
+    "official lyrics video",
+    "official m v",
+    "official music clip",
+    "official music video",
+    "official music video clip",
+    "official mv",
+    "official video",
+    "official video clip",
+    "official visualiser",
+    "official visualizer",
+    "video",
+    "video clip",
+    "visualiser",
+    "visualizer",
+}
+_VIDEO_QUALITY_TAGS = {
+    "4k", "8k", "720p", "1080p", "1440p", "2160p", "hd", "hq", "uhd",
+}
+_PRODUCER_CREDIT_RE = re.compile(r"prod(?:uced)?\s+by\s+.+")
 
 
 ROTATE_URL = "https://accounts.youtube.com/RotateCookies"
@@ -133,6 +182,87 @@ def _artist_from_channel(channel):
     return _TOPIC_RE.sub("", channel or "").strip()
 
 
+def _channel_name_keys(channel):
+    """Comparable channel spellings used only for a video-title prefix.
+
+    YouTube appends branding such as ``VEVO`` and ``Official Channel`` to many
+    owner names while the video's leading credit remains the plain artist.
+    Keep the stored artist convention unchanged, but accept each progressively
+    undecorated spelling when deciding whether a prefix is safe to remove.
+    """
+    variants = set()
+    current = str(channel or "").strip()
+    while current:
+        key = normalize_text(current)
+        if key:
+            variants.add(key)
+        undecorated = _CHANNEL_DECORATION_RE.sub("", current).strip()
+        if undecorated == current:
+            break
+        current = undecorated
+    return variants
+
+
+def _is_video_production_tag(value):
+    normalized = normalize_text(value)
+    if _PRODUCER_CREDIT_RE.fullmatch(normalized):
+        return True
+    words = normalized.split()
+    without_quality = [word for word in words if word not in _VIDEO_QUALITY_TAGS]
+    return bool(words) and (
+        not without_quality or " ".join(without_quality) in _VIDEO_PRODUCTION_TAGS
+    )
+
+
+def _clean_data_api_video_title(title, channel):
+    """Turn an unstructured Data API video title into a search-safe track name.
+
+    Prefix removal is gated on the owner channel, so a legitimate title such as
+    ``Love - Hate`` is never split just because it contains a dash. Production
+    labels are removed only when they occupy a complete trailing bracket or a
+    separator-delimited suffix. Creative recording qualifiers (live, acoustic,
+    remix, remaster, featured artists) deliberately remain for match safety.
+    """
+    raw = str(title or "").strip()
+    if not raw:
+        return ""
+
+    cleaned = raw
+    prefix = _TITLE_PREFIX_RE.match(cleaned)
+    if prefix and normalize_text(prefix.group("prefix")) in _channel_name_keys(channel):
+        candidate = prefix.group("title").strip()
+        if candidate:
+            cleaned = candidate
+
+    while cleaned:
+        bracket = _TRAILING_BRACKET_RE.search(cleaned)
+        if bracket:
+            tag = next(
+                value
+                for value in (
+                    bracket.group("paren"),
+                    bracket.group("bracket"),
+                    bracket.group("brace"),
+                )
+                if value is not None
+            )
+            if _is_video_production_tag(tag):
+                candidate = cleaned[:bracket.start()].rstrip(" -–—|:")
+                if candidate:
+                    cleaned = candidate
+                    continue
+
+        suffix = _TRAILING_SEPARATOR_RE.match(cleaned)
+        if suffix and _is_video_production_tag(suffix.group("tag")):
+            candidate = suffix.group("title").rstrip(" -–—|:")
+            if candidate:
+                cleaned = candidate
+                continue
+        break
+
+    return cleaned or raw
+
+
 def _normalized_data_api_playlist_item(item):
     video_id = item.get("contentDetails", {}).get("videoId")
     if not video_id:
@@ -149,7 +279,7 @@ def _normalized_data_api_playlist_item(item):
         "id": video_id,
         "videoId": video_id,
         "playlistItemId": item.get("id"),
-        "name": snippet.get("title", ""),
+        "name": _clean_data_api_video_title(snippet.get("title", ""), artist),
         "artist": artist,
         "artists": [artist] if artist else [""],
         "album": None,

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 
+import pytest
+
 from songmirror.engine import archive
 from songmirror.engine.config import parse_interval
 from songmirror.engine.matching import (
@@ -45,6 +47,31 @@ def cid_of(t):
 
 def accepts(*a):
     return score_candidate(*a)[1]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Emir Can İğrek", "emir can iğrek"),
+        ("İki Şeye Pişmanım", "iki şeye pişmanım"),
+        ("I\u0307ki", "iki"),
+        ("İ\u0301lhan", "ílhan"),
+    ],
+)
+def test_normalize_text_does_not_split_turkish_dotted_i(value, expected):
+    assert normalize_text(value) == expected
+
+
+def test_normalize_text_preserves_canonical_accents_and_non_latin_letters():
+    assert normalize_text("Cafe\u0301") == normalize_text("CAFÉ") == "café"
+    assert normalize_text("mañana") != normalize_text("manana")
+    assert normalize_text("嘘") == "嘘"
+
+
+def test_turkish_case_variants_produce_the_same_track_key():
+    assert track_key("İki Şeye Pişmanım", "Emir Can İğrek") == track_key(
+        "iki şeye pişmanım", "emir can iğrek"
+    )
 
 
 def test_compute_diff_orders_mixed_timestamp_formats_chronologically():

--- a/tests/test_ytmusic_stub.py
+++ b/tests/test_ytmusic_stub.py
@@ -7,7 +7,99 @@ import pytest
 
 from songmirror.engine.targets import ytmusic
 from songmirror.engine.targets.base import TargetAuthError
-from songmirror.engine.targets.ytmusic import YTMusicBrowserTarget, _expired, rotate_browser_cookie
+from songmirror.engine.targets.ytmusic import (
+    YTMusicBrowserTarget,
+    _expired,
+    _normalized_data_api_playlist_item,
+    _normalized_youtubei_playlist_track,
+    rotate_browser_cookie,
+)
+
+
+def _data_api_item(title, channel="BLOK3"):
+    return {
+        "id": "playlist-item-1",
+        "contentDetails": {"videoId": "video-1"},
+        "snippet": {
+            "title": title,
+            "videoOwnerChannelTitle": channel,
+            "publishedAt": "2026-08-01T00:00:00Z",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("title", "channel", "expected"),
+    [
+        ("BLOK3 - KAYIP KALP (Official Music Video)", "BLOK3", "KAYIP KALP"),
+        ("BLOK3 – KAYIP KALP [Official Video]", "BLOK3", "KAYIP KALP"),
+        ("BLOK3: KAYIP KALP | Official Audio", "BLOK3", "KAYIP KALP"),
+        ("BLOK3 | KAYIP KALP [4K]", "BLOK3", "KAYIP KALP"),
+        ("BLOK3 - KAYIP KALP (Lyric Video)", "BLOK3", "KAYIP KALP"),
+        ("BLOK3 - KAYIP KALP (Prod. by Worry)", "BLOK3", "KAYIP KALP"),
+        ("BLOK3 - KAYIP KALP [4K · Official MV · UHD]", "BLOK3", "KAYIP KALP"),
+        ("BLOK3 - KAYIP KALP (Official Video)", "BLOK3VEVO", "KAYIP KALP"),
+        (
+            "BLOK3 — KAYIP KALP (Official Visualizer) [4K]",
+            "BLOK3 Official Channel",
+            "KAYIP KALP",
+        ),
+        (
+            "Emir Can İğrek - Ali Cabbar (Official Video)",
+            "Emir Can İğrek - Topic",
+            "Ali Cabbar",
+        ),
+    ],
+)
+def test_data_api_playlist_titles_strip_channel_prefixes_and_video_noise(
+    title, channel, expected
+):
+    track = _normalized_data_api_playlist_item(_data_api_item(title, channel))
+
+    assert track["name"] == expected
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "BLOK3 - KAYIP KALP (Acoustic)",
+        "BLOK3 - KAYIP KALP (Live at Zorlu PSM)",
+        "BLOK3 - KAYIP KALP (feat. Ati242)",
+        "BLOK3 - KAYIP KALP (Official Remix)",
+        "BLOK3 - KAYIP KALP [Remastered 2024]",
+    ],
+)
+def test_data_api_playlist_titles_preserve_recording_qualifiers(title):
+    track = _normalized_data_api_playlist_item(_data_api_item(title))
+
+    assert track["name"] == title.removeprefix("BLOK3 - ")
+
+
+@pytest.mark.parametrize(
+    ("title", "channel", "expected"),
+    [
+        ("Love - Hate (Official Video)", "Some Channel", "Love - Hate"),
+        ("BLOK3", "BLOK3", "BLOK3"),
+        ("BLOK3 - Official Video", "BLOK3", "Official Video"),
+        ("BLOK3 - KAYIP-KALP [From the Album]", "BLOK3", "KAYIP-KALP [From the Album]"),
+    ],
+)
+def test_data_api_playlist_title_cleanup_is_conservative(title, channel, expected):
+    track = _normalized_data_api_playlist_item(_data_api_item(title, channel))
+
+    assert track["name"] == expected
+
+
+def test_native_youtubei_titles_are_not_reparsed_as_raw_video_titles():
+    title = "BLOK3 - KAYIP KALP (Official Music Video)"
+
+    track = _normalized_youtubei_playlist_track({
+        "videoId": "video-1",
+        "title": title,
+        "artists": [{"name": "BLOK3"}],
+    })
+
+    assert track["name"] == title
 
 
 def _auth_file(tmp_path, ts="old"):


### PR DESCRIPTION
## Summary

- normalize Unicode casefold output so Turkish capital dotted I no longer creates artificial word boundaries, while preserving canonical accents and non-Latin text
- clean raw YouTube Data API playlist titles by removing owner-confirmed artist/channel prefixes and terminal video-production, quality, and producer tags
- retain creative recording qualifiers and leave native youtubei titles untouched so cleanup cannot collapse live, acoustic, remix, remaster, or featured-artist variants
- cover the reported Turkish examples, common dash/colon/pipe title formats, Topic/VEVO/Official channel variants, stacked bracketed tags, and conservative guard cases

## Verification

- `uv run pytest -q tests/test_matching.py tests/test_ytmusic_stub.py` — 44 passed
- `uv run pytest -q` — 553 passed, 1 skipped
- `pnpm -C frontend lint` — passed
- `pnpm -C frontend build` — passed
- `pnpm -C frontend test:e2e` with `CI=true` — 131 checks, 0 failures

Closes #44