### PR TITLE
feat(backups): schedule persistent playlist snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ SongMirror keeps your playlists identical everywhere without manual re-adding, o
 - 🕒 **Append or preserve order** — copies land at the end of the destination by default, fast and additive. Switch on **Preserve Recently Added order** to rewrite the tracks after the oldest new one so date-added order matches the source.
 - 🔗 **Transfer from a link** — paste a public playlist URL from any connected service and copy it straight across. No need to save or follow it first.
 - 🌐 **Followed playlists** — sync and transfer playlists you follow but don't own, not just ones you created.
-- 📦 **Portable metadata backups** — download one playlist or a service's entire library as ordered, versioned JSON/XML; single playlists also export as import-ready Soundiiz JSON.
+- 📦 **Scheduled metadata backups** — archive an account's entire playlist library on its own schedule under persistent app data, with JSON/XML, retention limits, and visible success/failure history. One-off downloads and import-ready Soundiiz JSON remain available too.
 - 💿 **Local download mirror** — keep offline audio, one folder per playlist in **Jellyfin's** `AlbumArtist/Album` layout, with covers and an auto-updated `.m3u8`.
 - 🛡️ **Safety rails** — dry-run by default, per-pass add/removal caps, net-loss protection, empty-snapshot guard, fail-closed on expired tokens.
 - 🗃️ **Ever-growing song archive** — every track ever seen is recorded in a local SQLite database (name, artist, album, ISRC, raw metadata, first/last seen).
@@ -206,7 +206,7 @@ SongMirror will then advertise `https://music.example.com/oauth/spotify/callback
 | --- | --- |
 | **Image** | `ghcr.io/ahnafnafee/songmirror:latest` supports AMD64 and ARM64. Each build is also published with a commit-specific `sha-...` tag; Git tags such as `v1.2.3` additionally publish `1.2.3`, `1.2`, and `1`. Use the [container image guide](docs/docker-image.md) to pin an immutable digest. |
 | **Port** | The UI is published on host **8888** (the `8888:8080` mapping in `docker-compose.yml`; change the host side if it clashes). **LAN-only** — don't port-forward it to the internet; the UI has no login yet. |
-| **Persistence** | `./data` holds credentials, tokens, caches, and the song archive. Back it up to keep your setup across rebuilds. |
+| **Persistence** | `./data` holds credentials, tokens, caches, the song archive, and scheduled playlist snapshots under `playlist_backups/`. Back it up to keep your setup and archives across rebuilds. |
 | **Downloads** | Set `DOWNLOAD_DIR` (in `.env` or your shell) to your host music dir (e.g. `F:\Torrent\Music`); compose bind-mounts it to `/music`. From Docker, set `JELLYFIN_URL` to `http://host.docker.internal:8096`. |
 | **Expired sessions** | Renewable sessions recover on the next scheduled or manual pass. TIDAL web-player sessions renew from the captured refresh token; Qobuz and Apple Music tokens must still be re-pasted when rejected. No restart is needed. |
 
@@ -297,13 +297,16 @@ Some of these integrations use the providers' first-party web interfaces and can
 
 ## 📦 Playlist metadata backups
 
-The **Playlists** page can download a fresh snapshot without requiring a second provider or a sync job:
+Backups do not require a second provider or a sync job:
 
-- Use **Local backup** on a service card to save every playlist from that service in one versioned JSON or XML file.
+- On **Settings → Playlist archive**, add any connected playlist account, choose JSON or XML, set its interval and how many snapshots to retain, then leave SongMirror running. Set retention to `0` to keep every snapshot.
+- Scheduled files are written under `data/playlist_backups/<account-profile-id>/` (or `/data/playlist_backups/<account-profile-id>/` in Docker), alongside the rest of SongMirror's persistent data. Each account keeps its own schedule, including multiple accounts on the same service. Removing a schedule never deletes snapshots already on disk.
+- The same Settings card shows the next run, stored snapshot count, last successful file and counts, and the most recent failure. **Back up now** queues a safe on-demand run; **Download latest** retrieves the newest persisted snapshot.
+- On the **Playlists** page, use **Export** on a service card to download every playlist from that service in one versioned JSON or XML file.
 - Open a playlist to export only that playlist. Its **Soundiiz** option follows [Soundiiz's documented JSON import shape](https://soundiiz.com/data/fileExamples/playlistExport.json), so the downloaded track list can be uploaded through Soundiiz's **Import Playlist → From File** flow.
 - SongMirror JSON/XML preserves playlist order and names plus provider track/occurrence IDs, available ISRCs, artists, albums, album track positions, durations, added dates, artwork links, and unavailable-entry markers. ID-less catalog ghosts remain in the backup instead of disappearing. Files contain no cookies, tokens, request headers, previews, or streaming-file URLs.
 
-Exports are downloaded by the browser to the device running the UI; SongMirror does not need write access to a host backup directory. The `schema_version` field lets future releases evolve the lossless format without making old snapshots ambiguous.
+Manual exports are downloaded by the browser to the device running the UI. Scheduled exports use the existing application-data volume, so no second host path or container mount is required. Backup reads queue behind syncs and transfers instead of accessing provider clients concurrently. The `schema_version` field lets future releases evolve the lossless format without making old snapshots ambiguous.
 
 <div align="right">
 

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -147,8 +147,10 @@ const SETTINGS = {
 function initialPlaylistBackups() {
   const now = Date.now()
   return [{
+    account_id: 'spotify',
     provider: 'spotify',
     provider_name: 'Spotify',
+    account_name: 'Spotify',
     enabled: true,
     interval: '24h',
     format: 'json',
@@ -584,13 +586,15 @@ async function installMocks(page, opts = {}) {
 
     if (p === '/api/playlist-backups' && method === 'GET') return json(playlistBackupsData)
     if (/^\/api\/playlist-backups\/[^/]+$/.test(p) && method === 'PUT') {
-      const provider = decodeURIComponent(p.split('/')[3])
+      const accountId = decodeURIComponent(p.split('/')[3])
       const body = req.postDataJSON() ?? {}
-      const account = accountsData.find((item) => item.id === provider)
-      const existing = playlistBackupsData.find((item) => item.provider === provider)
+      const account = accountsData.find((item) => item.id === accountId)
+      const existing = playlistBackupsData.find((item) => item.account_id === accountId)
       const updated = {
-        provider,
-        provider_name: account?.name ?? provider,
+        account_id: accountId,
+        provider: account?.provider ?? existing?.provider ?? accountId,
+        provider_name: account?.provider_name ?? existing?.provider_name ?? accountId,
+        account_name: account?.name ?? existing?.account_name ?? accountId,
         enabled: true,
         interval: '24h',
         format: 'json',
@@ -598,31 +602,31 @@ async function installMocks(page, opts = {}) {
         running: false,
         next_run_at: Math.floor(Date.now() / 1000) + 24 * 3600,
         snapshot_count: 0,
-        storage_path: `/data/playlist_backups/${provider}`,
+        storage_path: `/data/playlist_backups/${accountId}`,
         last_success: null,
         last_failure: null,
         ...existing,
         ...body,
       }
       playlistBackupsData = [
-        ...playlistBackupsData.filter((item) => item.provider !== provider),
+        ...playlistBackupsData.filter((item) => item.account_id !== accountId),
         updated,
       ]
       return json(updated)
     }
     if (/^\/api\/playlist-backups\/[^/]+$/.test(p) && method === 'DELETE') {
-      const provider = decodeURIComponent(p.split('/')[3])
-      playlistBackupsData = playlistBackupsData.filter((item) => item.provider !== provider)
+      const accountId = decodeURIComponent(p.split('/')[3])
+      playlistBackupsData = playlistBackupsData.filter((item) => item.account_id !== accountId)
       return json({ ok: true })
     }
     if (/^\/api\/playlist-backups\/[^/]+\/run$/.test(p) && method === 'POST') {
-      const provider = decodeURIComponent(p.split('/')[3])
-      playlistBackupsData = playlistBackupsData.map((item) => item.provider === provider ? {
+      const accountId = decodeURIComponent(p.split('/')[3])
+      playlistBackupsData = playlistBackupsData.map((item) => item.account_id === accountId ? {
         ...item,
         snapshot_count: item.snapshot_count + 1,
         last_success: {
           at: new Date().toISOString(),
-          filename: `songmirror-${provider}-all-playlists-20260904T120000Z.${item.format}`,
+          filename: `songmirror-${accountId}-all-playlists-20260904T120000Z.${item.format}`,
           format: item.format,
           playlist_count: 12,
           track_count: 847,
@@ -2418,11 +2422,11 @@ async function main() {
       console.log(`${manualBackupRecorded ? 'ok        ' : 'FAIL      '} an on-demand backup refreshes the persisted snapshot status`)
       if (!manualBackupRecorded) results.push({ label: 'playlist backup run now', overflow: true })
 
-      await page.getByLabel('Add a connected service', { exact: true }).selectOption('apple')
+      await page.getByLabel('Add a connected account', { exact: true }).selectOption('apple')
       await page.getByRole('button', { name: 'Add daily backup', exact: true }).click()
       await page.waitForSelector('h3:has-text("Apple Music")')
       const appleScheduleAdded = (await page.locator('body').innerText()).includes('/data/playlist_backups/apple')
-      console.log(`${appleScheduleAdded ? 'ok        ' : 'FAIL      '} a connected provider gets its own persisted backup schedule`)
+      console.log(`${appleScheduleAdded ? 'ok        ' : 'FAIL      '} a connected account gets its own persisted backup schedule`)
       if (!appleScheduleAdded) results.push({ label: 'playlist backup schedule create', overflow: true })
       await checkOverflow(page, `Settings shape @ ${width}`, results)
       await shot(page, `settings-${width}`)
@@ -4058,6 +4062,79 @@ async function main() {
       if (!payloadOk) results.push({ label: 'same-provider transfer profile payload', overflow: true })
       await checkOverflow(page, 'Household profiles and cross-profile transfer @ 1280', results)
       await shot(page, 'household-profile-transfer')
+      await context.close()
+    }
+
+    // -----------------------------------------------------------------
+    // Scheduled backups are account-scoped: after one Spotify profile has a
+    // schedule, a second Spotify profile remains selectable and gets its own
+    // API identity, card label, storage directory, and run history.
+    // -----------------------------------------------------------------
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'light'))
+      const page = await context.newPage()
+      const spotify = ACCOUNTS.find((account) => account.provider === 'spotify')
+      const defaultSpotify = {
+        ...spotify,
+        id: 'profile_default_spotify',
+        label: 'Spotify',
+        name: 'Spotify',
+        is_default: true,
+        removable: false,
+        state: 'connected',
+      }
+      const alexSpotify = {
+        ...spotify,
+        id: 'profile_alex_spotify',
+        label: 'Alex',
+        name: 'Spotify · Alex',
+        is_default: false,
+        removable: true,
+        state: 'connected',
+      }
+      const defaultBackup = {
+        ...initialPlaylistBackups()[0],
+        account_id: defaultSpotify.id,
+        provider: 'spotify',
+        provider_name: 'Spotify',
+        account_name: 'Spotify',
+        storage_path: `/data/playlist_backups/${defaultSpotify.id}`,
+      }
+      await installMocks(page, {
+        accounts: [defaultSpotify, alexSpotify],
+        playlistBackups: [defaultBackup],
+      })
+      let scheduledAccount = null
+      page.on('request', (request) => {
+        const url = new URL(request.url())
+        if (request.method() === 'PUT' && /^\/api\/playlist-backups\/[^/]+$/.test(url.pathname)) {
+          scheduledAccount = decodeURIComponent(url.pathname.split('/')[3])
+        }
+      })
+
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/settings', { waitUntil: 'networkidle' })
+      const accountSelect = page.getByLabel('Add a connected account', { exact: true })
+      const availableAccountIds = await accountSelect.locator('option').evaluateAll(
+        (options) => options.map((option) => option.value),
+      )
+      const secondProfileAvailable =
+        availableAccountIds.includes(alexSpotify.id)
+        && !availableAccountIds.includes(defaultSpotify.id)
+      await accountSelect.selectOption(alexSpotify.id)
+      await page.getByRole('button', { name: 'Add daily backup', exact: true }).click()
+      await page.getByRole('heading', { name: 'Spotify · Alex', exact: true }).waitFor()
+      const body = await page.locator('body').innerText()
+      const profilesStaySeparate =
+        secondProfileAvailable
+        && scheduledAccount === alexSpotify.id
+        && body.includes(`/data/playlist_backups/${defaultSpotify.id}`)
+        && body.includes(`/data/playlist_backups/${alexSpotify.id}`)
+      console.log(`${profilesStaySeparate ? 'ok        ' : 'FAIL      '} scheduled backups keep same-provider accounts separate`)
+      if (!profilesStaySeparate) results.push({ label: 'account-scoped scheduled backups', overflow: true })
+      await checkOverflow(page, 'Account-scoped scheduled backups @ 1280', results)
+      await shot(page, 'account-scoped-scheduled-backups')
       await context.close()
     }
 

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -144,6 +144,34 @@ const SETTINGS = {
   LOCAL_MIRROR_FORMAT: 'mp3',
 }
 
+function initialPlaylistBackups() {
+  const now = Date.now()
+  return [{
+    provider: 'spotify',
+    provider_name: 'Spotify',
+    enabled: true,
+    interval: '24h',
+    format: 'json',
+    retention: 30,
+    running: false,
+    next_run_at: Math.floor(now / 1000) + 6 * 3600,
+    snapshot_count: 3,
+    storage_path: '/data/playlist_backups/spotify',
+    last_success: {
+      at: new Date(now - 24 * 3600 * 1000).toISOString(),
+      filename: 'songmirror-spotify-all-playlists-20260903T120000Z.json',
+      format: 'json',
+      playlist_count: 12,
+      track_count: 847,
+      pruned: 1,
+    },
+    last_failure: {
+      at: new Date(now - 48 * 3600 * 1000).toISOString(),
+      error: 'Spotify could not export playlists right now. Retry.',
+    },
+  }]
+}
+
 // Two named sync jobs (Soundiiz-style). "Default" preserves every scenario
 // the old single-config fixture exercised (N-way default, an explicit
 // PROVIDERS that excludes a connected peer, a manual playlist-filter chip,
@@ -482,6 +510,7 @@ async function installMocks(page, opts = {}) {
   const settingsData = opts.settings ?? SETTINGS
   const playlistsData = opts.playlists ?? PLAYLISTS
   const delays = opts.delays ?? {}
+  let playlistBackupsData = opts.playlistBackups ?? initialPlaylistBackups()
 
   async function delay(resource) {
     const ms = delays[resource] ?? 0
@@ -552,6 +581,64 @@ async function installMocks(page, opts = {}) {
       return json(settingsData)
     }
     if (p === '/api/settings' && method === 'PUT') return json({ ok: true })
+
+    if (p === '/api/playlist-backups' && method === 'GET') return json(playlistBackupsData)
+    if (/^\/api\/playlist-backups\/[^/]+$/.test(p) && method === 'PUT') {
+      const provider = decodeURIComponent(p.split('/')[3])
+      const body = req.postDataJSON() ?? {}
+      const account = accountsData.find((item) => item.id === provider)
+      const existing = playlistBackupsData.find((item) => item.provider === provider)
+      const updated = {
+        provider,
+        provider_name: account?.name ?? provider,
+        enabled: true,
+        interval: '24h',
+        format: 'json',
+        retention: 30,
+        running: false,
+        next_run_at: Math.floor(Date.now() / 1000) + 24 * 3600,
+        snapshot_count: 0,
+        storage_path: `/data/playlist_backups/${provider}`,
+        last_success: null,
+        last_failure: null,
+        ...existing,
+        ...body,
+      }
+      playlistBackupsData = [
+        ...playlistBackupsData.filter((item) => item.provider !== provider),
+        updated,
+      ]
+      return json(updated)
+    }
+    if (/^\/api\/playlist-backups\/[^/]+$/.test(p) && method === 'DELETE') {
+      const provider = decodeURIComponent(p.split('/')[3])
+      playlistBackupsData = playlistBackupsData.filter((item) => item.provider !== provider)
+      return json({ ok: true })
+    }
+    if (/^\/api\/playlist-backups\/[^/]+\/run$/.test(p) && method === 'POST') {
+      const provider = decodeURIComponent(p.split('/')[3])
+      playlistBackupsData = playlistBackupsData.map((item) => item.provider === provider ? {
+        ...item,
+        snapshot_count: item.snapshot_count + 1,
+        last_success: {
+          at: new Date().toISOString(),
+          filename: `songmirror-${provider}-all-playlists-20260904T120000Z.${item.format}`,
+          format: item.format,
+          playlist_count: 12,
+          track_count: 847,
+          pruned: item.retention > 0 ? 1 : 0,
+        },
+      } : item)
+      return json({ queued: true }, 202)
+    }
+    if (/^\/api\/playlist-backups\/[^/]+\/latest$/.test(p) && method === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'Content-Disposition': 'attachment; filename="songmirror-playlists.json"' },
+        body: '{"kind":"songmirror-playlist-backup"}',
+      })
+    }
 
     if (p === '/api/sync/status' && method === 'GET') return json(syncStatusFixture(syncsData))
     if (p === '/api/sync/run' && method === 'POST') return json({ queued: true }, 202)
@@ -2298,7 +2385,8 @@ async function main() {
       console.log(`${pageNoNull ? 'ok        ' : 'FAIL      '} Transfers page never renders the literal "null" anywhere`)
       if (!pageNoNull) results.push({ label: 'transfers page null literal', overflow: true })
 
-      // Settings: Profile + Appearance + the *global* Download mirror
+      // Settings: Profile + Appearance + the *global* Download mirror and
+      // persistent playlist archive, with a pointer to per-sync controls.
       // (moved back here from the old single-config Sync page), with a
       // pointer over to the Sync tab for per-sync direction/providers/etc.
       await page.goto(BASE_URL + '/settings', { waitUntil: 'networkidle' })
@@ -2308,9 +2396,13 @@ async function main() {
         settingsBodyText.includes('PROFILE') &&
         settingsBodyText.includes('APPEARANCE') &&
         settingsBodyText.includes('DOWNLOAD MIRROR') &&
+        settingsBodyText.includes('PLAYLIST ARCHIVE') &&
+        settingsBodyText.includes('/data/playlist_backups/spotify') &&
+        settingsBodyText.includes('Last success') &&
+        settingsBodyText.includes('Last failure') &&
         !settingsBodyText.includes('SYNC BEHAVIOR') &&
         !settingsBodyText.includes('SAFETY CAPS')
-      console.log(`${settingsShapeOk ? 'ok        ' : 'FAIL      '} Settings shows Profile + Appearance + Download mirror (per-sync fields live on /sync)`)
+      console.log(`${settingsShapeOk ? 'ok        ' : 'FAIL      '} Settings shows Profile + Appearance + Download mirror + persistent playlist archive`)
       if (!settingsShapeOk) results.push({ label: 'settings shape', overflow: true })
       const downloadDirValue = await page.getByLabel('Download folder', { exact: true }).inputValue()
       console.log(`${downloadDirValue === '/music/playlists' ? 'ok        ' : 'FAIL      '} Settings' Download folder is pre-filled from SETTINGS (got "${downloadDirValue}")`)
@@ -2319,6 +2411,19 @@ async function main() {
       const syncPointerHref = await syncPointer.getAttribute('href')
       console.log(`${syncPointerHref === '/sync' ? 'ok        ' : 'FAIL      '} Settings has a pointer link to the Sync tab (href="${syncPointerHref}")`)
       if (syncPointerHref !== '/sync') results.push({ label: 'settings sync pointer', overflow: true })
+
+      await page.getByRole('button', { name: 'Back up Spotify now', exact: true }).click()
+      await page.waitForTimeout(100)
+      const manualBackupRecorded = (await page.locator('body').innerText()).includes('4 stored snapshots')
+      console.log(`${manualBackupRecorded ? 'ok        ' : 'FAIL      '} an on-demand backup refreshes the persisted snapshot status`)
+      if (!manualBackupRecorded) results.push({ label: 'playlist backup run now', overflow: true })
+
+      await page.getByLabel('Add a connected service', { exact: true }).selectOption('apple')
+      await page.getByRole('button', { name: 'Add daily backup', exact: true }).click()
+      await page.waitForSelector('h3:has-text("Apple Music")')
+      const appleScheduleAdded = (await page.locator('body').innerText()).includes('/data/playlist_backups/apple')
+      console.log(`${appleScheduleAdded ? 'ok        ' : 'FAIL      '} a connected provider gets its own persisted backup schedule`)
+      if (!appleScheduleAdded) results.push({ label: 'playlist backup schedule create', overflow: true })
       await checkOverflow(page, `Settings shape @ ${width}`, results)
       await shot(page, `settings-${width}`)
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,11 +7,14 @@ import type {
   ConnectResponse,
   LinkUpsertRequest,
   OkResponse,
+  PlaylistBackupJob,
+  PlaylistBackupUpdate,
   PlaylistLink,
   PlaylistExportFormat,
   PollResponse,
   ProviderPlaylist,
   ProviderPlaylistDetail,
+  QueueResponse,
   RemovePlaylistTrackRequest,
   RemovePlaylistTracksRequest,
   ResolveCacheEntry,
@@ -145,6 +148,23 @@ export const api = {
   // Settings
   getSettings: () => request<Settings>('/api/settings'),
   saveSettings: (values: Settings) => request<OkResponse>('/api/settings', { method: 'PUT', body: JSON.stringify(values) }),
+
+  // Persistent scheduled playlist-metadata backups
+  getPlaylistBackups: () => request<PlaylistBackupJob[]>('/api/playlist-backups'),
+  savePlaylistBackup: (provider: string, values: PlaylistBackupUpdate) =>
+    request<PlaylistBackupJob>(
+      `/api/playlist-backups/${encodeURIComponent(provider)}`,
+      { method: 'PUT', body: JSON.stringify(values) },
+    ),
+  deletePlaylistBackup: (provider: string) =>
+    request<OkResponse>(`/api/playlist-backups/${encodeURIComponent(provider)}`, { method: 'DELETE' }),
+  runPlaylistBackup: (provider: string) =>
+    request<QueueResponse>(`/api/playlist-backups/${encodeURIComponent(provider)}/run`, { method: 'POST' }),
+  downloadLatestPlaylistBackup: (provider: string) =>
+    download(
+      `/api/playlist-backups/${encodeURIComponent(provider)}/latest`,
+      `songmirror-${provider}-playlists.json`,
+    ),
 
   // Sync (global: run-all + the auto-sync master switch)
   runSync: (execute: boolean) => request<RunResponse>(`/api/sync/run?execute=${execute ? 1 : 0}`, { method: 'POST' }),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -151,19 +151,19 @@ export const api = {
 
   // Persistent scheduled playlist-metadata backups
   getPlaylistBackups: () => request<PlaylistBackupJob[]>('/api/playlist-backups'),
-  savePlaylistBackup: (provider: string, values: PlaylistBackupUpdate) =>
+  savePlaylistBackup: (accountId: string, values: PlaylistBackupUpdate) =>
     request<PlaylistBackupJob>(
-      `/api/playlist-backups/${encodeURIComponent(provider)}`,
+      `/api/playlist-backups/${encodeURIComponent(accountId)}`,
       { method: 'PUT', body: JSON.stringify(values) },
     ),
-  deletePlaylistBackup: (provider: string) =>
-    request<OkResponse>(`/api/playlist-backups/${encodeURIComponent(provider)}`, { method: 'DELETE' }),
-  runPlaylistBackup: (provider: string) =>
-    request<QueueResponse>(`/api/playlist-backups/${encodeURIComponent(provider)}/run`, { method: 'POST' }),
-  downloadLatestPlaylistBackup: (provider: string) =>
+  deletePlaylistBackup: (accountId: string) =>
+    request<OkResponse>(`/api/playlist-backups/${encodeURIComponent(accountId)}`, { method: 'DELETE' }),
+  runPlaylistBackup: (accountId: string) =>
+    request<QueueResponse>(`/api/playlist-backups/${encodeURIComponent(accountId)}/run`, { method: 'POST' }),
+  downloadLatestPlaylistBackup: (accountId: string) =>
     download(
-      `/api/playlist-backups/${encodeURIComponent(provider)}/latest`,
-      `songmirror-${provider}-playlists.json`,
+      `/api/playlist-backups/${encodeURIComponent(accountId)}/latest`,
+      `songmirror-${accountId}-playlists.json`,
     ),
 
   // Sync (global: run-all + the auto-sync master switch)

--- a/frontend/src/components/settings/ScheduledPlaylistBackups.tsx
+++ b/frontend/src/components/settings/ScheduledPlaylistBackups.tsx
@@ -112,7 +112,7 @@ function BackupScheduleCard({
     setBusy('save')
     setActionError(null)
     try {
-      await api.savePlaylistBackup(job.provider, {
+      await api.savePlaylistBackup(job.account_id, {
         enabled: draft.enabled,
         interval: draft.interval.trim(),
         format: draft.format,
@@ -130,7 +130,7 @@ function BackupScheduleCard({
     setBusy('run')
     setActionError(null)
     try {
-      await api.runPlaylistBackup(job.provider)
+      await api.runPlaylistBackup(job.account_id)
       await refresh()
     } catch (err) {
       setActionError(errorMessage(err))
@@ -143,7 +143,7 @@ function BackupScheduleCard({
     setBusy('download')
     setActionError(null)
     try {
-      await api.downloadLatestPlaylistBackup(job.provider)
+      await api.downloadLatestPlaylistBackup(job.account_id)
     } catch (err) {
       setActionError(errorMessage(err))
     } finally {
@@ -155,7 +155,7 @@ function BackupScheduleCard({
     setBusy('delete')
     setActionError(null)
     try {
-      await api.deletePlaylistBackup(job.provider)
+      await api.deletePlaylistBackup(job.account_id)
       setConfirmDelete(false)
       await refresh()
     } catch (err) {
@@ -170,13 +170,13 @@ function BackupScheduleCard({
       <div className="flex flex-wrap items-start gap-3">
         <span className="flex size-9 shrink-0 items-center justify-center rounded-control bg-surface text-text-2">
           <ServiceLogo
-            service={(job.provider_type ?? job.provider) as Parameters<typeof ServiceLogo>[0]['service']}
+            service={job.provider as Parameters<typeof ServiceLogo>[0]['service']}
             className="size-5"
           />
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-sm font-semibold text-text">{job.provider_name}</h3>
+            <h3 className="text-sm font-semibold text-text">{job.account_name}</h3>
             <span className={`rounded-chip px-2 py-0.5 font-mono text-[10px] font-semibold ${
               job.running
                 ? 'bg-accent-soft text-accent'
@@ -202,7 +202,7 @@ function BackupScheduleCard({
         <Toggle
           checked={draft.enabled}
           onChange={(enabled) => setDraft((current) => ({ ...current, enabled }))}
-          label={`Automatically back up ${job.provider_name}`}
+          label={`Automatically back up ${job.account_name}`}
           hideLabel
         />
       </div>
@@ -274,7 +274,7 @@ function BackupScheduleCard({
           icon={<LuSave className="size-3.5" aria-hidden="true" />}
           loading={busy === 'save'}
           disabled={!dirty || !intervalOk || !retentionOk || busy !== null}
-          aria-label={`Save ${job.provider_name} backup schedule`}
+          aria-label={`Save ${job.account_name} backup schedule`}
           onClick={() => void save()}
         >
           Save schedule
@@ -285,7 +285,7 @@ function BackupScheduleCard({
           icon={<LuPlay className="size-3.5" aria-hidden="true" />}
           loading={busy === 'run'}
           disabled={dirty || job.running || busy !== null}
-          aria-label={`Back up ${job.provider_name} now`}
+          aria-label={`Back up ${job.account_name} now`}
           onClick={() => void runNow()}
         >
           Back up now
@@ -296,7 +296,7 @@ function BackupScheduleCard({
           icon={<LuDownload className="size-3.5" aria-hidden="true" />}
           loading={busy === 'download'}
           disabled={job.snapshot_count === 0 || busy !== null}
-          aria-label={`Download latest ${job.provider_name} backup`}
+          aria-label={`Download latest ${job.account_name} backup`}
           onClick={() => void downloadLatest()}
         >
           Download latest
@@ -306,7 +306,7 @@ function BackupScheduleCard({
           variant="danger-ghost"
           icon={<LuTrash2 className="size-3.5" aria-hidden="true" />}
           disabled={busy !== null}
-          aria-label={`Remove ${job.provider_name} backup schedule`}
+          aria-label={`Remove ${job.account_name} backup schedule`}
           onClick={() => setConfirmDelete(true)}
         >
           Remove schedule
@@ -315,7 +315,7 @@ function BackupScheduleCard({
 
       <ConfirmDialog
         open={confirmDelete}
-        title={`Remove ${job.provider_name} backup schedule?`}
+        title={`Remove ${job.account_name} backup schedule?`}
         description={`Automatic runs will stop. The ${job.snapshot_count} snapshots already stored on disk will not be deleted.`}
         confirmLabel="Remove schedule"
         danger
@@ -327,7 +327,7 @@ function BackupScheduleCard({
   )
 }
 
-function connectedBackupProviders(accounts: Account[] | null, scheduled: Set<string>) {
+function connectedBackupAccounts(accounts: Account[] | null, scheduled: Set<string>) {
   return (accounts ?? []).filter((account) => (
     account.state === 'connected'
     && account.transferable
@@ -339,33 +339,33 @@ function connectedBackupProviders(accounts: Account[] | null, scheduled: Set<str
 export function ScheduledPlaylistBackups() {
   const { accounts, loading: accountsLoading } = useAccounts()
   const { backups, loading, error, refresh } = usePlaylistBackups()
-  const [provider, setProvider] = useState('')
+  const [accountId, setAccountId] = useState('')
   const [adding, setAdding] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
   const scheduled = useMemo(
-    () => new Set((backups ?? []).map((job) => job.provider)),
+    () => new Set((backups ?? []).map((job) => job.account_id)),
     [backups],
   )
   const available = useMemo(
-    () => connectedBackupProviders(accounts, scheduled),
+    () => connectedBackupAccounts(accounts, scheduled),
     [accounts, scheduled],
   )
-  const connectedProviderCount = (accounts ?? []).filter((account) => (
+  const connectedAccountCount = (accounts ?? []).filter((account) => (
     account.state === 'connected'
     && account.transferable
     && capabilitiesOf(account).library_read
   )).length
-  const selectedProvider = available.some((account) => account.id === provider)
-    ? provider
+  const selectedAccount = available.some((account) => account.id === accountId)
+    ? accountId
     : available[0]?.id ?? ''
 
   async function addSchedule() {
-    if (!selectedProvider) return
+    if (!selectedAccount) return
     setAdding(true)
     setAddError(null)
     try {
-      await api.savePlaylistBackup(selectedProvider, DEFAULT_UPDATE)
-      setProvider('')
+      await api.savePlaylistBackup(selectedAccount, DEFAULT_UPDATE)
+      setAccountId('')
       await refresh()
     } catch (err) {
       setAddError(errorMessage(err))
@@ -383,7 +383,7 @@ export function ScheduledPlaylistBackups() {
         <div>
           <p className="text-sm font-medium text-text">Scheduled playlist archive</p>
           <p className="mt-0.5 text-xs leading-relaxed text-text-3">
-            Save fresh metadata for every playlist on a connected service alongside SongMirror's persistent app data.
+            Save fresh metadata for every playlist on a connected account alongside SongMirror's persistent app data.
             Snapshots contain no credentials and stay available when their schedule is removed.
           </p>
         </div>
@@ -392,7 +392,7 @@ export function ScheduledPlaylistBackups() {
       {error ? <p role="alert" className="rounded-control bg-danger-soft px-3 py-2 text-xs text-danger">Could not load backup schedules: {error}</p> : null}
       {loading ? <p className="text-xs text-text-3">Loading backup schedules…</p> : null}
       {(backups ?? []).map((job) => (
-        <BackupScheduleCard key={job.provider} job={job} refresh={refresh} />
+        <BackupScheduleCard key={job.account_id} job={job} refresh={refresh} />
       ))}
 
       {backups !== null ? (
@@ -401,11 +401,11 @@ export function ScheduledPlaylistBackups() {
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
               <div className="min-w-0 flex-1">
                 <SelectField
-                  label="Add a connected service"
-                  help="One schedule archives all playlists from that service."
+                  label="Add a connected account"
+                  help="Each account gets its own schedule, storage, and run history."
                   options={available.map((account) => ({ value: account.id, label: account.name }))}
-                  value={selectedProvider}
-                  onChange={(event) => setProvider(event.target.value)}
+                  value={selectedAccount}
+                  onChange={(event) => setAccountId(event.target.value)}
                 />
               </div>
               <Button
@@ -421,9 +421,9 @@ export function ScheduledPlaylistBackups() {
             <p className="text-xs leading-relaxed text-text-3">
               {accountsLoading
                 ? 'Loading connected services…'
-                : connectedProviderCount === 0
-                  ? 'Connect a playlist service on the Accounts page to add a backup schedule.'
-                  : 'Every connected playlist service already has a backup schedule.'}
+                : connectedAccountCount === 0
+                  ? 'Connect a playlist account on the Accounts page to add a backup schedule.'
+                  : 'Every connected playlist account already has a backup schedule.'}
             </p>
           )}
           {addError ? <p role="alert" className="mt-2 text-xs text-danger">{addError}</p> : null}

--- a/frontend/src/components/settings/ScheduledPlaylistBackups.tsx
+++ b/frontend/src/components/settings/ScheduledPlaylistBackups.tsx
@@ -1,0 +1,434 @@
+import { useEffect, useMemo, useState } from 'react'
+import { LuArchive, LuDownload, LuPlay, LuSave, LuTrash2 } from 'react-icons/lu'
+
+import { api, errorMessage } from '@/api'
+import { useAccounts } from '@/hooks/useAccounts'
+import { useNow } from '@/hooks/useNow'
+import { usePlaylistBackups } from '@/hooks/usePlaylistBackups'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
+import { formatClockTime, formatCountdown, isValidIntervalText } from '@/lib/format'
+import type {
+  Account,
+  PlaylistBackupFormat,
+  PlaylistBackupJob,
+  PlaylistBackupUpdate,
+} from '@/types'
+
+import { Button } from '../ui/Button'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { SelectField } from '../ui/SelectField'
+import { ServiceLogo } from '../ui/ServiceLogo'
+import { TextField } from '../ui/TextField'
+import { Toggle } from '../ui/Toggle'
+
+const FORMAT_OPTIONS = [
+  { value: 'json', label: 'JSON' },
+  { value: 'xml', label: 'XML' },
+]
+
+const DEFAULT_UPDATE: Required<PlaylistBackupUpdate> = {
+  enabled: true,
+  interval: '24h',
+  format: 'json',
+  retention: 30,
+}
+
+interface Draft {
+  enabled: boolean
+  interval: string
+  format: PlaylistBackupFormat
+  retention: string
+}
+
+function draftFrom(job: PlaylistBackupJob): Draft {
+  return {
+    enabled: job.enabled,
+    interval: job.interval,
+    format: job.format,
+    retention: String(job.retention),
+  }
+}
+
+function intervalSeconds(value: string): number | null {
+  const match = value.trim().toLocaleLowerCase().match(/^(\d+)\s*([smh]?)$/)
+  if (!match) return null
+  const multiplier = match[2] === 'h' ? 3600 : match[2] === 'm' ? 60 : 1
+  return Number(match[1]) * multiplier
+}
+
+function validInterval(value: string): boolean {
+  if (!isValidIntervalText(value)) return false
+  const seconds = intervalSeconds(value)
+  return seconds !== null && seconds >= 60 && seconds <= 365 * 24 * 60 * 60
+}
+
+function validRetention(value: string): boolean {
+  return /^\d+$/.test(value.trim()) && Number(value) <= 10_000
+}
+
+function dateTime(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+function resultIsFailure(job: PlaylistBackupJob): boolean {
+  if (!job.last_failure) return false
+  if (!job.last_success) return true
+  return Date.parse(job.last_failure.at) >= Date.parse(job.last_success.at)
+}
+
+function BackupScheduleCard({
+  job,
+  refresh,
+}: {
+  job: PlaylistBackupJob
+  refresh: () => Promise<void>
+}) {
+  const [draft, setDraft] = useState<Draft>(() => draftFrom(job))
+  const [busy, setBusy] = useState<'save' | 'run' | 'download' | 'delete' | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const now = useNow()
+  const { enabled, format, interval, retention } = job
+
+  useEffect(() => {
+    setDraft({ enabled, format, interval, retention: String(retention) })
+  }, [enabled, format, interval, retention])
+
+  const dirty = draft.enabled !== job.enabled
+    || draft.interval !== job.interval
+    || draft.format !== job.format
+    || draft.retention !== String(job.retention)
+  const intervalOk = validInterval(draft.interval)
+  const retentionOk = validRetention(draft.retention)
+  const latestFailed = resultIsFailure(job)
+
+  async function save() {
+    if (!intervalOk || !retentionOk) return
+    setBusy('save')
+    setActionError(null)
+    try {
+      await api.savePlaylistBackup(job.provider, {
+        enabled: draft.enabled,
+        interval: draft.interval.trim(),
+        format: draft.format,
+        retention: Number(draft.retention),
+      })
+      await refresh()
+    } catch (err) {
+      setActionError(errorMessage(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function runNow() {
+    setBusy('run')
+    setActionError(null)
+    try {
+      await api.runPlaylistBackup(job.provider)
+      await refresh()
+    } catch (err) {
+      setActionError(errorMessage(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function downloadLatest() {
+    setBusy('download')
+    setActionError(null)
+    try {
+      await api.downloadLatestPlaylistBackup(job.provider)
+    } catch (err) {
+      setActionError(errorMessage(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function removeSchedule() {
+    setBusy('delete')
+    setActionError(null)
+    try {
+      await api.deletePlaylistBackup(job.provider)
+      setConfirmDelete(false)
+      await refresh()
+    } catch (err) {
+      setActionError(errorMessage(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="rounded-control border border-border bg-surface-2/45 p-3.5 sm:p-4">
+      <div className="flex flex-wrap items-start gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-control bg-surface text-text-2">
+          <ServiceLogo
+            service={(job.provider_type ?? job.provider) as Parameters<typeof ServiceLogo>[0]['service']}
+            className="size-5"
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-semibold text-text">{job.provider_name}</h3>
+            <span className={`rounded-chip px-2 py-0.5 font-mono text-[10px] font-semibold ${
+              job.running
+                ? 'bg-accent-soft text-accent'
+                : latestFailed
+                  ? 'bg-danger-soft text-danger'
+                  : job.last_success
+                    ? 'bg-success-soft text-success'
+                    : 'bg-neutral-soft text-neutral'
+            }`}>
+              {job.running
+                ? 'RUNNING'
+                : latestFailed
+                  ? 'LAST RUN FAILED'
+                  : job.last_success
+                    ? 'HEALTHY'
+                    : 'WAITING'}
+            </span>
+          </div>
+          <p className="mt-0.5 break-all font-mono text-[10.5px] text-text-3">
+            {job.storage_path}
+          </p>
+        </div>
+        <Toggle
+          checked={draft.enabled}
+          onChange={(enabled) => setDraft((current) => ({ ...current, enabled }))}
+          label={`Automatically back up ${job.provider_name}`}
+          hideLabel
+        />
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <TextField
+          label="Run every"
+          help="1m–8760h; for example 6h, 24h, or 168h."
+          value={draft.interval}
+          error={intervalOk ? undefined : 'Use an interval from 1m through 8760h.'}
+          onChange={(event) => setDraft((current) => ({ ...current, interval: event.target.value }))}
+        />
+        <SelectField
+          label="Snapshot format"
+          help="JSON is easiest to inspect or process."
+          options={FORMAT_OPTIONS}
+          value={draft.format}
+          onChange={(event) => setDraft((current) => ({
+            ...current,
+            format: event.target.value as PlaylistBackupFormat,
+          }))}
+        />
+        <TextField
+          label="Snapshots to keep"
+          help="Set 0 to keep every snapshot."
+          type="number"
+          min={0}
+          max={10_000}
+          step={1}
+          value={draft.retention}
+          error={retentionOk ? undefined : 'Enter a whole number from 0 through 10000.'}
+          onChange={(event) => setDraft((current) => ({ ...current, retention: event.target.value }))}
+        />
+      </div>
+
+      <div aria-live="polite" className="mt-4 rounded-control border border-border/80 bg-surface px-3 py-2.5 text-xs leading-relaxed text-text-2">
+        {job.running ? (
+          <p>Reading every playlist now. Syncs and transfers will run before or after this backup, never at the same time.</p>
+        ) : job.enabled && job.next_run_at ? (
+          <p>
+            Next run at <span className="font-semibold text-text">{formatClockTime(job.next_run_at)}</span>
+            {' '}· {formatCountdown(job.next_run_at, now)}
+          </p>
+        ) : (
+          <p>Automatic backups are paused. Run now is still available.</p>
+        )}
+        {job.last_success ? (
+          <p className="mt-1 break-words text-success">
+            Last success {dateTime(job.last_success.at)} · {job.last_success.playlist_count} playlists,
+            {' '}{job.last_success.track_count} tracks · {job.last_success.filename}
+          </p>
+        ) : (
+          <p className="mt-1 text-text-3">No successful snapshot yet.</p>
+        )}
+        {job.last_failure ? (
+          <p className={`mt-1 break-words ${latestFailed ? 'text-danger' : 'text-text-3'}`}>
+            Last failure {dateTime(job.last_failure.at)} · {job.last_failure.error}
+          </p>
+        ) : null}
+        <p className="mt-1 text-text-3">
+          {job.snapshot_count} stored snapshot{job.snapshot_count === 1 ? '' : 's'}.
+        </p>
+      </div>
+
+      {actionError ? <p role="alert" className="mt-3 text-xs text-danger">{actionError}</p> : null}
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          icon={<LuSave className="size-3.5" aria-hidden="true" />}
+          loading={busy === 'save'}
+          disabled={!dirty || !intervalOk || !retentionOk || busy !== null}
+          aria-label={`Save ${job.provider_name} backup schedule`}
+          onClick={() => void save()}
+        >
+          Save schedule
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          icon={<LuPlay className="size-3.5" aria-hidden="true" />}
+          loading={busy === 'run'}
+          disabled={dirty || job.running || busy !== null}
+          aria-label={`Back up ${job.provider_name} now`}
+          onClick={() => void runNow()}
+        >
+          Back up now
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          icon={<LuDownload className="size-3.5" aria-hidden="true" />}
+          loading={busy === 'download'}
+          disabled={job.snapshot_count === 0 || busy !== null}
+          aria-label={`Download latest ${job.provider_name} backup`}
+          onClick={() => void downloadLatest()}
+        >
+          Download latest
+        </Button>
+        <Button
+          size="sm"
+          variant="danger-ghost"
+          icon={<LuTrash2 className="size-3.5" aria-hidden="true" />}
+          disabled={busy !== null}
+          aria-label={`Remove ${job.provider_name} backup schedule`}
+          onClick={() => setConfirmDelete(true)}
+        >
+          Remove schedule
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={confirmDelete}
+        title={`Remove ${job.provider_name} backup schedule?`}
+        description={`Automatic runs will stop. The ${job.snapshot_count} snapshots already stored on disk will not be deleted.`}
+        confirmLabel="Remove schedule"
+        danger
+        loading={busy === 'delete'}
+        onConfirm={() => void removeSchedule()}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </div>
+  )
+}
+
+function connectedBackupProviders(accounts: Account[] | null, scheduled: Set<string>) {
+  return (accounts ?? []).filter((account) => (
+    account.state === 'connected'
+    && account.transferable
+    && capabilitiesOf(account).library_read
+    && !scheduled.has(account.id)
+  ))
+}
+
+export function ScheduledPlaylistBackups() {
+  const { accounts, loading: accountsLoading } = useAccounts()
+  const { backups, loading, error, refresh } = usePlaylistBackups()
+  const [provider, setProvider] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
+  const scheduled = useMemo(
+    () => new Set((backups ?? []).map((job) => job.provider)),
+    [backups],
+  )
+  const available = useMemo(
+    () => connectedBackupProviders(accounts, scheduled),
+    [accounts, scheduled],
+  )
+  const connectedProviderCount = (accounts ?? []).filter((account) => (
+    account.state === 'connected'
+    && account.transferable
+    && capabilitiesOf(account).library_read
+  )).length
+  const selectedProvider = available.some((account) => account.id === provider)
+    ? provider
+    : available[0]?.id ?? ''
+
+  async function addSchedule() {
+    if (!selectedProvider) return
+    setAdding(true)
+    setAddError(null)
+    try {
+      await api.savePlaylistBackup(selectedProvider, DEFAULT_UPDATE)
+      setProvider('')
+      await refresh()
+    } catch (err) {
+      setAddError(errorMessage(err))
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      <div className="flex items-start gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-control bg-accent-soft text-accent">
+          <LuArchive className="size-4.5" aria-hidden="true" />
+        </span>
+        <div>
+          <p className="text-sm font-medium text-text">Scheduled playlist archive</p>
+          <p className="mt-0.5 text-xs leading-relaxed text-text-3">
+            Save fresh metadata for every playlist on a connected service alongside SongMirror's persistent app data.
+            Snapshots contain no credentials and stay available when their schedule is removed.
+          </p>
+        </div>
+      </div>
+
+      {error ? <p role="alert" className="rounded-control bg-danger-soft px-3 py-2 text-xs text-danger">Could not load backup schedules: {error}</p> : null}
+      {loading ? <p className="text-xs text-text-3">Loading backup schedules…</p> : null}
+      {(backups ?? []).map((job) => (
+        <BackupScheduleCard key={job.provider} job={job} refresh={refresh} />
+      ))}
+
+      {backups !== null ? (
+        <div className="rounded-control border border-dashed border-border-strong p-3.5 sm:p-4">
+          {available.length > 0 ? (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="min-w-0 flex-1">
+                <SelectField
+                  label="Add a connected service"
+                  help="One schedule archives all playlists from that service."
+                  options={available.map((account) => ({ value: account.id, label: account.name }))}
+                  value={selectedProvider}
+                  onChange={(event) => setProvider(event.target.value)}
+                />
+              </div>
+              <Button
+                className="sm:mb-[1.625rem]"
+                size="sm"
+                loading={adding}
+                onClick={() => void addSchedule()}
+              >
+                Add daily backup
+              </Button>
+            </div>
+          ) : (
+            <p className="text-xs leading-relaxed text-text-3">
+              {accountsLoading
+                ? 'Loading connected services…'
+                : connectedProviderCount === 0
+                  ? 'Connect a playlist service on the Accounts page to add a backup schedule.'
+                  : 'Every connected playlist service already has a backup schedule.'}
+            </p>
+          )}
+          {addError ? <p role="alert" className="mt-2 text-xs text-danger">{addError}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/hooks/usePlaylistBackups.ts
+++ b/frontend/src/hooks/usePlaylistBackups.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { api, errorMessage } from '../api'
+import type { PlaylistBackupJob } from '../types'
+
+const POLL_MS = 5000
+
+/** Backup runs happen out of band, so poll while Settings is open to surface a
+ * queued run, its result, and the next wall-clock boundary without reloading. */
+export function usePlaylistBackups() {
+  const [backups, setBackups] = useState<PlaylistBackupJob[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const inFlight = useRef(false)
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return
+    inFlight.current = true
+    try {
+      setBackups(await api.getPlaylistBackups())
+      setError(null)
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      inFlight.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const id = window.setInterval(() => void refresh(), POLL_MS)
+    return () => window.clearInterval(id)
+  }, [refresh])
+
+  return { backups, loading: backups === null && error === null, error, refresh }
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { LuArrowRight } from 'react-icons/lu'
 
 import { api, errorMessage } from '@/api'
 import { ThemeToggle } from '@/components/layout/ThemeToggle'
+import { ScheduledPlaylistBackups } from '@/components/settings/ScheduledPlaylistBackups'
 import { Button } from '@/components/ui/Button'
 import { SelectField } from '@/components/ui/SelectField'
 import { LoadingStatus, Skeleton } from '@/components/ui/Skeleton'
@@ -91,7 +92,7 @@ export default function Settings() {
       <div>
         <h1 className="text-xl font-bold tracking-tight text-text sm:text-[22px]">Settings</h1>
         <p className="mt-1 text-sm text-text-3">
-          Profile, appearance, and the shared download folder. Provider credentials live on the Accounts page.
+          Profile, appearance, downloads, and persistent playlist archives. Provider credentials live on the Accounts page.
         </p>
         <Link
           to="/sync"
@@ -109,6 +110,10 @@ export default function Settings() {
         <p className="text-xs leading-relaxed text-text-3">
           Applies instantly and is remembered on this device, separate from your account settings.
         </p>
+      </SettingsGroup>
+
+      <SettingsGroup label="PLAYLIST ARCHIVE">
+        <ScheduledPlaylistBackups />
       </SettingsGroup>
 
       {loading && !form ? (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -402,6 +402,54 @@ export interface ProviderPlaylistDetail extends ProviderPlaylist {
  * option follows Soundiiz's documented importable JSON array shape. */
 export type PlaylistExportFormat = 'json' | 'xml' | 'soundiiz'
 
+export type PlaylistBackupFormat = 'json' | 'xml'
+
+export interface PlaylistBackupSuccess {
+  at: string
+  filename: string
+  format: PlaylistBackupFormat
+  playlist_count: number
+  track_count: number
+  pruned: number
+}
+
+export interface PlaylistBackupFailure {
+  at: string
+  error: string
+}
+
+/** GET /api/playlist-backups — one persistent provider-wide backup schedule
+ * plus its scheduler state and durable last-success/last-failure history. */
+export interface PlaylistBackupJob {
+  /** Stable account profile id used by the schedule and API routes. */
+  provider: string
+  /** Connector/catalog type used for provider branding. */
+  provider_type?: string
+  provider_name: string
+  enabled: boolean
+  interval: string
+  format: PlaylistBackupFormat
+  /** Maximum snapshots retained; zero keeps every snapshot. */
+  retention: number
+  running: boolean
+  next_run_at: number | null
+  snapshot_count: number
+  storage_path: string
+  last_success: PlaylistBackupSuccess | null
+  last_failure: PlaylistBackupFailure | null
+}
+
+export interface PlaylistBackupUpdate {
+  enabled?: boolean
+  interval?: string
+  format?: PlaylistBackupFormat
+  retention?: number
+}
+
+export interface QueueResponse {
+  queued: boolean
+}
+
 export interface RemovePlaylistTrackRequest {
   position: number
   track_id: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -418,14 +418,17 @@ export interface PlaylistBackupFailure {
   error: string
 }
 
-/** GET /api/playlist-backups — one persistent provider-wide backup schedule
- * plus its scheduler state and durable last-success/last-failure history. */
+/** GET /api/playlist-backups — one persistent account-wide backup schedule
+ * plus its provider metadata, scheduler state, and durable run history. */
 export interface PlaylistBackupJob {
-  /** Stable account profile id used by the schedule and API routes. */
+  /** Stable account profile id used by the schedule, storage, and API routes. */
+  account_id: string
+  /** Connector/catalog type shared by one or more accounts. */
   provider: string
-  /** Connector/catalog type used for provider branding. */
-  provider_type?: string
+  /** Provider brand name, such as Spotify. */
   provider_name: string
+  /** Profile-aware display name, such as Spotify · Alex. */
+  account_name: string
   enabled: boolean
   interval: string
   format: PlaylistBackupFormat

--- a/songmirror/services/playlist_backups.py
+++ b/songmirror/services/playlist_backups.py
@@ -1,0 +1,550 @@
+"""Scheduled, persistent provider-wide playlist metadata backups.
+
+Each provider has at most one schedule. Configuration and run history live in
+small owner-only JSON files under SongMirror's application-data directory;
+snapshots live below ``playlist_backups/<provider>`` so the existing data
+volume is sufficient to preserve them across container replacements.
+
+Provider reads share SyncService's exclusive engine lock. A scheduled backup
+therefore queues behind a sync or transfer instead of racing the same provider
+clients and on-disk caches.
+"""
+
+import asyncio
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..engine import logs
+from ..engine.config import parse_interval
+from .playlists import PlaylistService, provider_label
+
+
+DEFAULT_BACKUP_INTERVAL = "24h"
+DEFAULT_BACKUP_FORMAT = "json"
+DEFAULT_BACKUP_RETENTION = 30
+SUPPORTED_BACKUP_FORMATS = frozenset({"json", "xml"})
+MIN_BACKUP_INTERVAL_SECONDS = 60
+MAX_BACKUP_INTERVAL_SECONDS = 365 * 24 * 60 * 60
+MAX_BACKUP_RETENTION = 10_000
+
+_MANAGED_SNAPSHOT = re.compile(
+    r"^songmirror-.+-(?P<timestamp>\d{8}T\d{6}Z)"
+    r"(?:-(?P<collision>\d+))?\.(?:json|xml)$"
+)
+
+
+def _utc_timestamp(now=None):
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _atomic_json(path, value):
+    """Durably replace a private JSON file without leaving it half-written."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        try:
+            os.chmod(temporary, 0o600)
+        except OSError:
+            pass
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+@dataclass
+class PlaylistBackupJob:
+    provider: str
+    enabled: bool = True
+    interval: str = DEFAULT_BACKUP_INTERVAL
+    format: str = DEFAULT_BACKUP_FORMAT
+    retention: int = DEFAULT_BACKUP_RETENTION
+
+
+def validate_backup_job(job):
+    """Validate a persisted or API-created schedule and return it normalized."""
+    job.provider = str(job.provider or "").strip().casefold()
+    job.interval = str(job.interval or "").strip().casefold()
+    job.format = str(job.format or "").strip().casefold()
+    if not re.fullmatch(r"[a-z0-9_-]+", job.provider):
+        raise ValueError("provider is required")
+    if type(job.enabled) is not bool:
+        raise ValueError("enabled must be true or false")
+    try:
+        interval_seconds = parse_interval(job.interval)
+    except ValueError as exc:
+        raise ValueError("interval must look like 1h, 12h, or 24h") from exc
+    if not MIN_BACKUP_INTERVAL_SECONDS <= interval_seconds <= MAX_BACKUP_INTERVAL_SECONDS:
+        raise ValueError("interval must be between 1 minute and 365 days")
+    if job.format not in SUPPORTED_BACKUP_FORMATS:
+        raise ValueError("format must be json or xml")
+    if type(job.retention) is not int:
+        raise ValueError("retention must be a whole number")
+    if not 0 <= job.retention <= MAX_BACKUP_RETENTION:
+        raise ValueError(
+            f"retention must be between 0 and {MAX_BACKUP_RETENTION}"
+        )
+    return job
+
+
+class PlaylistBackupStore:
+    """Schedule, history, and snapshot storage rooted in the app data dir.
+
+    The persisted ``provider`` key is the selected account profile id when
+    profiles are available. Legacy provider ids resolve to their deterministic
+    default profiles, while standalone callers keep the original provider-only
+    behavior.
+    """
+
+    def __init__(self, dir="data", profiles=None):
+        self._dir = Path(dir)
+        self._config_path = self._dir / "playlist_backups.json"
+        self._status_path = self._dir / "playlist_backup_status.json"
+        self._snapshots_dir = self._dir / "playlist_backups"
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._profiles = profiles
+
+    def _account(self, identity):
+        identity = str(identity or "").strip().casefold()
+        return self._profiles.canonical_id(identity) if self._profiles else identity
+
+    @property
+    def snapshots_dir(self):
+        return self._snapshots_dir
+
+    def provider_dir(self, provider):
+        return self._snapshots_dir / self._account(provider)
+
+    @staticmethod
+    def _read_json(path, default):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                return json.load(handle)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return default
+
+    def list(self):
+        with self._lock:
+            rows = self._read_json(self._config_path, [])
+        if not isinstance(rows, list):
+            return []
+        allowed = {field.name for field in fields(PlaylistBackupJob)}
+        jobs = []
+        migrated = False
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            try:
+                data = {key: value for key, value in row.items() if key in allowed}
+                provider = self._account(data.get("provider"))
+                migrated = migrated or provider != data.get("provider")
+                data["provider"] = provider
+                jobs.append(validate_backup_job(PlaylistBackupJob(**data)))
+            except (TypeError, ValueError):
+                continue
+        if migrated:
+            _atomic_json(
+                self._config_path,
+                [asdict(job) for job in sorted(jobs, key=lambda item: item.provider)],
+            )
+        return sorted(jobs, key=lambda job: job.provider)
+
+    def get(self, provider):
+        provider = self._account(provider)
+        return next((job for job in self.list() if job.provider == provider), None)
+
+    def upsert(self, job):
+        job.provider = self._account(job.provider)
+        job = validate_backup_job(job)
+        with self._lock:
+            jobs = [item for item in self.list() if item.provider != job.provider]
+            jobs.append(job)
+            _atomic_json(
+                self._config_path,
+                [asdict(item) for item in sorted(jobs, key=lambda item: item.provider)],
+            )
+        return job
+
+    def delete(self, provider):
+        provider = self._account(provider)
+        with self._lock:
+            jobs = [item for item in self.list() if item.provider != provider]
+            _atomic_json(self._config_path, [asdict(item) for item in jobs])
+
+    def _statuses(self):
+        statuses = self._read_json(self._status_path, {})
+        return statuses if isinstance(statuses, dict) else {}
+
+    def status(self, provider):
+        provider = self._account(provider)
+        with self._lock:
+            value = self._statuses().get(provider, {})
+        if not isinstance(value, dict):
+            return {}
+        result = {}
+        success = value.get("last_success")
+        if (
+            isinstance(success, dict)
+            and isinstance(success.get("at"), str)
+            and isinstance(success.get("filename"), str)
+            and success.get("format") in SUPPORTED_BACKUP_FORMATS
+            and type(success.get("playlist_count")) is int
+            and type(success.get("track_count")) is int
+            and type(success.get("pruned")) is int
+        ):
+            result["last_success"] = success
+        failure = value.get("last_failure")
+        if (
+            isinstance(failure, dict)
+            and isinstance(failure.get("at"), str)
+            and isinstance(failure.get("error"), str)
+        ):
+            result["last_failure"] = failure
+        return result
+
+    def _record(self, provider, key, value):
+        provider = self._account(provider)
+        with self._lock:
+            statuses = self._statuses()
+            current = statuses.get(provider)
+            if not isinstance(current, dict):
+                current = {}
+            current[key] = value
+            statuses[provider] = current
+            _atomic_json(self._status_path, statuses)
+
+    def record_success(self, provider, value):
+        self._record(provider, "last_success", value)
+
+    def record_failure(self, provider, value):
+        self._record(provider, "last_failure", value)
+
+    def snapshots(self, provider):
+        provider = self._account(provider)
+        directory = self.provider_dir(provider)
+        try:
+            candidates = [
+                path for path in directory.iterdir()
+                if (
+                    path.is_file()
+                    and not path.is_symlink()
+                    and _MANAGED_SNAPSHOT.fullmatch(path.name)
+                )
+            ]
+        except OSError:
+            return []
+
+        def sort_key(path):
+            match = _MANAGED_SNAPSHOT.fullmatch(path.name)
+            collision = int(match.group("collision") or 1)
+            return match.group("timestamp"), collision, path.name
+
+        return sorted(candidates, key=sort_key, reverse=True)
+
+    def write_snapshot(self, provider, export, retention):
+        provider = self._account(provider)
+        directory = self.provider_dir(provider)
+        directory.mkdir(parents=True, exist_ok=True)
+        if (
+            directory.is_symlink()
+            or directory.resolve().parent != self._snapshots_dir.resolve()
+        ):
+            raise ValueError("playlist backup directory escapes application data")
+        for private_directory in (self._snapshots_dir, directory):
+            try:
+                os.chmod(private_directory, 0o700)
+            except OSError:
+                pass
+
+        export_name = str(export.filename)
+        if Path(export_name).name != export_name or not _MANAGED_SNAPSHOT.fullmatch(
+            export_name
+        ):
+            raise ValueError("playlist export produced an unsafe snapshot filename")
+        destination = directory / export_name
+        collision = 2
+        while destination.exists():
+            destination = directory / (
+                f"{Path(export.filename).stem}-{collision}{Path(export.filename).suffix}"
+            )
+            collision += 1
+
+        fd, temporary = tempfile.mkstemp(
+            dir=directory,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+        )
+        try:
+            try:
+                os.chmod(temporary, 0o600)
+            except OSError:
+                pass
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(export.content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, destination)
+            try:
+                os.chmod(destination, 0o600)
+            except OSError:
+                pass
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+            raise
+
+        removed = 0
+        if retention > 0:
+            for stale in self.snapshots(provider)[retention:]:
+                stale.unlink()
+                removed += 1
+        return destination, removed
+
+    def latest_snapshot(self, provider):
+        snapshots = self.snapshots(provider)
+        return snapshots[0] if snapshots else None
+
+
+class PlaylistBackupService:
+    """Own scheduled timers and serialize backup reads with engine work."""
+
+    def __init__(self, settings, sync_service, bus, store=None, profiles=None):
+        self._settings = settings
+        self._sync = sync_service
+        self._bus = bus
+        self._profiles = profiles
+        self.store = store or PlaylistBackupStore(settings.data_dir, profiles=profiles)
+        self._stopping = False
+        self._schedulers = {}
+        self._scheduler_intervals = {}
+        self._next_run = {}
+        self._runs = {}
+
+    def _account(self, identity):
+        identity = str(identity or "").strip().casefold()
+        return self._profiles.canonical_id(identity) if self._profiles else identity
+
+    def _provider(self, identity):
+        return self._profiles.provider_of(identity) if self._profiles else identity
+
+    def _label(self, identity):
+        provider = self._provider(identity)
+        base = provider_label(provider) or str(provider or identity)
+        return self._profiles.display_name(identity, base) if self._profiles else base
+
+    async def start(self):
+        self._stopping = False
+        await self.reconcile()
+
+    async def shutdown(self):
+        self._stopping = True
+        schedulers = list(self._schedulers.values())
+        self._schedulers.clear()
+        self._scheduler_intervals.clear()
+        self._next_run.clear()
+        for task in schedulers:
+            task.cancel()
+        if schedulers:
+            await asyncio.gather(*schedulers, return_exceptions=True)
+        # Let a snapshot already holding or waiting for the shared engine lock
+        # finish cleanly; cancelling asyncio.to_thread would not stop its worker.
+        running = list(self._runs.values())
+        if running:
+            await asyncio.gather(*running, return_exceptions=True)
+
+    async def reconcile(self):
+        jobs = {job.provider: job for job in self.store.list() if job.enabled}
+        wanted = set(jobs) if not self._stopping else set()
+        for provider in list(self._schedulers):
+            interval = jobs.get(provider).interval if provider in jobs else None
+            if provider not in wanted or self._scheduler_intervals.get(provider) != interval:
+                self._schedulers.pop(provider).cancel()
+                self._scheduler_intervals.pop(provider, None)
+                self._next_run.pop(provider, None)
+        for provider in wanted:
+            if provider not in self._schedulers:
+                job = jobs[provider]
+                self._set_next_run(provider, job.interval)
+                self._scheduler_intervals[provider] = job.interval
+                self._schedulers[provider] = asyncio.create_task(
+                    self._scheduler(provider)
+                )
+
+    def _set_next_run(self, provider, interval):
+        now = time.time()
+        seconds = parse_interval(interval)
+        self._next_run[provider] = now + (seconds - (now % seconds))
+
+    async def _scheduler(self, provider):
+        own_task = asyncio.current_task()
+        try:
+            while not self._stopping:
+                job = self.store.get(provider)
+                if job is None or not job.enabled:
+                    break
+                due = self._next_run.get(provider)
+                if due is None:
+                    self._set_next_run(provider, job.interval)
+                    due = self._next_run[provider]
+                await asyncio.sleep(max(0, due - time.time()))
+                if self._stopping:
+                    break
+                self.queue(provider)
+                current = self.store.get(provider)
+                if current is None or not current.enabled:
+                    break
+                self._set_next_run(provider, current.interval)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # A changed interval replaces this task before its cancellation is
+            # delivered. Do not let the retired task clear the replacement's
+            # freshly computed next-run time.
+            if self._schedulers.get(provider) is own_task:
+                self._schedulers.pop(provider, None)
+                self._scheduler_intervals.pop(provider, None)
+                self._next_run.pop(provider, None)
+
+    def queue(self, provider):
+        provider = self._account(provider)
+        if self._stopping:
+            return False
+        current = self._runs.get(provider)
+        if current is not None and not current.done():
+            return False
+        if self.store.get(provider) is None:
+            return False
+        task = asyncio.create_task(self._execute(provider))
+        self._runs[provider] = task
+
+        def finished(done):
+            if self._runs.get(provider) is done:
+                self._runs.pop(provider, None)
+            try:
+                unexpected = done.exception()
+            except asyncio.CancelledError:
+                return
+            if unexpected is not None:
+                self._emit(
+                    "warn",
+                    f"{self._label(provider)}: playlist backup task stopped unexpectedly",
+                    provider,
+                )
+
+        task.add_done_callback(finished)
+        return True
+
+    async def run(self, provider):
+        provider = self._account(provider)
+        if not self.queue(provider):
+            return False
+        await self._runs[provider]
+        return True
+
+    async def _execute(self, provider):
+        job = self.store.get(provider)
+        if job is None:
+            return
+        label = self._label(provider)
+        self._emit("section", f"{label}: playlist backup started", provider)
+        try:
+            export = await self._sync.run_exclusive(
+                lambda: PlaylistService(self._settings, self._profiles).export(
+                    provider,
+                    job.format,
+                )
+            )
+            destination, removed = await asyncio.to_thread(
+                self.store.write_snapshot,
+                provider,
+                export,
+                job.retention,
+            )
+            success = {
+                "at": _utc_timestamp(),
+                "filename": destination.name,
+                "format": job.format,
+                "playlist_count": export.playlist_count,
+                "track_count": export.track_count,
+                "pruned": removed,
+            }
+            self.store.record_success(provider, success)
+            self._emit(
+                "summary",
+                f"{label}: playlist backup saved ({destination.name})",
+                provider,
+                success,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            failure = {
+                "at": _utc_timestamp(),
+                "error": str(exc).strip()[:500] or type(exc).__name__,
+            }
+            self.store.record_failure(provider, failure)
+            self._emit(
+                "warn",
+                f"{label}: playlist backup failed: {failure['error']}",
+                provider,
+            )
+
+    def list_status(self):
+        return [self.job_status(job) for job in self.store.list()]
+
+    def job_status(self, job):
+        history = self.store.status(job.provider)
+        return {
+            **asdict(job),
+            "provider_type": self._provider(job.provider),
+            "provider_name": self._label(job.provider),
+            "running": job.provider in self._runs,
+            "next_run_at": self._next_run.get(job.provider) if job.enabled else None,
+            "snapshot_count": len(self.store.snapshots(job.provider)),
+            "storage_path": str(self.store.provider_dir(job.provider).resolve()),
+            "last_success": history.get("last_success"),
+            "last_failure": history.get("last_failure"),
+        }
+
+    def _emit(self, kind, message, tag, data=None):
+        self._bus.publish(logs.Event(time.time(), kind, tag, message, data))

--- a/songmirror/services/playlist_backups.py
+++ b/songmirror/services/playlist_backups.py
@@ -1,12 +1,12 @@
-"""Scheduled, persistent provider-wide playlist metadata backups.
+"""Scheduled, persistent account-wide playlist metadata backups.
 
-Each provider has at most one schedule. Configuration and run history live in
+Each account profile has at most one schedule. Configuration and run history live in
 small owner-only JSON files under SongMirror's application-data directory;
-snapshots live below ``playlist_backups/<provider>`` so the existing data
+snapshots live below ``playlist_backups/<account-profile-id>`` so the existing data
 volume is sufficient to preserve them across container replacements.
 
 Provider reads share SyncService's exclusive engine lock. A scheduled backup
-therefore queues behind a sync or transfer instead of racing the same provider
+therefore queues behind a sync or transfer instead of racing the same account
 clients and on-disk caches.
 """
 
@@ -87,7 +87,7 @@ def _atomic_json(path, value):
 
 @dataclass
 class PlaylistBackupJob:
-    provider: str
+    account_id: str
     enabled: bool = True
     interval: str = DEFAULT_BACKUP_INTERVAL
     format: str = DEFAULT_BACKUP_FORMAT
@@ -96,11 +96,11 @@ class PlaylistBackupJob:
 
 def validate_backup_job(job):
     """Validate a persisted or API-created schedule and return it normalized."""
-    job.provider = str(job.provider or "").strip().casefold()
+    job.account_id = str(job.account_id or "").strip().casefold()
     job.interval = str(job.interval or "").strip().casefold()
     job.format = str(job.format or "").strip().casefold()
-    if not re.fullmatch(r"[a-z0-9_-]+", job.provider):
-        raise ValueError("provider is required")
+    if not re.fullmatch(r"[a-z0-9_-]+", job.account_id):
+        raise ValueError("account is required")
     if type(job.enabled) is not bool:
         raise ValueError("enabled must be true or false")
     try:
@@ -123,10 +123,10 @@ def validate_backup_job(job):
 class PlaylistBackupStore:
     """Schedule, history, and snapshot storage rooted in the app data dir.
 
-    The persisted ``provider`` key is the selected account profile id when
-    profiles are available. Legacy provider ids resolve to their deterministic
-    default profiles, while standalone callers keep the original provider-only
-    behavior.
+    The persisted ``account_id`` key is the selected account profile. Legacy
+    rows whose ``provider`` key held either a provider alias or a profile id are
+    migrated on read. Provider aliases resolve to deterministic default profiles,
+    while standalone callers keep the original provider-only identity.
     """
 
     def __init__(self, dir="data", profiles=None):
@@ -146,8 +146,8 @@ class PlaylistBackupStore:
     def snapshots_dir(self):
         return self._snapshots_dir
 
-    def provider_dir(self, provider):
-        return self._snapshots_dir / self._account(provider)
+    def account_dir(self, account_id):
+        return self._snapshots_dir / self._account(account_id)
 
     @staticmethod
     def _read_json(path, default):
@@ -170,49 +170,73 @@ class PlaylistBackupStore:
                 continue
             try:
                 data = {key: value for key, value in row.items() if key in allowed}
-                provider = self._account(data.get("provider"))
-                migrated = migrated or provider != data.get("provider")
-                data["provider"] = provider
+                original_account_id = data.get("account_id") or row.get("provider")
+                account_id = self._account(original_account_id)
+                migrated = migrated or (
+                    "account_id" not in row
+                    or "provider" in row
+                    or account_id != original_account_id
+                )
+                data["account_id"] = account_id
                 jobs.append(validate_backup_job(PlaylistBackupJob(**data)))
             except (TypeError, ValueError):
                 continue
         if migrated:
             _atomic_json(
                 self._config_path,
-                [asdict(job) for job in sorted(jobs, key=lambda item: item.provider)],
+                [asdict(job) for job in sorted(jobs, key=lambda item: item.account_id)],
             )
-        return sorted(jobs, key=lambda job: job.provider)
+        return sorted(jobs, key=lambda job: job.account_id)
 
-    def get(self, provider):
-        provider = self._account(provider)
-        return next((job for job in self.list() if job.provider == provider), None)
+    def get(self, account_id):
+        account_id = self._account(account_id)
+        return next((job for job in self.list() if job.account_id == account_id), None)
 
     def upsert(self, job):
-        job.provider = self._account(job.provider)
+        job.account_id = self._account(job.account_id)
         job = validate_backup_job(job)
         with self._lock:
-            jobs = [item for item in self.list() if item.provider != job.provider]
+            jobs = [item for item in self.list() if item.account_id != job.account_id]
             jobs.append(job)
             _atomic_json(
                 self._config_path,
-                [asdict(item) for item in sorted(jobs, key=lambda item: item.provider)],
+                [asdict(item) for item in sorted(jobs, key=lambda item: item.account_id)],
             )
         return job
 
-    def delete(self, provider):
-        provider = self._account(provider)
+    def delete(self, account_id):
+        account_id = self._account(account_id)
         with self._lock:
-            jobs = [item for item in self.list() if item.provider != provider]
+            jobs = [item for item in self.list() if item.account_id != account_id]
             _atomic_json(self._config_path, [asdict(item) for item in jobs])
 
     def _statuses(self):
-        statuses = self._read_json(self._status_path, {})
-        return statuses if isinstance(statuses, dict) else {}
+        raw = self._read_json(self._status_path, {})
+        if not isinstance(raw, dict):
+            return {}
+        statuses = {}
+        migrated = False
+        # Process legacy aliases first so an existing canonical-profile record
+        # wins if both keys are present.
+        for identity, value in sorted(
+            raw.items(), key=lambda item: self._account(item[0]) == item[0]
+        ):
+            account_id = self._account(identity)
+            migrated = migrated or account_id != identity
+            current = statuses.get(account_id, {})
+            statuses[account_id] = (
+                {**current, **value}
+                if isinstance(current, dict) and isinstance(value, dict)
+                else value
+            )
+        if migrated:
+            _atomic_json(self._status_path, statuses)
+        return statuses
 
-    def status(self, provider):
-        provider = self._account(provider)
+    def status(self, account_id):
+        account_id = self._account(account_id)
         with self._lock:
-            value = self._statuses().get(provider, {})
+            value = self._statuses().get(account_id, {})
         if not isinstance(value, dict):
             return {}
         result = {}
@@ -236,26 +260,26 @@ class PlaylistBackupStore:
             result["last_failure"] = failure
         return result
 
-    def _record(self, provider, key, value):
-        provider = self._account(provider)
+    def _record(self, account_id, key, value):
+        account_id = self._account(account_id)
         with self._lock:
             statuses = self._statuses()
-            current = statuses.get(provider)
+            current = statuses.get(account_id)
             if not isinstance(current, dict):
                 current = {}
             current[key] = value
-            statuses[provider] = current
+            statuses[account_id] = current
             _atomic_json(self._status_path, statuses)
 
-    def record_success(self, provider, value):
-        self._record(provider, "last_success", value)
+    def record_success(self, account_id, value):
+        self._record(account_id, "last_success", value)
 
-    def record_failure(self, provider, value):
-        self._record(provider, "last_failure", value)
+    def record_failure(self, account_id, value):
+        self._record(account_id, "last_failure", value)
 
-    def snapshots(self, provider):
-        provider = self._account(provider)
-        directory = self.provider_dir(provider)
+    def snapshots(self, account_id):
+        account_id = self._account(account_id)
+        directory = self.account_dir(account_id)
         try:
             candidates = [
                 path for path in directory.iterdir()
@@ -275,9 +299,9 @@ class PlaylistBackupStore:
 
         return sorted(candidates, key=sort_key, reverse=True)
 
-    def write_snapshot(self, provider, export, retention):
-        provider = self._account(provider)
-        directory = self.provider_dir(provider)
+    def write_snapshot(self, account_id, export, retention):
+        account_id = self._account(account_id)
+        directory = self.account_dir(account_id)
         directory.mkdir(parents=True, exist_ok=True)
         if (
             directory.is_symlink()
@@ -335,13 +359,13 @@ class PlaylistBackupStore:
 
         removed = 0
         if retention > 0:
-            for stale in self.snapshots(provider)[retention:]:
+            for stale in self.snapshots(account_id)[retention:]:
                 stale.unlink()
                 removed += 1
         return destination, removed
 
-    def latest_snapshot(self, provider):
-        snapshots = self.snapshots(provider)
+    def latest_snapshot(self, account_id):
+        snapshots = self.snapshots(account_id)
         return snapshots[0] if snapshots else None
 
 
@@ -393,73 +417,73 @@ class PlaylistBackupService:
             await asyncio.gather(*running, return_exceptions=True)
 
     async def reconcile(self):
-        jobs = {job.provider: job for job in self.store.list() if job.enabled}
+        jobs = {job.account_id: job for job in self.store.list() if job.enabled}
         wanted = set(jobs) if not self._stopping else set()
-        for provider in list(self._schedulers):
-            interval = jobs.get(provider).interval if provider in jobs else None
-            if provider not in wanted or self._scheduler_intervals.get(provider) != interval:
-                self._schedulers.pop(provider).cancel()
-                self._scheduler_intervals.pop(provider, None)
-                self._next_run.pop(provider, None)
-        for provider in wanted:
-            if provider not in self._schedulers:
-                job = jobs[provider]
-                self._set_next_run(provider, job.interval)
-                self._scheduler_intervals[provider] = job.interval
-                self._schedulers[provider] = asyncio.create_task(
-                    self._scheduler(provider)
+        for account_id in list(self._schedulers):
+            interval = jobs.get(account_id).interval if account_id in jobs else None
+            if account_id not in wanted or self._scheduler_intervals.get(account_id) != interval:
+                self._schedulers.pop(account_id).cancel()
+                self._scheduler_intervals.pop(account_id, None)
+                self._next_run.pop(account_id, None)
+        for account_id in wanted:
+            if account_id not in self._schedulers:
+                job = jobs[account_id]
+                self._set_next_run(account_id, job.interval)
+                self._scheduler_intervals[account_id] = job.interval
+                self._schedulers[account_id] = asyncio.create_task(
+                    self._scheduler(account_id)
                 )
 
-    def _set_next_run(self, provider, interval):
+    def _set_next_run(self, account_id, interval):
         now = time.time()
         seconds = parse_interval(interval)
-        self._next_run[provider] = now + (seconds - (now % seconds))
+        self._next_run[account_id] = now + (seconds - (now % seconds))
 
-    async def _scheduler(self, provider):
+    async def _scheduler(self, account_id):
         own_task = asyncio.current_task()
         try:
             while not self._stopping:
-                job = self.store.get(provider)
+                job = self.store.get(account_id)
                 if job is None or not job.enabled:
                     break
-                due = self._next_run.get(provider)
+                due = self._next_run.get(account_id)
                 if due is None:
-                    self._set_next_run(provider, job.interval)
-                    due = self._next_run[provider]
+                    self._set_next_run(account_id, job.interval)
+                    due = self._next_run[account_id]
                 await asyncio.sleep(max(0, due - time.time()))
                 if self._stopping:
                     break
-                self.queue(provider)
-                current = self.store.get(provider)
+                self.queue(account_id)
+                current = self.store.get(account_id)
                 if current is None or not current.enabled:
                     break
-                self._set_next_run(provider, current.interval)
+                self._set_next_run(account_id, current.interval)
         except asyncio.CancelledError:
             pass
         finally:
             # A changed interval replaces this task before its cancellation is
             # delivered. Do not let the retired task clear the replacement's
             # freshly computed next-run time.
-            if self._schedulers.get(provider) is own_task:
-                self._schedulers.pop(provider, None)
-                self._scheduler_intervals.pop(provider, None)
-                self._next_run.pop(provider, None)
+            if self._schedulers.get(account_id) is own_task:
+                self._schedulers.pop(account_id, None)
+                self._scheduler_intervals.pop(account_id, None)
+                self._next_run.pop(account_id, None)
 
-    def queue(self, provider):
-        provider = self._account(provider)
+    def queue(self, account_id):
+        account_id = self._account(account_id)
         if self._stopping:
             return False
-        current = self._runs.get(provider)
+        current = self._runs.get(account_id)
         if current is not None and not current.done():
             return False
-        if self.store.get(provider) is None:
+        if self.store.get(account_id) is None:
             return False
-        task = asyncio.create_task(self._execute(provider))
-        self._runs[provider] = task
+        task = asyncio.create_task(self._execute(account_id))
+        self._runs[account_id] = task
 
         def finished(done):
-            if self._runs.get(provider) is done:
-                self._runs.pop(provider, None)
+            if self._runs.get(account_id) is done:
+                self._runs.pop(account_id, None)
             try:
                 unexpected = done.exception()
             except asyncio.CancelledError:
@@ -467,36 +491,36 @@ class PlaylistBackupService:
             if unexpected is not None:
                 self._emit(
                     "warn",
-                    f"{self._label(provider)}: playlist backup task stopped unexpectedly",
-                    provider,
+                    f"{self._label(account_id)}: playlist backup task stopped unexpectedly",
+                    account_id,
                 )
 
         task.add_done_callback(finished)
         return True
 
-    async def run(self, provider):
-        provider = self._account(provider)
-        if not self.queue(provider):
+    async def run(self, account_id):
+        account_id = self._account(account_id)
+        if not self.queue(account_id):
             return False
-        await self._runs[provider]
+        await self._runs[account_id]
         return True
 
-    async def _execute(self, provider):
-        job = self.store.get(provider)
+    async def _execute(self, account_id):
+        job = self.store.get(account_id)
         if job is None:
             return
-        label = self._label(provider)
-        self._emit("section", f"{label}: playlist backup started", provider)
+        label = self._label(account_id)
+        self._emit("section", f"{label}: playlist backup started", account_id)
         try:
             export = await self._sync.run_exclusive(
                 lambda: PlaylistService(self._settings, self._profiles).export(
-                    provider,
+                    account_id,
                     job.format,
                 )
             )
             destination, removed = await asyncio.to_thread(
                 self.store.write_snapshot,
-                provider,
+                account_id,
                 export,
                 job.retention,
             )
@@ -508,11 +532,11 @@ class PlaylistBackupService:
                 "track_count": export.track_count,
                 "pruned": removed,
             }
-            self.store.record_success(provider, success)
+            self.store.record_success(account_id, success)
             self._emit(
                 "summary",
                 f"{label}: playlist backup saved ({destination.name})",
-                provider,
+                account_id,
                 success,
             )
         except asyncio.CancelledError:
@@ -522,26 +546,29 @@ class PlaylistBackupService:
                 "at": _utc_timestamp(),
                 "error": str(exc).strip()[:500] or type(exc).__name__,
             }
-            self.store.record_failure(provider, failure)
+            self.store.record_failure(account_id, failure)
             self._emit(
                 "warn",
                 f"{label}: playlist backup failed: {failure['error']}",
-                provider,
+                account_id,
             )
 
     def list_status(self):
         return [self.job_status(job) for job in self.store.list()]
 
     def job_status(self, job):
-        history = self.store.status(job.provider)
+        account_id = job.account_id
+        provider = self._provider(account_id)
+        history = self.store.status(account_id)
         return {
             **asdict(job),
-            "provider_type": self._provider(job.provider),
-            "provider_name": self._label(job.provider),
-            "running": job.provider in self._runs,
-            "next_run_at": self._next_run.get(job.provider) if job.enabled else None,
-            "snapshot_count": len(self.store.snapshots(job.provider)),
-            "storage_path": str(self.store.provider_dir(job.provider).resolve()),
+            "provider": provider,
+            "provider_name": provider_label(provider) or str(provider or account_id),
+            "account_name": self._label(account_id),
+            "running": account_id in self._runs,
+            "next_run_at": self._next_run.get(account_id) if job.enabled else None,
+            "snapshot_count": len(self.store.snapshots(account_id)),
+            "storage_path": str(self.store.account_dir(account_id).resolve()),
             "last_success": history.get("last_success"),
             "last_failure": history.get("last_failure"),
         }

--- a/songmirror/services/playlist_exports.py
+++ b/songmirror/services/playlist_exports.py
@@ -52,6 +52,8 @@ class PlaylistExport:
     content: bytes
     media_type: str
     filename: str
+    playlist_count: int = 0
+    track_count: int = 0
 
 
 def _utc_timestamp(now=None):
@@ -246,4 +248,10 @@ def render_backup(
     timestamp = re.sub(r"[-:]", "", backup["exported_at"])
     suffix = "soundiiz.json" if export_format == "soundiiz" else export_format
     filename = f"songmirror-{provider_part}-{scope_part}-{timestamp}.{suffix}"
-    return PlaylistExport(content=content, media_type=media_type, filename=filename)
+    return PlaylistExport(
+        content=content,
+        media_type=media_type,
+        filename=filename,
+        playlist_count=backup["playlist_count"],
+        track_count=backup["track_count"],
+    )

--- a/songmirror/web/__init__.py
+++ b/songmirror/web/__init__.py
@@ -15,8 +15,9 @@ from fastapi import FastAPI
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from ..services.events import EventBus
 from ..services.account_profiles import AccountProfileStore
+from ..services.events import EventBus
+from ..services.playlist_backups import PlaylistBackupService, PlaylistBackupStore
 from ..services.playlists import LinkStore
 from ..services.resolve_cache import ResolveCacheStore
 from ..services.settings import SettingsStore
@@ -25,8 +26,9 @@ from ..services.syncs import SyncStore
 from ..services.transfers import TransferService
 from .access_log import install_oauth_access_log_filter
 from .routers import (
-    accounts, events, playlists, resolve_cache as resolve_cache_router,
-    settings as settings_router, sync, syncs as syncs_router,
+    accounts, events, playlist_backups as playlist_backups_router, playlists,
+    resolve_cache as resolve_cache_router, settings as settings_router, sync,
+    syncs as syncs_router,
     transfers as transfers_router,
 )
 
@@ -36,7 +38,8 @@ _DIST = Path(__file__).resolve().parents[2] / "frontend" / "dist"
 
 
 def create_app(settings=None, bus=None, sync_service=None, links=None, transfers=None,
-               syncs=None, resolve_cache=None, account_profiles=None) -> FastAPI:
+               syncs=None, resolve_cache=None, account_profiles=None,
+               playlist_backups=None) -> FastAPI:
     install_oauth_access_log_filter()
     settings = settings or SettingsStore()
     bus = bus or EventBus()
@@ -47,6 +50,13 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
     transfers = transfers or TransferService(settings, bus, sync_service, profiles=account_profiles)
     resolve_cache = resolve_cache or ResolveCacheStore(
         settings, sync_service, profiles=account_profiles
+    )
+    playlist_backups = playlist_backups or PlaylistBackupService(
+        settings,
+        sync_service,
+        bus,
+        PlaylistBackupStore(settings.data_dir, profiles=account_profiles),
+        profiles=account_profiles,
     )
 
     @asynccontextmanager
@@ -60,9 +70,11 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
         os.environ["SONGMIRROR_ENV_FILE"] = settings.env_path
         settings.apply_to_env()
         await sync_service.start()
+        await playlist_backups.start()
         try:
             yield
         finally:
+            await playlist_backups.shutdown()
             await sync_service.shutdown()
 
     app = FastAPI(title="SongMirror", lifespan=lifespan)
@@ -74,6 +86,7 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
     app.state.links = links
     app.state.transfers = transfers
     app.state.resolve_cache = resolve_cache
+    app.state.playlist_backups = playlist_backups
 
     app.include_router(accounts.router)
     app.include_router(settings_router.router)
@@ -81,6 +94,7 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
     app.include_router(syncs_router.router)
     app.include_router(events.router)
     app.include_router(playlists.router)
+    app.include_router(playlist_backups_router.router)
     app.include_router(transfers_router.router)
     app.include_router(resolve_cache_router.router)
 

--- a/songmirror/web/routers/playlist_backups.py
+++ b/songmirror/web/routers/playlist_backups.py
@@ -14,9 +14,9 @@ router = APIRouter()
 _FIELDS = {"enabled", "interval", "format", "retention"}
 
 
-def _known_provider(provider, profiles=None):
-    account_id = str(provider).strip().casefold()
-    provider_id = account_id
+def _known_account(account_id, profiles=None):
+    account_id = str(account_id).strip().casefold()
+    provider = account_id
     if profiles is not None:
         profile = profiles.resolve(account_id)
         if profile is None:
@@ -25,8 +25,8 @@ def _known_provider(provider, profiles=None):
                 detail="account must be a supported playlist service",
             )
         account_id = profile.id
-        provider_id = profile.provider
-    if provider_id not in CONNECTORS or not is_peer(provider_id):
+        provider = profile.provider
+    if provider not in CONNECTORS or not is_peer(provider):
         raise HTTPException(
             status_code=422,
             detail="account must be a supported playlist service",
@@ -34,8 +34,8 @@ def _known_provider(provider, profiles=None):
     return account_id
 
 
-def _job_from(provider, values, existing=None, profiles=None):
-    provider = _known_provider(provider, profiles)
+def _job_from(account_id, values, existing=None, profiles=None):
+    account_id = _known_account(account_id, profiles)
     if not isinstance(values, dict):
         raise HTTPException(status_code=422, detail="request body must be an object")
     unknown = set(values) - _FIELDS
@@ -44,9 +44,9 @@ def _job_from(provider, values, existing=None, profiles=None):
             status_code=422,
             detail=f"unknown field: {sorted(unknown)[0]}",
         )
-    data = asdict(existing) if existing is not None else {"provider": provider}
+    data = asdict(existing) if existing is not None else {"account_id": account_id}
     data.update(values)
-    data["provider"] = provider
+    data["account_id"] = account_id
     retention = data.get("retention")
     if retention is not None and type(retention) is not int:
         raise HTTPException(status_code=422, detail="retention must be a whole number")
@@ -61,20 +61,20 @@ def list_playlist_backups(request: Request):
     return request.app.state.playlist_backups.list_status()
 
 
-@router.put("/api/playlist-backups/{provider}")
+@router.put("/api/playlist-backups/{account_id}")
 async def put_playlist_backup(
-    provider: str,
+    account_id: str,
     request: Request,
     values: dict = Body(...),
 ):
     service = request.app.state.playlist_backups
     profiles = request.app.state.account_profiles
-    provider = _known_provider(provider, profiles)
+    account_id = _known_account(account_id, profiles)
     job = service.store.upsert(
         _job_from(
-            provider,
+            account_id,
             values,
-            existing=service.store.get(provider),
+            existing=service.store.get(account_id),
             profiles=profiles,
         )
     )
@@ -82,34 +82,34 @@ async def put_playlist_backup(
     return service.job_status(job)
 
 
-@router.delete("/api/playlist-backups/{provider}")
-async def delete_playlist_backup(provider: str, request: Request):
+@router.delete("/api/playlist-backups/{account_id}")
+async def delete_playlist_backup(account_id: str, request: Request):
     service = request.app.state.playlist_backups
-    provider = _known_provider(provider, request.app.state.account_profiles)
-    if service.store.get(provider) is None:
+    account_id = _known_account(account_id, request.app.state.account_profiles)
+    if service.store.get(account_id) is None:
         raise HTTPException(status_code=404, detail="backup schedule not found")
-    service.store.delete(provider)
+    service.store.delete(account_id)
     await service.reconcile()
     return {"ok": True}
 
 
-@router.post("/api/playlist-backups/{provider}/run")
-async def run_playlist_backup(provider: str, request: Request):
+@router.post("/api/playlist-backups/{account_id}/run")
+async def run_playlist_backup(account_id: str, request: Request):
     service = request.app.state.playlist_backups
-    provider = _known_provider(provider, request.app.state.account_profiles)
-    if service.store.get(provider) is None:
+    account_id = _known_account(account_id, request.app.state.account_profiles)
+    if service.store.get(account_id) is None:
         raise HTTPException(status_code=404, detail="backup schedule not found")
-    queued = service.queue(provider)
+    queued = service.queue(account_id)
     return JSONResponse({"queued": queued}, status_code=202)
 
 
-@router.get("/api/playlist-backups/{provider}/latest")
-def latest_playlist_backup(provider: str, request: Request):
+@router.get("/api/playlist-backups/{account_id}/latest")
+def latest_playlist_backup(account_id: str, request: Request):
     service = request.app.state.playlist_backups
-    provider = _known_provider(provider, request.app.state.account_profiles)
-    if service.store.get(provider) is None:
+    account_id = _known_account(account_id, request.app.state.account_profiles)
+    if service.store.get(account_id) is None:
         raise HTTPException(status_code=404, detail="backup schedule not found")
-    snapshot = service.store.latest_snapshot(provider)
+    snapshot = service.store.latest_snapshot(account_id)
     if snapshot is None:
         raise HTTPException(status_code=404, detail="no playlist backup exists yet")
     media_type = "application/xml" if snapshot.suffix == ".xml" else "application/json"

--- a/songmirror/web/routers/playlist_backups.py
+++ b/songmirror/web/routers/playlist_backups.py
@@ -1,0 +1,124 @@
+"""CRUD, run-now, status, and latest-file access for playlist backups."""
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Body, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+
+from ...engine.targets import is_peer
+from ...services.accounts import CONNECTORS
+from ...services.playlist_backups import PlaylistBackupJob, validate_backup_job
+
+
+router = APIRouter()
+_FIELDS = {"enabled", "interval", "format", "retention"}
+
+
+def _known_provider(provider, profiles=None):
+    account_id = str(provider).strip().casefold()
+    provider_id = account_id
+    if profiles is not None:
+        profile = profiles.resolve(account_id)
+        if profile is None:
+            raise HTTPException(
+                status_code=422,
+                detail="account must be a supported playlist service",
+            )
+        account_id = profile.id
+        provider_id = profile.provider
+    if provider_id not in CONNECTORS or not is_peer(provider_id):
+        raise HTTPException(
+            status_code=422,
+            detail="account must be a supported playlist service",
+        )
+    return account_id
+
+
+def _job_from(provider, values, existing=None, profiles=None):
+    provider = _known_provider(provider, profiles)
+    if not isinstance(values, dict):
+        raise HTTPException(status_code=422, detail="request body must be an object")
+    unknown = set(values) - _FIELDS
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f"unknown field: {sorted(unknown)[0]}",
+        )
+    data = asdict(existing) if existing is not None else {"provider": provider}
+    data.update(values)
+    data["provider"] = provider
+    retention = data.get("retention")
+    if retention is not None and type(retention) is not int:
+        raise HTTPException(status_code=422, detail="retention must be a whole number")
+    try:
+        return validate_backup_job(PlaylistBackupJob(**data))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/api/playlist-backups")
+def list_playlist_backups(request: Request):
+    return request.app.state.playlist_backups.list_status()
+
+
+@router.put("/api/playlist-backups/{provider}")
+async def put_playlist_backup(
+    provider: str,
+    request: Request,
+    values: dict = Body(...),
+):
+    service = request.app.state.playlist_backups
+    profiles = request.app.state.account_profiles
+    provider = _known_provider(provider, profiles)
+    job = service.store.upsert(
+        _job_from(
+            provider,
+            values,
+            existing=service.store.get(provider),
+            profiles=profiles,
+        )
+    )
+    await service.reconcile()
+    return service.job_status(job)
+
+
+@router.delete("/api/playlist-backups/{provider}")
+async def delete_playlist_backup(provider: str, request: Request):
+    service = request.app.state.playlist_backups
+    provider = _known_provider(provider, request.app.state.account_profiles)
+    if service.store.get(provider) is None:
+        raise HTTPException(status_code=404, detail="backup schedule not found")
+    service.store.delete(provider)
+    await service.reconcile()
+    return {"ok": True}
+
+
+@router.post("/api/playlist-backups/{provider}/run")
+async def run_playlist_backup(provider: str, request: Request):
+    service = request.app.state.playlist_backups
+    provider = _known_provider(provider, request.app.state.account_profiles)
+    if service.store.get(provider) is None:
+        raise HTTPException(status_code=404, detail="backup schedule not found")
+    queued = service.queue(provider)
+    return JSONResponse({"queued": queued}, status_code=202)
+
+
+@router.get("/api/playlist-backups/{provider}/latest")
+def latest_playlist_backup(provider: str, request: Request):
+    service = request.app.state.playlist_backups
+    provider = _known_provider(provider, request.app.state.account_profiles)
+    if service.store.get(provider) is None:
+        raise HTTPException(status_code=404, detail="backup schedule not found")
+    snapshot = service.store.latest_snapshot(provider)
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="no playlist backup exists yet")
+    media_type = "application/xml" if snapshot.suffix == ".xml" else "application/json"
+    return FileResponse(
+        snapshot,
+        media_type=media_type,
+        filename=snapshot.name,
+        headers={
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/tests/test_playlist_backups.py
+++ b/tests/test_playlist_backups.py
@@ -52,7 +52,7 @@ def _export(day, *, playlist_count=2, track_count=3):
     ],
 )
 def test_backup_job_validation_rejects_unsafe_schedules(changes, message):
-    job = PlaylistBackupJob(provider="spotify")
+    job = PlaylistBackupJob(account_id="spotify")
     for key, value in changes.items():
         setattr(job, key, value)
 
@@ -73,8 +73,8 @@ def test_backup_run_persists_status_and_prunes_only_managed_snapshots(
         lambda self, provider, format: next(exports),
     )
     store = PlaylistBackupStore(tmp_path)
-    store.upsert(PlaylistBackupJob(provider="spotify", retention=2))
-    unmanaged = store.provider_dir("spotify") / "read-me.txt"
+    store.upsert(PlaylistBackupJob(account_id="spotify", retention=2))
+    unmanaged = store.account_dir("spotify") / "read-me.txt"
     unmanaged.parent.mkdir(parents=True)
     unmanaged.write_text("keep me", encoding="utf-8")
     sync = _ExclusiveSync()
@@ -125,7 +125,7 @@ def test_backup_failure_is_persisted_without_erasing_last_success(tmp_path, monk
 
     monkeypatch.setattr(module.PlaylistService, "export", export)
     store = PlaylistBackupStore(tmp_path)
-    store.upsert(PlaylistBackupJob(provider="spotify"))
+    store.upsert(PlaylistBackupJob(account_id="spotify"))
     service = PlaylistBackupService(
         SettingsStore(dir=tmp_path),
         _ExclusiveSync(),
@@ -147,8 +147,8 @@ def test_backup_failure_is_persisted_without_erasing_last_success(tmp_path, monk
 
 def test_backup_scheduler_status_survives_restart_and_respects_enabled(tmp_path):
     store = PlaylistBackupStore(tmp_path)
-    store.upsert(PlaylistBackupJob(provider="spotify", interval="12h"))
-    store.upsert(PlaylistBackupJob(provider="apple", enabled=False))
+    store.upsert(PlaylistBackupJob(account_id="spotify", interval="12h"))
+    store.upsert(PlaylistBackupJob(account_id="apple", enabled=False))
     store.record_success("spotify", {
         "at": "2026-09-04T12:00:00Z",
         "filename": _export(1).filename,
@@ -166,7 +166,7 @@ def test_backup_scheduler_status_survives_restart_and_respects_enabled(tmp_path)
 
     async def scenario():
         await service.start()
-        statuses = {row["provider"]: row for row in service.list_status()}
+        statuses = {row["account_id"]: row for row in service.list_status()}
         assert statuses["spotify"]["next_run_at"] is not None
         assert statuses["spotify"]["last_success"]["filename"] == _export(1).filename
         assert statuses["apple"]["next_run_at"] is None
@@ -179,7 +179,7 @@ def test_scheduler_boundary_queues_an_automatic_backup(tmp_path, monkeypatch):
     import songmirror.services.playlist_backups as module
 
     store = PlaylistBackupStore(tmp_path)
-    store.upsert(PlaylistBackupJob(provider="spotify", interval="1m"))
+    store.upsert(PlaylistBackupJob(account_id="spotify", interval="1m"))
     service = PlaylistBackupService(
         SettingsStore(dir=tmp_path),
         _ExclusiveSync(),
@@ -218,7 +218,7 @@ def test_backup_run_and_storage_are_scoped_to_the_selected_profile(tmp_path, mon
 
     monkeypatch.setattr(module.PlaylistService, "export", export)
     store = PlaylistBackupStore(tmp_path, profiles=profiles)
-    store.upsert(PlaylistBackupJob(provider=alex.id))
+    store.upsert(PlaylistBackupJob(account_id=alex.id))
     service = PlaylistBackupService(
         settings,
         _ExclusiveSync(),
@@ -231,11 +231,78 @@ def test_backup_run_and_storage_are_scoped_to_the_selected_profile(tmp_path, mon
 
     status = service.list_status()[0]
     assert seen == [(alex.id, "json")]
-    assert status["provider"] == alex.id
-    assert status["provider_type"] == "spotify"
-    assert status["provider_name"] == "Spotify · Alex"
+    assert status["account_id"] == alex.id
+    assert status["provider"] == "spotify"
+    assert status["provider_name"] == "Spotify"
+    assert status["account_name"] == "Spotify · Alex"
     assert Path(status["storage_path"]).name == alex.id
     assert store.latest_snapshot(alex.id).is_file()
+
+
+def test_legacy_provider_schedule_and_history_migrate_to_default_account(tmp_path):
+    settings = SettingsStore(dir=tmp_path)
+    profiles = AccountProfileStore(settings)
+    default_spotify = profiles.default_id("spotify")
+    success = {
+        "at": "2026-09-04T12:00:00Z",
+        "filename": _export(1).filename,
+        "format": "json",
+        "playlist_count": 2,
+        "track_count": 3,
+        "pruned": 0,
+    }
+    (tmp_path / "playlist_backups.json").write_text(
+        json.dumps([{"provider": "spotify", "interval": "12h"}]),
+        encoding="utf-8",
+    )
+    (tmp_path / "playlist_backup_status.json").write_text(
+        json.dumps({"spotify": {"last_success": success}}),
+        encoding="utf-8",
+    )
+
+    store = PlaylistBackupStore(tmp_path, profiles=profiles)
+
+    assert store.list() == [
+        PlaylistBackupJob(account_id=default_spotify, interval="12h")
+    ]
+    assert store.status(default_spotify)["last_success"] == success
+    persisted_jobs = json.loads((tmp_path / "playlist_backups.json").read_text())
+    persisted_status = json.loads(
+        (tmp_path / "playlist_backup_status.json").read_text()
+    )
+    assert persisted_jobs[0]["account_id"] == default_spotify
+    assert "provider" not in persisted_jobs[0]
+    assert set(persisted_status) == {default_spotify}
+
+
+def test_playlist_backup_api_keeps_same_provider_profiles_separate(tmp_path):
+    app = create_app(settings=SettingsStore(dir=tmp_path))
+    profiles = app.state.account_profiles
+    default_spotify = profiles.default_id("spotify")
+    alex = profiles.create("spotify", "Alex")
+
+    with TestClient(app) as client:
+        for account_id in (default_spotify, alex.id):
+            response = client.put(
+                f"/api/playlist-backups/{account_id}",
+                json={"enabled": False, "interval": "24h", "format": "json"},
+            )
+            assert response.status_code == 200
+
+        schedules = client.get("/api/playlist-backups").json()
+
+    assert {schedule["account_id"] for schedule in schedules} == {
+        default_spotify,
+        alex.id,
+    }
+    assert {schedule["provider"] for schedule in schedules} == {"spotify"}
+    assert {schedule["account_name"] for schedule in schedules} == {
+        "Spotify",
+        "Spotify · Alex",
+    }
+    assert {
+        Path(schedule["storage_path"]).name for schedule in schedules
+    } == {default_spotify, alex.id}
 
 
 def test_playlist_backup_api_configures_runs_and_downloads_latest(
@@ -259,9 +326,10 @@ def test_playlist_backup_api_configures_runs_and_downloads_latest(
         )
         assert response.status_code == 200
         configured = response.json()
-        assert configured["provider"] == spotify_account
-        assert configured["provider_type"] == "spotify"
+        assert configured["account_id"] == spotify_account
+        assert configured["provider"] == "spotify"
         assert configured["provider_name"] == "Spotify"
+        assert configured["account_name"] == "Spotify"
         assert configured["next_run_at"] is not None
         assert configured["snapshot_count"] == 0
         assert configured["last_success"] is None

--- a/tests/test_playlist_backups.py
+++ b/tests/test_playlist_backups.py
@@ -1,0 +1,304 @@
+"""Persistent playlist-backup schedules, retention, status, and API access."""
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from songmirror.services.account_profiles import AccountProfileStore
+from songmirror.services.events import EventBus
+from songmirror.services.playlist_backups import (
+    PlaylistBackupJob,
+    PlaylistBackupService,
+    PlaylistBackupStore,
+    validate_backup_job,
+)
+from songmirror.services.playlist_exports import PlaylistExport
+from songmirror.services.settings import SettingsStore
+from songmirror.web import create_app
+
+
+class _ExclusiveSync:
+    def __init__(self):
+        self.calls = 0
+
+    async def run_exclusive(self, callback):
+        self.calls += 1
+        return callback()
+
+
+def _export(day, *, playlist_count=2, track_count=3):
+    filename = f"songmirror-spotify-all-playlists-202609{day:02d}T120000Z.json"
+    return PlaylistExport(
+        content=(json.dumps({"day": day}) + "\n").encode(),
+        media_type="application/json",
+        filename=filename,
+        playlist_count=playlist_count,
+        track_count=track_count,
+    )
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"interval": "0s"}, "between 1 minute and 365 days"),
+        ({"interval": "tomorrow"}, "must look like"),
+        ({"format": "csv"}, "json or xml"),
+        ({"retention": -1}, "between 0 and 10000"),
+        ({"retention": True}, "whole number"),
+    ],
+)
+def test_backup_job_validation_rejects_unsafe_schedules(changes, message):
+    job = PlaylistBackupJob(provider="spotify")
+    for key, value in changes.items():
+        setattr(job, key, value)
+
+    with pytest.raises(ValueError, match=message):
+        validate_backup_job(job)
+
+
+def test_backup_run_persists_status_and_prunes_only_managed_snapshots(
+    tmp_path,
+    monkeypatch,
+):
+    import songmirror.services.playlist_backups as module
+
+    exports = iter([_export(1), _export(2), _export(3)])
+    monkeypatch.setattr(
+        module.PlaylistService,
+        "export",
+        lambda self, provider, format: next(exports),
+    )
+    store = PlaylistBackupStore(tmp_path)
+    store.upsert(PlaylistBackupJob(provider="spotify", retention=2))
+    unmanaged = store.provider_dir("spotify") / "read-me.txt"
+    unmanaged.parent.mkdir(parents=True)
+    unmanaged.write_text("keep me", encoding="utf-8")
+    sync = _ExclusiveSync()
+    service = PlaylistBackupService(
+        SettingsStore(dir=tmp_path),
+        sync,
+        EventBus(),
+        store,
+    )
+
+    async def scenario():
+        await service.run("spotify")
+        await service.run("spotify")
+        await service.run("spotify")
+
+    asyncio.run(scenario())
+
+    snapshots = store.snapshots("spotify")
+    assert [path.name for path in snapshots] == [
+        _export(3).filename,
+        _export(2).filename,
+    ]
+    assert unmanaged.read_text(encoding="utf-8") == "keep me"
+    assert sync.calls == 3
+    status = PlaylistBackupStore(tmp_path).status("spotify")
+    assert status["last_success"] == {
+        "at": status["last_success"]["at"],
+        "filename": _export(3).filename,
+        "format": "json",
+        "playlist_count": 2,
+        "track_count": 3,
+        "pruned": 1,
+    }
+    assert (tmp_path / "playlist_backups.json").is_file()
+    assert (tmp_path / "playlist_backup_status.json").is_file()
+
+
+def test_backup_failure_is_persisted_without_erasing_last_success(tmp_path, monkeypatch):
+    import songmirror.services.playlist_backups as module
+
+    outcomes = iter([_export(1), RuntimeError("provider unavailable")])
+
+    def export(self, provider, format):
+        outcome = next(outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(module.PlaylistService, "export", export)
+    store = PlaylistBackupStore(tmp_path)
+    store.upsert(PlaylistBackupJob(provider="spotify"))
+    service = PlaylistBackupService(
+        SettingsStore(dir=tmp_path),
+        _ExclusiveSync(),
+        EventBus(),
+        store,
+    )
+
+    async def scenario():
+        assert await service.run("spotify") is True
+        assert await service.run("spotify") is True
+
+    asyncio.run(scenario())
+
+    status = store.status("spotify")
+    assert status["last_success"]["filename"] == _export(1).filename
+    assert status["last_failure"]["error"] == "provider unavailable"
+    assert status["last_failure"]["at"] >= status["last_success"]["at"]
+
+
+def test_backup_scheduler_status_survives_restart_and_respects_enabled(tmp_path):
+    store = PlaylistBackupStore(tmp_path)
+    store.upsert(PlaylistBackupJob(provider="spotify", interval="12h"))
+    store.upsert(PlaylistBackupJob(provider="apple", enabled=False))
+    store.record_success("spotify", {
+        "at": "2026-09-04T12:00:00Z",
+        "filename": _export(1).filename,
+        "format": "json",
+        "playlist_count": 2,
+        "track_count": 3,
+        "pruned": 0,
+    })
+    service = PlaylistBackupService(
+        SettingsStore(dir=tmp_path),
+        _ExclusiveSync(),
+        EventBus(),
+        PlaylistBackupStore(tmp_path),
+    )
+
+    async def scenario():
+        await service.start()
+        statuses = {row["provider"]: row for row in service.list_status()}
+        assert statuses["spotify"]["next_run_at"] is not None
+        assert statuses["spotify"]["last_success"]["filename"] == _export(1).filename
+        assert statuses["apple"]["next_run_at"] is None
+        await service.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_scheduler_boundary_queues_an_automatic_backup(tmp_path, monkeypatch):
+    import songmirror.services.playlist_backups as module
+
+    store = PlaylistBackupStore(tmp_path)
+    store.upsert(PlaylistBackupJob(provider="spotify", interval="1m"))
+    service = PlaylistBackupService(
+        SettingsStore(dir=tmp_path),
+        _ExclusiveSync(),
+        EventBus(),
+        store,
+    )
+    queued = []
+
+    async def no_wait(delay):
+        assert delay >= 0
+
+    def queue(provider):
+        queued.append(provider)
+        service._stopping = True
+        return True
+
+    monkeypatch.setattr(module.asyncio, "sleep", no_wait)
+    monkeypatch.setattr(service, "queue", queue)
+
+    asyncio.run(service._scheduler("spotify"))
+
+    assert queued == ["spotify"]
+
+
+def test_backup_run_and_storage_are_scoped_to_the_selected_profile(tmp_path, monkeypatch):
+    import songmirror.services.playlist_backups as module
+
+    settings = SettingsStore(dir=tmp_path)
+    profiles = AccountProfileStore(settings)
+    alex = profiles.create("spotify", "Alex")
+    seen = []
+
+    def export(self, provider, format):
+        seen.append((provider, format))
+        return _export(5)
+
+    monkeypatch.setattr(module.PlaylistService, "export", export)
+    store = PlaylistBackupStore(tmp_path, profiles=profiles)
+    store.upsert(PlaylistBackupJob(provider=alex.id))
+    service = PlaylistBackupService(
+        settings,
+        _ExclusiveSync(),
+        EventBus(),
+        store,
+        profiles=profiles,
+    )
+
+    asyncio.run(service.run(alex.id))
+
+    status = service.list_status()[0]
+    assert seen == [(alex.id, "json")]
+    assert status["provider"] == alex.id
+    assert status["provider_type"] == "spotify"
+    assert status["provider_name"] == "Spotify · Alex"
+    assert Path(status["storage_path"]).name == alex.id
+    assert store.latest_snapshot(alex.id).is_file()
+
+
+def test_playlist_backup_api_configures_runs_and_downloads_latest(
+    tmp_path,
+    monkeypatch,
+):
+    import songmirror.services.playlist_backups as module
+
+    monkeypatch.setattr(
+        module.PlaylistService,
+        "export",
+        lambda self, provider, format: _export(4, playlist_count=4, track_count=99),
+    )
+    app = create_app(settings=SettingsStore(dir=tmp_path))
+    spotify_account = app.state.account_profiles.default_id("spotify")
+
+    with TestClient(app) as client:
+        response = client.put(
+            "/api/playlist-backups/spotify",
+            json={"enabled": True, "interval": "6h", "format": "json", "retention": 7},
+        )
+        assert response.status_code == 200
+        configured = response.json()
+        assert configured["provider"] == spotify_account
+        assert configured["provider_type"] == "spotify"
+        assert configured["provider_name"] == "Spotify"
+        assert configured["next_run_at"] is not None
+        assert configured["snapshot_count"] == 0
+        assert configured["last_success"] is None
+        assert Path(configured["storage_path"]).name == spotify_account
+
+        queued = client.post("/api/playlist-backups/spotify/run")
+        assert queued.status_code == 202
+        assert queued.json() == {"queued": True}
+        for _ in range(100):
+            status = client.get("/api/playlist-backups").json()[0]
+            if status["last_success"] is not None:
+                break
+            time.sleep(0.01)
+        assert status["last_success"]["playlist_count"] == 4
+        assert status["last_success"]["track_count"] == 99
+        assert status["snapshot_count"] == 1
+
+        latest = client.get("/api/playlist-backups/spotify/latest")
+        assert latest.status_code == 200
+        assert latest.content == _export(4, playlist_count=4, track_count=99).content
+        assert latest.headers["content-disposition"] == (
+            f'attachment; filename="{_export(4).filename}"'
+        )
+        assert latest.headers["cache-control"] == "no-store"
+
+        assert client.put(
+            "/api/playlist-backups/spotify",
+            json={"format": "csv"},
+        ).status_code == 422
+        assert client.put(
+            "/api/playlist-backups/jellyfin",
+            json={},
+        ).status_code == 422
+        assert client.delete("/api/playlist-backups/spotify").json() == {"ok": True}
+
+    # Deleting a schedule is intentionally non-destructive: archived metadata
+    # remains in the data volume for the operator's normal backup routine.
+    assert (
+        tmp_path / "playlist_backups" / spotify_account / _export(4).filename
+    ).is_file()


### PR DESCRIPTION
## Summary
- add independent per-provider playlist backup schedules that persist configuration, snapshots, retention, and run history under the application data directory
- serialize provider-wide JSON/XML exports with syncs and transfers, align automatic runs to wall-clock boundaries, and expose validated status/run/download APIs
- add Settings controls for connected providers, including interval, format, retention, next run, stored path/count, and last-success/last-failure details
- document the persistent archive layout and cover schedule, retention, failure, API, and responsive UI behavior

## Verification
- `uv run pytest -q` — 537 passed, 1 skipped
- `pnpm -C frontend lint` — passed
- `pnpm -C frontend build` — passed
- `CI=1 pnpm -C frontend test:e2e` — 131 checks, 0 with horizontal overflow
- `docker compose config --quiet` — passed

Closes #39