### PR TITLE
feat(apple): enable catalog-only playlist transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ No Apple Developer account needed — two headers from `music.apple.com` are eno
 
 The connect wizard lets you paste the raw headers and parses the values for you. Tokens last months; re-paste them on the Accounts page when they expire.
 
+An Apple ID without an active Apple Music subscription can still connect in **Catalog-only** mode. In that mode, paste a public Apple Music playlist link on Transfers to copy it into another connected service. Apple library browsing, scheduled syncing, and using Apple Music as a transfer destination still require the paid CloudLibrary privilege; SongMirror shows those operations as unavailable instead of treating the valid catalog credentials as expired.
+
 ### YouTube Music
 
 Talks to the **official [YouTube Data API v3](https://developers.google.com/youtube/v3)**, whose OAuth refresh token is durable and survives restarts.

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -3882,6 +3882,73 @@ async function main() {
     }
 
     // -----------------------------------------------------------------
+    // Catalog-only Apple credentials remain valid public-link sources, but
+    // never appear in CloudLibrary-backed source or destination controls.
+    // -----------------------------------------------------------------
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'light'))
+      const page = await context.newPage()
+      await installMocks(page)
+      const applePlaylistRequests = []
+      page.on('request', (request) => {
+        if (request.url().includes('/api/playlists?provider=apple')) applePlaylistRequests.push(request.url())
+      })
+      const fullCapabilities = {
+        library_read: true,
+        library_write: true,
+        public_playlist_read: true,
+      }
+      await page.route('**/api/accounts', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback()
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ACCOUNTS.map((account) => {
+            if (account.id === 'apple') {
+              return {
+                ...account,
+                detail: 'Catalog-only access. Public Apple Music playlist links can be transferred out; library browsing, syncing, and destination writes require an active Apple Music subscription.',
+                capabilities: {
+                  library_read: false,
+                  library_write: false,
+                  public_playlist_read: true,
+                },
+              }
+            }
+            if (account.id === 'deezer') {
+              return { ...account, state: 'connected', capabilities: fullCapabilities }
+            }
+            return account
+          })),
+        })
+      })
+
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/transfers', { waitUntil: 'networkidle' })
+      const sourceSelect = page.getByLabel('Service', { exact: true }).first()
+      const sourceOptions = await sourceSelect.locator('option').allTextContents()
+      await sourceSelect.selectOption('spotify')
+      const destinationOptions = await page.getByLabel('Service', { exact: true }).nth(1).locator('option').allTextContents()
+      const capabilityOptionsOk =
+        !sourceOptions.some((text) => /apple music/i.test(text)) &&
+        !destinationOptions.some((text) => /apple music/i.test(text)) &&
+        destinationOptions.some((text) => /deezer/i.test(text))
+      console.log(`${capabilityOptionsOk ? 'ok        ' : 'FAIL      '} catalog-only Apple is link-source only in Transfers`)
+      if (!capabilityOptionsOk) results.push({ label: 'catalog-only apple transfer capabilities', overflow: true })
+
+      const skippedLibraryOk = applePlaylistRequests.length === 0
+      console.log(`${skippedLibraryOk ? 'ok        ' : 'FAIL      '} catalog-only Apple skips CloudLibrary browse requests`)
+      if (!skippedLibraryOk) results.push({ label: 'catalog-only apple skips library browse', overflow: true })
+
+      await page.goto(BASE_URL + '/accounts', { waitUntil: 'networkidle' })
+      const catalogDetailVisible = await page.getByText(/Catalog-only access\. Public Apple Music playlist links/).isVisible()
+      console.log(`${catalogDetailVisible ? 'ok        ' : 'FAIL      '} Accounts explains Apple catalog-only access`)
+      if (!catalogDetailVisible) results.push({ label: 'catalog-only apple account detail', overflow: true })
+      await context.close()
+    }
+
+    // -----------------------------------------------------------------
     // Transfer pickers exclude browse-only (non-transferable) services:
     // Jellyfin is a connected account, but transferable:false, so it must
     // never appear as a source or destination option - previously it was

--- a/frontend/src/components/accounts/AccountCard.tsx
+++ b/frontend/src/components/accounts/AccountCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import { api, errorMessage } from '@/api'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
 import { cn } from '@/lib/cn'
 import { serviceLogoId, tagDot, tagText } from '@/lib/constants'
 import type { Account, AuthKind } from '@/types'
@@ -50,6 +51,8 @@ export function AccountCard({ account, onChanged }: { account: Account; onChange
   const [error, setError] = useState<string | null>(null)
 
   const isConnected = account.state === 'connected' || account.state === 'expired'
+  const capabilities = capabilitiesOf(account)
+  const catalogOnly = capabilities.public_playlist_read && !capabilities.library_read
   const logoId = serviceLogoId(account.provider)
 
   async function disconnect() {
@@ -125,6 +128,12 @@ export function AccountCard({ account, onChanged }: { account: Account; onChange
             Cancel
           </Button>
         </div>
+      )}
+
+      {catalogOnly && account.detail && (
+        <p className="rounded-control bg-info-soft px-3.5 py-2.5 text-[12.5px] leading-relaxed text-text-2">
+          {account.detail}
+        </p>
       )}
 
       {account.detail && account.state !== 'connected' && account.state !== 'error' && (

--- a/frontend/src/components/playlists/LinkEditorModal.tsx
+++ b/frontend/src/components/playlists/LinkEditorModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { api, errorMessage } from '@/api'
 import type { ProviderPlaylistsEntry } from '@/hooks/useProviderPlaylists'
+import { canSyncAccount } from '@/lib/accountCapabilities'
 import { serviceLogoId, tagText } from '@/lib/constants'
 import type { Account, LinkDirection, LinkMembers, PlaylistLink } from '@/types'
 
@@ -41,7 +42,7 @@ export function LinkEditorModal({ open, onClose, link, accounts, playlistEntries
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const connectedIds = useMemo(() => new Set(accounts.filter((a) => a.state === 'connected').map((a) => a.id)), [accounts])
+  const connectedIds = useMemo(() => new Set(accounts.filter(canSyncAccount).map((a) => a.id)), [accounts])
 
   // Fresh state whenever the editor (re)opens, so a previous attempt never
   // leaks into a new one. Rows cover every currently-connected service PLUS

--- a/frontend/src/components/playlists/ProviderPlaylistsCard.tsx
+++ b/frontend/src/components/playlists/ProviderPlaylistsCard.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom'
 import { LuExternalLink, LuListMusic } from 'react-icons/lu'
 
 import type { ProviderPlaylistsEntry } from '@/hooks/useProviderPlaylists'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
 import { cn } from '@/lib/cn'
 import { serviceHomeUrl, serviceLogoId, tagText } from '@/lib/constants'
 import { formatTrackCount } from '@/lib/format'
@@ -31,6 +32,7 @@ export function ProviderPlaylistsCard({
   onRetry: () => void
 }) {
   const connected = account.state === 'connected'
+  const libraryReadable = capabilitiesOf(account).library_read
   const logoId = serviceLogoId(account.provider)
   const homeUrl = serviceHomeUrl(account.provider)
 
@@ -83,6 +85,12 @@ export function ProviderPlaylistsCard({
               Connect
             </Link>
           }
+        />
+      ) : !libraryReadable ? (
+        <EmptyState
+          className="py-6"
+          title="Catalog access only"
+          description={account.detail || 'Paste a public playlist link on Transfers. Library browsing and writes are unavailable.'}
         />
       ) : !entry || (entry.loading && entry.playlists.length === 0) ? (
         <LoadingStatus label={`Loading ${account.name} playlists…`}>
@@ -141,7 +149,7 @@ export function ProviderPlaylistsCard({
         />
       )}
 
-      {connected && account.transferable && entry && entry.playlists.length > 0 ? (
+      {connected && libraryReadable && account.transferable && entry && entry.playlists.length > 0 ? (
         <div className="border-t border-border pt-3">
           <p className="font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-text-3">
             Local backup

--- a/frontend/src/components/settings/PlaylistFilterField.tsx
+++ b/frontend/src/components/settings/PlaylistFilterField.tsx
@@ -3,6 +3,7 @@ import { LuCheck, LuChevronDown, LuChevronUp, LuHeart, LuInfo, LuSearch, LuX } f
 
 import { useAccounts } from '@/hooks/useAccounts'
 import { useProviderPlaylists } from '@/hooks/useProviderPlaylists'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
 import { cn } from '@/lib/cn'
 import { formatTrackCount } from '@/lib/format'
 import { providerLikedTracksLabel } from '@/lib/likedTracks'
@@ -53,7 +54,12 @@ interface PickerSource {
  * playlist can legitimately exist on more than one service). */
 function usePickerSource(preferredProviderId?: string | null): PickerSource {
   const { accounts } = useAccounts()
-  const connected = useMemo(() => accounts?.filter((a: Account) => a.state === 'connected') ?? [], [accounts])
+  const connected = useMemo(
+    () => accounts?.filter((account: Account) => (
+      account.state === 'connected' && capabilitiesOf(account).library_read
+    )) ?? [],
+    [accounts],
+  )
   const connectedIds = useMemo(() => connected.map((a) => a.id), [connected])
   const { entries } = useProviderPlaylists(connectedIds)
   const pinned = preferredProviderId

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -12,6 +12,7 @@ import { TextField } from '@/components/ui/TextField'
 import { Toggle } from '@/components/ui/Toggle'
 import { Tooltip } from '@/components/ui/Tooltip'
 import { useSettings } from '@/hooks/useSettings'
+import { canSyncAccount } from '@/lib/accountCapabilities'
 import { cn } from '@/lib/cn'
 import { serviceLogoId, tagDot, tagText } from '@/lib/constants'
 import { isValidIntervalText, isValidPositiveInt } from '@/lib/format'
@@ -149,8 +150,9 @@ function ProviderChip({
   role?: 'source' | 'order' | 'authority' | 'mirror'
   onToggle: () => void
 }) {
+  const connected = canSyncAccount(account)
+  const unavailableLabel = account.state === 'connected' ? 'catalog only' : 'not connected'
   const logoId = serviceLogoId(account.provider)
-  const connected = account.state === 'connected'
 
   return (
     <button
@@ -160,7 +162,9 @@ function ProviderChip({
       aria-pressed={connected ? checked : undefined}
       title={
         !connected
-          ? `Connect ${account.name} on the Accounts page to include it in syncing.`
+          ? account.state === 'connected'
+            ? `${account.name} has catalog-only access and cannot participate in syncing.`
+            : `Connect ${account.name} on the Accounts page to include it in syncing.`
           : locked
             ? `${account.name} is ${role === 'order' ? 'the order authority' : role === 'authority' ? 'an authority' : 'the sync source'} and is always included.`
             : undefined
@@ -185,7 +189,7 @@ function ProviderChip({
           {role}
         </span>
       )}
-      {!connected && <span className="font-normal text-text-3">not connected</span>}
+      {!connected && <span className="font-normal text-text-3">{unavailableLabel}</span>}
     </button>
   )
 }
@@ -194,8 +198,9 @@ function ProviderChip({
  * source of truth" picker — same visual language as ProviderChip, but
  * exclusive-choice (radio) rather than a toggle set. */
 function SourceChip({ account, selected, onSelect }: { account: Account; selected: boolean; onSelect: () => void }) {
+  const connected = canSyncAccount(account)
+  const unavailableLabel = account.state === 'connected' ? 'catalog only' : 'not connected'
   const logoId = serviceLogoId(account.provider)
-  const connected = account.state === 'connected'
 
   return (
     <button
@@ -204,7 +209,13 @@ function SourceChip({ account, selected, onSelect }: { account: Account; selecte
       aria-checked={connected ? selected : undefined}
       onClick={connected ? onSelect : undefined}
       disabled={!connected}
-      title={!connected ? `Connect ${account.name} on the Accounts page to choose it as the source.` : undefined}
+      title={
+        !connected
+          ? account.state === 'connected'
+            ? `${account.name} has catalog-only access and cannot be a sync source.`
+            : `Connect ${account.name} on the Accounts page to choose it as the source.`
+          : undefined
+      }
       className={cn(
         'inline-flex h-9 items-center gap-2 rounded-chip border-[1.5px] px-3 text-[13px] font-semibold transition-colors duration-fast',
         !connected
@@ -220,7 +231,7 @@ function SourceChip({ account, selected, onSelect }: { account: Account; selecte
         <span className={cn('size-2 shrink-0 rounded-full', tagDot(account.provider))} aria-hidden="true" />
       )}
       {account.name}
-      {!connected && <span className="font-normal text-text-3">not connected</span>}
+      {!connected && <span className="font-normal text-text-3">{unavailableLabel}</span>}
     </button>
   )
 }
@@ -308,7 +319,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     if (!job) {
       // Snapshot the connected peers now. Persisting an empty sentinel would
       // make this job silently gain every provider connected in the future.
-      const connected = syncPeersOf(accounts).filter((account) => account.state === 'connected')
+      const connected = syncPeersOf(accounts).filter(canSyncAccount)
       initial.providers = connected.map((account) => account.id).join(',')
       initial.source = connected.find((account) => account.provider === 'spotify')?.id ?? connected[0]?.id ?? initial.source
     }
@@ -347,7 +358,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     form.mode !== 'nway' && sourceAccount?.provider !== 'spotify' && (form.download || jellyfinConnected)
 
   const enabledProviders = enabledProvidersOf({ providers: form.providers }, syncPeers)
-  const connectedPeerIds = new Set(syncPeers.filter((account) => account.state === 'connected').map((account) => account.id))
+  const connectedPeerIds = new Set(syncPeers.filter(canSyncAccount).map((account) => account.id))
 
   function csvInPeerOrder(ids: Set<string>) {
     return syncPeers.filter((account) => ids.has(account.id)).map((account) => account.id).join(',')
@@ -356,7 +367,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   function selectMode(mode: SyncMode) {
     setForm((prev) => {
       const next = { ...prev, mode }
-      const connected = syncPeers.filter((account) => account.state === 'connected').map((account) => account.id)
+      const connected = syncPeers.filter(canSyncAccount).map((account) => account.id)
       if (mode === 'group') {
         const spotifyAccount = syncPeers.find(
           (account) => account.state === 'connected' && account.provider === 'spotify',

--- a/frontend/src/components/transfers/TransferSetupForm.tsx
+++ b/frontend/src/components/transfers/TransferSetupForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { api, errorMessage } from '@/api'
 import type { ProviderPlaylistsEntry } from '@/hooks/useProviderPlaylists'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
 import { cn } from '@/lib/cn'
 import { serviceLogoId, tagText } from '@/lib/constants'
 import type { Account, StartTransferRequest, TransferSourcePreview } from '@/types'
@@ -61,11 +62,26 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
   // Only sync/transfer peers can be an endpoint — browse-only services like
   // Jellyfin (a local mirror the download step feeds) are filtered out.
   const transferable = useMemo(() => accounts.filter((a) => a.transferable), [accounts])
+  const librarySources = useMemo(
+    () => transferable.filter((account) => capabilitiesOf(account).library_read),
+    [transferable],
+  )
+  const publicSources = useMemo(
+    () => transferable.filter((account) => capabilitiesOf(account).public_playlist_read),
+    [transferable],
+  )
   // Same-provider transfers are allowed (e.g. copy a followed Spotify list into a
   // new owned Spotify playlist), so the destination service list isn't filtered.
-  const destProviderOptions = transferable
+  const destProviderOptions = useMemo(
+    () => transferable.filter((account) => capabilitiesOf(account).library_write),
+    [transferable],
+  )
   const sourceAccount = transferable.find((account) => account.id === sourceProvider)
   const destAccount = transferable.find((account) => account.id === destProvider)
+  const canConfigureTransfer =
+    transferable.length >= 2 &&
+    destProviderOptions.length > 0 &&
+    (librarySources.length > 0 || publicSources.length > 0)
 
   // Default "create new"'s name to the source playlist's name — re-derives
   // whenever the source playlist or the create-new choice changes, but a
@@ -185,10 +201,10 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
         </p>
       </div>
 
-      {transferable.length < 2 ? (
+      {!canConfigureTransfer ? (
         <p className="text-sm text-text-3">
-          Connect at least 2 transferable accounts on the Accounts page to copy a playlist between
-          them. Browse-only accounts like Jellyfin can't be a transfer endpoint.
+          Connect a readable source and a writable destination on the Accounts page to copy a playlist
+          between them. Catalog-only accounts can supply a public link, but cannot be destinations.
         </p>
       ) : (
         <>
@@ -221,7 +237,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                     <SelectField
                       label="Service"
                       icon={serviceIcon(sourceAccount)}
-                      options={[{ value: '', label: 'Choose a service…' }, ...transferable.map((a) => ({ value: a.id, label: a.name }))]}
+                      options={[{ value: '', label: 'Choose a service…' }, ...librarySources.map((a) => ({ value: a.id, label: a.name }))]}
                       value={sourceProvider}
                       onChange={(e) => {
                         setSourceProvider(e.target.value)
@@ -243,7 +259,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                       label="Open with account"
                       help="The link must belong to the selected account's service."
                       icon={serviceIcon(sourceAccount)}
-                      options={[{ value: '', label: 'Choose an account…' }, ...transferable.map((a) => ({ value: a.id, label: a.name }))]}
+                      options={[{ value: '', label: 'Choose an account…' }, ...publicSources.map((a) => ({ value: a.id, label: a.name }))]}
                       value={sourceProvider}
                       onChange={(e) => {
                         setSourceProvider(e.target.value)
@@ -254,7 +270,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                     />
                     <TextField
                       label="Playlist link"
-                      help="A public playlist URL from any connected service. It does not have to be saved in your library."
+                      help="A public playlist URL from a connected service with public-link access. It does not have to be saved in your library."
                       placeholder="https://open.spotify.com/playlist/…"
                       value={sourceLink}
                       onChange={(e) => clearLink(e.target.value)}

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -15,7 +15,17 @@ function isAccountArray(value: unknown): value is Account[] {
         typeof account.name === 'string' &&
         typeof account.state === 'string' &&
         Array.isArray(account.fields) &&
-        typeof account.transferable === 'boolean',
+        typeof account.transferable === 'boolean' &&
+        (!('capabilities' in account) || (
+          account.capabilities !== null &&
+          typeof account.capabilities === 'object' &&
+          'library_read' in account.capabilities &&
+          typeof account.capabilities.library_read === 'boolean' &&
+          'library_write' in account.capabilities &&
+          typeof account.capabilities.library_write === 'boolean' &&
+          'public_playlist_read' in account.capabilities &&
+          typeof account.capabilities.public_playlist_read === 'boolean'
+        )),
     )
   )
 }

--- a/frontend/src/lib/accountCapabilities.ts
+++ b/frontend/src/lib/accountCapabilities.ts
@@ -1,0 +1,24 @@
+import type { Account, AccountCapabilities } from '@/types'
+
+const NO_CAPABILITIES: AccountCapabilities = {
+  library_read: false,
+  library_write: false,
+  public_playlist_read: false,
+}
+
+/** Current credential grants, with a compatibility fallback for account data
+ * cached by a SongMirror release that predates the capability payload. */
+export function capabilitiesOf(account: Account): AccountCapabilities {
+  if (account.state !== 'connected') return NO_CAPABILITIES
+  if (account.capabilities) return account.capabilities
+  return {
+    library_read: true,
+    library_write: account.transferable,
+    public_playlist_read: account.transferable,
+  }
+}
+
+export function canSyncAccount(account: Account): boolean {
+  const capabilities = capabilitiesOf(account)
+  return account.transferable && capabilities.library_read && capabilities.library_write
+}

--- a/frontend/src/pages/Playlists.tsx
+++ b/frontend/src/pages/Playlists.tsx
@@ -10,11 +10,16 @@ import { LoadingStatus, Skeleton } from '@/components/ui/Skeleton'
 import { useAccounts } from '@/hooks/useAccounts'
 import { useLinks } from '@/hooks/useLinks'
 import { useProviderPlaylists } from '@/hooks/useProviderPlaylists'
+import { canSyncAccount, capabilitiesOf } from '@/lib/accountCapabilities'
 import type { Account, PlaylistLink, ProviderPlaylist } from '@/types'
 
 export default function Playlists() {
   const { accounts, loading: accountsLoading, error: accountsError } = useAccounts()
-  const connectedAccounts = useMemo(() => accounts?.filter((a) => a.state === 'connected') ?? [], [accounts])
+  const connectedAccounts = useMemo(
+    () => accounts?.filter((account) => account.state === 'connected' && capabilitiesOf(account).library_read) ?? [],
+    [accounts],
+  )
+  const syncAccounts = useMemo(() => accounts?.filter(canSyncAccount) ?? [], [accounts])
   const connectedIds = useMemo(() => connectedAccounts.map((a) => a.id), [connectedAccounts])
   const { entries, refresh: refreshPlaylists } = useProviderPlaylists(connectedIds)
   const { links, loading: linksLoading, error: linksError, refresh: refreshLinks } = useLinks()
@@ -76,8 +81,8 @@ export default function Playlists() {
           </div>
           <Button
             onClick={() => setEditorTarget('new')}
-            disabled={connectedAccounts.length < 2}
-            title={connectedAccounts.length < 2 ? 'Connect at least 2 services first' : undefined}
+            disabled={syncAccounts.length < 2}
+            title={syncAccounts.length < 2 ? 'Connect at least 2 full-library services first' : undefined}
           >
             + New pairing
           </Button>

--- a/frontend/src/pages/Transfers.tsx
+++ b/frontend/src/pages/Transfers.tsx
@@ -11,11 +11,15 @@ import { useAccounts } from '@/hooks/useAccounts'
 import { useEventStream } from '@/hooks/useEventStream'
 import { useProviderPlaylists } from '@/hooks/useProviderPlaylists'
 import { useTransfer } from '@/hooks/useTransfer'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
 
 export default function Transfers() {
   const { accounts, loading: accountsLoading, error: accountsError } = useAccounts()
   const connectedAccounts = useMemo(() => accounts?.filter((a) => a.state === 'connected') ?? [], [accounts])
-  const connectedIds = useMemo(() => connectedAccounts.map((a) => a.id), [connectedAccounts])
+  const connectedIds = useMemo(
+    () => connectedAccounts.filter((account) => capabilitiesOf(account).library_read).map((account) => account.id),
+    [connectedAccounts],
+  )
   const { entries } = useProviderPlaylists(connectedIds)
 
   const [jobId, setJobId] = useState<string | null>(null)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -18,6 +18,15 @@ export interface AccountField {
   configured?: boolean
 }
 
+export interface AccountCapabilities {
+  /** The credentials can list and open the signed-in account's playlists. */
+  library_read: boolean
+  /** The credentials can create and edit playlists in the signed-in account. */
+  library_write: boolean
+  /** The credentials can open a public playlist URL as a transfer source. */
+  public_playlist_read: boolean
+}
+
 export interface Account {
   /** Stable selectable profile id. Never equal to a provider type id. */
   id: string
@@ -40,6 +49,9 @@ export interface Account {
    * False where the provider's writes can't express the repair safely (Deezer),
    * which greys out the transfer form's "preserve order" switch. */
   preserves_order: boolean
+  /** Operations granted by the current credentials. Optional only so a cached
+   * account payload from an older SongMirror release can be upgraded safely. */
+  capabilities?: AccountCapabilities
 }
 
 /** Shared shape for the plain `{ok: true}` acks (config save, settings save,
@@ -68,6 +80,7 @@ export interface ConnectDirectResponse {
   kind: 'token_paste' | 'api_key'
   state: AccountState
   detail: string | null
+  capabilities?: AccountCapabilities
 }
 
 export type ConnectResponse = ConnectRedirectResponse | ConnectDeviceResponse | ConnectDirectResponse
@@ -75,6 +88,7 @@ export type ConnectResponse = ConnectRedirectResponse | ConnectDeviceResponse | 
 export interface PollResponse {
   state: AccountState
   detail: string | null
+  capabilities?: AccountCapabilities
 }
 
 /** GET/PUT /api/settings — arbitrary KEY:value config; secrets are masked out

--- a/songmirror/engine/apple_access.py
+++ b/songmirror/engine/apple_access.py
@@ -1,0 +1,27 @@
+"""Apple Music access-tier response classification.
+
+Apple uses error code 40015 when otherwise-valid credentials do not include
+the paid CloudLibrary privilege. Keep the parser shared by account validation
+and the target transport so both paths distinguish that one capability denial
+from expired credentials and unrelated request failures.
+"""
+
+
+def is_cloud_library_denial(response) -> bool:
+    """Return True only for Apple's HTTP 400 error code 40015 response."""
+
+    if getattr(response, "status_code", None) != 400:
+        return False
+    try:
+        payload = response.json()
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    errors = payload.get("errors")
+    if not isinstance(errors, list):
+        return False
+    return any(
+        isinstance(error, dict) and str(error.get("code") or "") == "40015"
+        for error in errors
+    )

--- a/songmirror/engine/targets/__init__.py
+++ b/songmirror/engine/targets/__init__.py
@@ -14,6 +14,7 @@ from .amazon_music import AmazonMusicTarget
 from .base import (
     MirrorTarget,
     TargetAuthError,
+    TargetCapabilityError,
     TargetDirectoryIncompleteError,
     TargetTransientError,
     mirror_pair,
@@ -27,6 +28,7 @@ from . import ytmusic
 
 __all__ = ["AppleMusicTarget", "AmazonMusicTarget", "DeezerTarget", "QobuzTarget",
            "SpotifyTarget", "TidalTarget", "MirrorTarget", "TargetAuthError",
+           "TargetCapabilityError",
            "TargetDirectoryIncompleteError", "TargetTransientError",
            "mirror_pair", "reconcile", "build_targets", "build_peers", "build_one", "is_peer",
            "target_class", "provider_ids",

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -8,12 +8,18 @@ import time
 
 import requests
 
+from ..apple_access import is_cloud_library_denial
 from ..config import (
     AMP, DEFAULT_CACHE_FILE, REQUEST_TIMEOUT, polite_sleep, required_env,
 )
 from ..logs import log, log_warn
 from ..matching import normalize_text, romanized, score_candidate
-from .base import MirrorTarget, TargetAuthError, TargetTransientError
+from .base import (
+    MirrorTarget,
+    TargetAuthError,
+    TargetCapabilityError,
+    TargetTransientError,
+)
 from .provider_utils import source_playlist_details
 
 # playlist_id -> (lastModifiedDate, track_count): in-process cache so the browse
@@ -135,6 +141,11 @@ class AppleMusicTarget(MirrorTarget):
                     f"Apple rejected {method} {url.split('/v1/')[-1]} ({r.status_code}). "
                     "Re-capture APPLE_BEARER_TOKEN / APPLE_USER_TOKEN from music.apple.com DevTools."
                 )
+            if is_cloud_library_denial(r):
+                raise TargetCapabilityError(
+                    "Apple Music library access requires an active Apple Music subscription. "
+                    "This account can still transfer public Apple Music playlist links out."
+                )
             if r.status_code == 404 and ok404:
                 return None
             if r.status_code == 429:
@@ -232,17 +243,26 @@ class AppleMusicTarget(MirrorTarget):
         pid = str(playlist_id)
         if not is_catalog_playlist_id(pid):
             return None
-        try:
-            response = self._request(
-                "GET", f"{AMP}/catalog/{self.storefront}/playlists/{pid}", ok404=True)
-        except Exception:
-            return None
+        response = self._request(
+            "GET", f"{AMP}/catalog/{self.storefront}/playlists/{pid}", ok404=True)
         if response is None:
             return None
         rows = response.json().get("data") or []
         if not rows:
             return None
         return {**rows[0], "_catalog": True}
+
+    def find_playlist(self, playlist_id):
+        """Open catalog ids without probing the signed-in CloudLibrary.
+
+        Public Apple links always carry a ``pl.`` catalog id. Going through the
+        base library scan first is both unnecessary and unavailable to a valid
+        catalog-only account, while ``p.`` library ids retain the normal lookup.
+        """
+
+        if is_catalog_playlist_id(playlist_id):
+            return self.fetch_playlist(playlist_id)
+        return super().find_playlist(playlist_id)
 
     def playlist_tracks_page(self, playlist, cursor=None):
         try:

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -40,6 +40,10 @@ class TargetAuthError(RuntimeError):
     """Auth expired / rejected. Fatal for the pass — never a partial write."""
 
 
+class TargetCapabilityError(RuntimeError):
+    """Valid credentials lack a provider capability required by this action."""
+
+
 class TargetDirectoryIncompleteError(RuntimeError):
     """A playlist directory was incomplete and cannot safely drive writes."""
 

--- a/songmirror/services/accounts/apple.py
+++ b/songmirror/services/accounts/apple.py
@@ -3,8 +3,17 @@ wizard guides pasting the web player's bearer + Media-User-Token."""
 
 import requests
 
+from ...engine.apple_access import is_cloud_library_denial
 from ...engine.config import AMP
-from .base import ConnStatus, Connector, Field
+from .base import FULL_PEER_CAPABILITIES, ConnStatus, Connector, Field
+
+
+CATALOG_ONLY_CAPABILITIES = frozenset({"public_playlist_read"})
+CATALOG_ONLY_DETAIL = (
+    "Catalog-only access. Public Apple Music playlist links can be transferred "
+    "out; library browsing, syncing, and destination writes require an active "
+    "Apple Music subscription."
+)
 
 
 class AppleConnector(Connector):
@@ -23,25 +32,29 @@ class AppleConnector(Connector):
     def status(self) -> ConnStatus:
         if not self._configured("APPLE_BEARER_TOKEN", "APPLE_USER_TOKEN"):
             return ConnStatus("unconfigured")
-        ok, detail = self._validate()
+        ok, detail, capabilities, storefront = self._validate()
         if ok:
-            self._ensure_storefront()  # one-time: backfill the account's region if it's blank
-        return ConnStatus("connected", detail) if ok else ConnStatus("expired", detail)
+            self._ensure_storefront(storefront)  # one-time: backfill the account's region if it's blank
+        return ConnStatus("connected", detail, capabilities) if ok else ConnStatus("expired", detail)
 
     def submit(self, values: dict) -> ConnStatus:
         self._store.save({k: values.get(k) for k in ("APPLE_BEARER_TOKEN", "APPLE_USER_TOKEN", "APPLE_STOREFRONT")})
-        ok, detail = self._validate()
+        ok, detail, capabilities, storefront = self._validate()
         if ok:
-            self._ensure_storefront()  # auto-detect the account's region when the field was left blank
-        return ConnStatus("connected", detail) if ok else ConnStatus("error", detail or "token rejected")
+            self._ensure_storefront(storefront)  # auto-detect the account's region when the field was left blank
+        return (ConnStatus("connected", detail, capabilities) if ok
+                else ConnStatus("error", detail or "token rejected"))
 
-    def _ensure_storefront(self):
+    def _ensure_storefront(self, detected=""):
         """Detect and persist the account's storefront (e.g. 'us', 'bd') from
         /v1/me/storefront when it's blank, so catalog searches hit the right
         region. A user-set value is left untouched; best-effort otherwise (a blank
         storefront falls back to 'us' in the engine). No-op once one is stored, so
         it's a single lookup on connect, not per status poll."""
         if (self._store.get("APPLE_STOREFRONT") or "").strip():
+            return
+        if str(detected or "").strip():
+            self._store.save({"APPLE_STOREFRONT": str(detected).strip()})
             return
         try:
             r = requests.get(
@@ -67,14 +80,54 @@ class AppleConnector(Connector):
         bearer = self._bearer()
         user = self._store.get("APPLE_USER_TOKEN") or ""
         if not (bearer and user):
-            return False, "missing tokens"
+            return False, "missing tokens", frozenset(), ""
+        headers = {
+            "Authorization": f"Bearer {bearer}",
+            "Media-User-Token": user,
+            "Origin": "https://music.apple.com",
+        }
         try:
             r = requests.get(
                 f"{AMP}/me/library/playlists?limit=1",
-                headers={"Authorization": f"Bearer {bearer}", "Media-User-Token": user,
-                         "Origin": "https://music.apple.com"},
+                headers=headers,
                 timeout=15,
             )
-            return r.ok, "" if r.ok else f"HTTP {r.status_code}"
-        except Exception as e:
-            return False, repr(e)
+            if r.ok:
+                return True, "", FULL_PEER_CAPABILITIES, ""
+            if not is_cloud_library_denial(r):
+                return False, f"HTTP {r.status_code}", frozenset(), ""
+
+            storefront_response = requests.get(
+                f"{AMP}/me/storefront",
+                headers=headers,
+                timeout=15,
+            )
+            if not storefront_response.ok:
+                return (
+                    False,
+                    f"catalog validation failed (HTTP {storefront_response.status_code})",
+                    frozenset(),
+                    "",
+                )
+            payload = storefront_response.json()
+            data = (payload.get("data") or []) if isinstance(payload, dict) else []
+            storefront = (
+                str(data[0].get("id") or "").strip()
+                if data and isinstance(data[0], dict)
+                else ""
+            )
+            if not storefront:
+                return False, "catalog validation returned no storefront", frozenset(), ""
+            return True, CATALOG_ONLY_DETAIL, CATALOG_ONLY_CAPABILITIES, storefront
+        except requests.RequestException as exc:
+            # Request exceptions may include caller-supplied text. Report only
+            # the class so pasted bearer and user tokens can never be reflected
+            # into an API response or log through validation detail.
+            return (
+                False,
+                f"could not reach Apple Music ({type(exc).__name__})",
+                frozenset(),
+                "",
+            )
+        except (AttributeError, TypeError, ValueError):
+            return False, "Apple Music returned an invalid validation response", frozenset(), ""

--- a/songmirror/services/accounts/base.py
+++ b/songmirror/services/accounts/base.py
@@ -9,6 +9,13 @@ from dataclasses import dataclass
 from typing import Literal
 
 AuthKind = Literal["oauth_redirect", "oauth_device", "token_paste", "api_key"]
+AccountCapability = Literal["library_read", "library_write", "public_playlist_read"]
+
+FULL_PEER_CAPABILITIES = frozenset({
+    "library_read",
+    "library_write",
+    "public_playlist_read",
+})
 
 
 @dataclass
@@ -26,6 +33,9 @@ class Field:
 class ConnStatus:
     state: Literal["connected", "expired", "unconfigured", "error"]
     detail: str = ""
+    # None means the connector uses the normal full peer capability set. A
+    # connector with narrower credentials supplies the exact granted subset.
+    capabilities: frozenset[AccountCapability] | None = None
 
 
 @dataclass

--- a/songmirror/services/playlists.py
+++ b/songmirror/services/playlists.py
@@ -17,7 +17,7 @@ from urllib.parse import quote
 from ..engine import archive, spotify, spotify_cookie
 from ..engine.config import parse_args, spotify_write_backend
 from ..engine.logs import log_warn
-from ..engine.targets import build_one, target_provider
+from ..engine.targets import TargetCapabilityError, build_one, target_provider
 from .playlist_exports import render_backup
 from .playlist_links import external_url, provider_label
 from .settings import _open_private
@@ -168,6 +168,8 @@ class PlaylistService:
     def _failure(self, provider_id, action, exc):
         label = self._label(provider_id)
         log_warn(f"{action} failed: {exc!r}", tag=provider_id)
+        if isinstance(exc, TargetCapabilityError):
+            raise PlaylistReadOnlyError(str(exc)) from exc
         raise PlaylistBrowseError(
             f"{label} could not {action} right now. Retry; if it continues, reconnect the account."
         ) from exc

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -19,6 +19,7 @@ from ..engine.targets import build_one, is_peer, target_provider
 from ..engine.targets.base import (
     MirrorTarget,
     TargetAuthError,
+    TargetCapabilityError,
     _fit_chronology_writes,
     _normalize,
     _ordered_current_matches,
@@ -223,6 +224,8 @@ def _friendly_error(e):
     """Turn a raw provider exception into a message a user can act on. Falls back
     to repr() for anything unrecognized."""
     status = getattr(e, "http_status", None)
+    if isinstance(e, TargetCapabilityError):
+        return str(e)
     if status == 403:
         return ("The source service blocked reading this playlist (HTTP 403) — it's most "
                 "likely owned by another account, or an editorial/auto-generated playlist the "

--- a/songmirror/web/routers/accounts.py
+++ b/songmirror/web/routers/accounts.py
@@ -16,9 +16,11 @@ from fastapi.responses import HTMLResponse
 
 from ...engine.targets import is_peer, target_class
 from ...services.accounts import CONNECTORS
-from ...services.accounts.base import ConnStatus, DeviceCode
+from ...services.accounts.base import FULL_PEER_CAPABILITIES, ConnStatus, DeviceCode
 
 router = APIRouter()
+
+_CAPABILITY_KEYS = ("library_read", "library_write", "public_playlist_read")
 
 
 def _profile(request: Request, identity: str):
@@ -42,6 +44,35 @@ def _conn(request: Request, identity: str):
 def _preserves_order(provider):
     cls = target_class(provider)
     return cls is not None and callable(getattr(cls, "replay_chronology", None))
+
+
+def _capabilities(provider, status):
+    """Current operations the connected credentials can perform.
+
+    Most peer connectors grant the target's full read/write contract. A
+    connector can narrow that set in ConnStatus when the credentials are valid
+    for only part of the provider, as with Apple's catalog-only accounts.
+    """
+
+    granted = set()
+    if status.state == "connected":
+        if status.capabilities is not None:
+            granted = set(status.capabilities)
+        elif is_peer(provider):
+            granted = set(FULL_PEER_CAPABILITIES)
+        else:
+            # Browse-only connectors still expose their own playlist directory,
+            # but cannot participate in track-level syncs or transfers.
+            granted = {"library_read"}
+    return {key: key in granted for key in _CAPABILITY_KEYS}
+
+
+def _status_values(provider, status):
+    return {
+        "state": status.state,
+        "detail": status.detail,
+        "capabilities": _capabilities(provider, status),
+    }
 
 
 def _redirect_uri(request: Request, account_id: str) -> str:
@@ -106,8 +137,7 @@ def _status_payload(request, profile):
         "removable": not profile.is_default,
         "auth_kind": connector.auth_kind,
         "fields": fields,
-        "state": status.state,
-        "detail": status.detail,
+        **_status_values(profile.provider, status),
         "transferable": is_peer(profile.provider),
         "preserves_order": _preserves_order(profile.provider),
     }
@@ -170,7 +200,7 @@ async def connect(account_id: str, request: Request, body: dict | None = Body(de
         if connector.auth_kind == "oauth_device":
             return {"kind": "device", **asdict(connector.begin_device())}
         status = connector.submit(body or {})
-    return {"kind": connector.auth_kind, "state": status.state, "detail": status.detail}
+    return {"kind": connector.auth_kind, **_status_values(profile.provider, status)}
 
 
 @router.get("/oauth/{account_id}/callback")
@@ -205,7 +235,7 @@ async def poll(account_id: str, request: Request):
     code = DeviceCode("", "", body["device_code"], body.get("interval", 5))
     with request.app.state.account_profiles.activate(profile.id):
         status = _conn(request, profile.id).poll_device(code)
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 @router.post("/api/accounts/{account_id}/disconnect")
@@ -240,7 +270,7 @@ async def ytmusic_enable_browser(account_id: str, request: Request, body: dict =
     profile, connector = _provider_connector(request, account_id, "ytmusic")
     with request.app.state.account_profiles.activate(profile.id):
         status = connector.enable_browser(body.get("headers", ""))
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 @router.delete("/api/accounts/{account_id}/ytmusic/browser")
@@ -248,7 +278,7 @@ def ytmusic_disable_browser(account_id: str, request: Request):
     profile, connector = _provider_connector(request, account_id, "ytmusic")
     with request.app.state.account_profiles.activate(profile.id):
         status = connector.disable_browser()
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 @router.post("/api/accounts/{account_id}/spotify/cookie")
@@ -256,7 +286,7 @@ async def spotify_enable_cookie(account_id: str, request: Request, body: dict = 
     profile, connector = _provider_connector(request, account_id, "spotify")
     with request.app.state.account_profiles.activate(profile.id):
         status = connector.enable_cookie(body.get("sp_dc", ""))
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 @router.delete("/api/accounts/{account_id}/spotify/cookie")
@@ -264,7 +294,7 @@ def spotify_disable_cookie(account_id: str, request: Request):
     profile, connector = _provider_connector(request, account_id, "spotify")
     with request.app.state.account_profiles.activate(profile.id):
         status = connector.disable_cookie()
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 @router.post("/api/accounts/{account_id}/spotify/isrc-app")
@@ -274,7 +304,7 @@ async def spotify_set_isrc_app(account_id: str, request: Request, body: dict = B
         status = connector.set_isrc_app(
             body.get("client_id", ""), body.get("client_secret", "")
         )
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 @router.delete("/api/accounts/{account_id}/spotify/isrc-app")
@@ -282,7 +312,7 @@ def spotify_clear_isrc_app(account_id: str, request: Request):
     profile, connector = _provider_connector(request, account_id, "spotify")
     with request.app.state.account_profiles.activate(profile.id):
         status = connector.clear_isrc_app()
-    return {"state": status.state, "detail": status.detail}
+    return _status_values(profile.provider, status)
 
 
 # Compatibility routes used by pre-profile frontends. Provider ids resolve to

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,5 +1,7 @@
 """Account connectors: status + the connect entry point per auth kind."""
 
+import pytest
+
 from songmirror.services.accounts import CONNECTORS
 from songmirror.services.accounts.base import DeviceCode
 from songmirror.services.settings import SettingsStore
@@ -18,10 +20,166 @@ def test_registry_has_all_supported_services():
 def test_apple_unconfigured_then_submit_stores(tmp_path, monkeypatch):
     c = _conn("apple", tmp_path)
     assert c.status().state == "unconfigured"
-    monkeypatch.setattr(c, "_validate", lambda: (True, "ok"))
+    monkeypatch.setattr(c, "_validate", lambda: (True, "ok", None, ""))
     st = c.submit({"APPLE_BEARER_TOKEN": "b", "APPLE_USER_TOKEN": "u"})
     assert st.state == "connected"
     assert c._store.get("APPLE_USER_TOKEN") == "u"
+
+
+def test_apple_cloud_library_denial_falls_back_to_catalog_access(tmp_path, monkeypatch):
+    class Response:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        @property
+        def ok(self):
+            return 200 <= self.status_code < 300
+
+        def json(self):
+            return self._payload
+
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        if url.endswith("/me/library/playlists?limit=1"):
+            return Response(400, {"errors": [{
+                "status": "400",
+                "code": "40015",
+                "title": "Insufficient Privileges",
+                "detail": "User's subscription tier does not have access to privilege: CloudLibrary",
+            }]})
+        if url.endswith("/me/storefront"):
+            return Response(200, {"data": [{"id": "tr", "type": "storefronts"}]})
+        raise AssertionError(f"unexpected Apple validation URL: {url}")
+
+    monkeypatch.setattr("songmirror.services.accounts.apple.requests.get", get)
+    c = _conn("apple", tmp_path)
+
+    status = c.submit({"APPLE_BEARER_TOKEN": "developer-token", "APPLE_USER_TOKEN": "user-token"})
+
+    assert status.state == "connected"
+    assert status.capabilities == frozenset({"public_playlist_read"})
+    assert "catalog-only" in status.detail.casefold()
+    assert c._store.get("APPLE_STOREFRONT") == "tr"
+    assert [url.rsplit("/v1/", 1)[-1] for url, _kwargs in calls] == [
+        "me/library/playlists?limit=1",
+        "me/storefront",
+    ]
+
+
+def test_apple_paid_library_validation_keeps_full_access(tmp_path, monkeypatch):
+    class Response:
+        status_code = 200
+        ok = True
+
+        @staticmethod
+        def json():
+            return {"data": [{"id": "us", "type": "storefronts"}]}
+
+    monkeypatch.setattr(
+        "songmirror.services.accounts.apple.requests.get",
+        lambda *_args, **_kwargs: Response(),
+    )
+    status = _conn("apple", tmp_path).submit({
+        "APPLE_BEARER_TOKEN": "developer-token",
+        "APPLE_USER_TOKEN": "user-token",
+    })
+
+    assert status.state == "connected"
+    assert status.detail == ""
+    assert status.capabilities == frozenset({
+        "library_read",
+        "library_write",
+        "public_playlist_read",
+    })
+
+
+def test_apple_catalog_fallback_must_validate_the_storefront(tmp_path, monkeypatch):
+    class Response:
+        def __init__(self, status_code, payload=None):
+            self.status_code = status_code
+            self._payload = payload or {}
+
+        @property
+        def ok(self):
+            return 200 <= self.status_code < 300
+
+        def json(self):
+            return self._payload
+
+    responses = iter([
+        Response(400, {"errors": [{"code": "40015"}]}),
+        Response(401),
+    ])
+    monkeypatch.setattr(
+        "songmirror.services.accounts.apple.requests.get",
+        lambda *_args, **_kwargs: next(responses),
+    )
+
+    status = _conn("apple", tmp_path).submit({
+        "APPLE_BEARER_TOKEN": "developer-token",
+        "APPLE_USER_TOKEN": "user-token",
+    })
+
+    assert status.state == "error"
+    assert status.detail == "catalog validation failed (HTTP 401)"
+    assert status.capabilities is None
+
+
+@pytest.mark.parametrize(
+    ("status_code", "payload"),
+    [
+        (400, {"errors": [{"code": "40016", "title": "Another error"}]}),
+        (401, {"errors": [{"code": "AUTHENTICATION_ERROR"}]}),
+    ],
+)
+def test_apple_validation_does_not_swallow_unrelated_errors(
+    tmp_path, monkeypatch, status_code, payload,
+):
+    calls = []
+
+    class Response:
+        ok = False
+
+        def json(self):
+            return payload
+
+    response = Response()
+    response.status_code = status_code
+
+    def get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return response
+
+    monkeypatch.setattr("songmirror.services.accounts.apple.requests.get", get)
+    status = _conn("apple", tmp_path).submit({
+        "APPLE_BEARER_TOKEN": "developer-token",
+        "APPLE_USER_TOKEN": "user-token",
+    })
+
+    assert status.state == "error"
+    assert status.detail == f"HTTP {status_code}"
+    assert len(calls) == 1
+
+
+def test_apple_validation_failure_never_echoes_tokens(tmp_path, monkeypatch):
+    import requests
+
+    def fail(*_args, **_kwargs):
+        raise requests.ConnectionError("request carrying developer-token failed")
+
+    monkeypatch.setattr("songmirror.services.accounts.apple.requests.get", fail)
+    status = _conn("apple", tmp_path).submit({
+        "APPLE_BEARER_TOKEN": "developer-token",
+        "APPLE_USER_TOKEN": "user-token",
+    })
+
+    assert status.state == "error"
+    assert status.detail == "could not reach Apple Music (ConnectionError)"
+    assert "developer-token" not in status.detail
+    assert "user-token" not in status.detail
 
 
 def test_jellyfin_unconfigured_then_submit(tmp_path, monkeypatch):

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -2312,6 +2312,67 @@ def test_apple_reads_a_shared_playlist_from_the_catalog_not_the_library():
     assert target.playlist_count(playlist) == 2
 
 
+def test_apple_catalog_id_lookup_never_reads_the_cloud_library():
+    target = _apple_target(lambda *_args, **_kwargs: None)
+    target.list_playlists = lambda: (_ for _ in ()).throw(
+        AssertionError("catalog lookup must not read the CloudLibrary")
+    )
+    target.fetch_playlist = lambda playlist_id: {
+        "id": playlist_id,
+        "_catalog": True,
+        "attributes": {"name": "Public mix"},
+    }
+
+    found = target.find_playlist("pl.u-public")
+
+    assert found["id"] == "pl.u-public"
+    assert found["_catalog"] is True
+
+
+def test_apple_cloud_library_operations_fail_as_a_capability_error():
+    import requests
+
+    from songmirror.engine.targets.apple import AppleMusicTarget
+    from songmirror.engine.targets.base import TargetCapabilityError
+
+    class Response:
+        status_code = 400
+        headers = {}
+
+        @staticmethod
+        def json():
+            return {"errors": [{"code": "40015"}]}
+
+        def raise_for_status(self):
+            raise requests.HTTPError("400 Client Error", response=self)
+
+    class Session:
+        @staticmethod
+        def request(*_args, **_kwargs):
+            return Response()
+
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target._session = Session()
+
+    with pytest.raises(TargetCapabilityError, match="active Apple Music subscription"):
+        target._request(
+            "GET",
+            "https://amp-api.music.apple.com/v1/me/library/playlists",
+        )
+
+
+def test_apple_catalog_fetch_does_not_swallow_authentication_errors():
+    from songmirror.engine.targets.base import TargetAuthError
+
+    def reject(*_args, **_kwargs):
+        raise TargetAuthError("Apple rejected the catalog request")
+
+    target = _apple_target(reject)
+
+    with pytest.raises(TargetAuthError, match="rejected the catalog"):
+        target.fetch_playlist("pl.u-public")
+
+
 def test_apple_reads_catalog_playlist_tracks_from_the_catalog_route():
     calls = []
 

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -153,6 +153,26 @@ def test_browse_failure_is_not_reported_as_an_empty_library(monkeypatch, tmp_pat
         PlaylistService(SettingsStore(dir=tmp_path)).browse("spotify")
 
 
+def test_browse_surfaces_a_missing_library_capability_as_read_only(monkeypatch, tmp_path):
+    from songmirror.engine.targets.base import TargetCapabilityError
+    from songmirror.services.playlists import PlaylistReadOnlyError, PlaylistService
+    from songmirror.services.settings import SettingsStore
+
+    class CatalogOnlyTarget:
+        def browse_playlists(self):
+            raise TargetCapabilityError(
+                "Apple Music library access requires an active Apple Music subscription."
+            )
+
+    monkeypatch.setattr(
+        "songmirror.services.playlists.build_one",
+        lambda provider, opts, sp=None: CatalogOnlyTarget(),
+    )
+
+    with pytest.raises(PlaylistReadOnlyError, match="active Apple Music subscription"):
+        PlaylistService(SettingsStore(dir=tmp_path)).browse("apple")
+
+
 def test_playlist_detail_normalizes_tracks_and_external_links(monkeypatch, tmp_path):
     from songmirror.services.playlists import PlaylistService
     from songmirror.services.settings import SettingsStore

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -872,6 +872,85 @@ def test_preview_resolves_a_public_link_into_a_startable_source(monkeypatch, tmp
         "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M")
 
 
+def test_catalog_only_apple_link_previews_and_transfers_without_library_access(
+    monkeypatch, tmp_path,
+):
+    from songmirror.engine.targets.apple import AppleMusicTarget
+
+    class Response:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    calls = []
+
+    def request(method, url, params=None, json_body=None, ok404=False):
+        calls.append((method, url))
+        if url.endswith("/tracks"):
+            return Response({"data": [{
+                "id": "relationship-1",
+                "attributes": {
+                    "name": "Public song",
+                    "artistName": "Public artist",
+                    "durationInMillis": 180000,
+                    "isrc": "USAAA2600001",
+                    "playParams": {"id": "apple-catalog-track"},
+                },
+            }]})
+        return Response({"data": [{
+            "id": "pl.u-public",
+            "attributes": {"name": "Public mix", "description": {"standard": "Open"}},
+            "relationships": {"tracks": {"data": [{"id": "relationship-1"}]}},
+        }]})
+
+    source = AppleMusicTarget.__new__(AppleMusicTarget)
+    source.storefront = "tr"
+    source.cache_file = str(tmp_path / "apple.json")
+    source._request = request
+
+    added = []
+    destination = _Prov(str(tmp_path / "dest.json"), [], source="deezer")
+    destination.resolve = lambda _track, _cache: ("deezer-track", "isrc")
+    destination.add = lambda _playlist, ids: added.extend(ids)
+
+    monkeypatch.setattr(
+        TransferService,
+        "_build",
+        lambda _self, provider_id, _opts: (
+            source if provider_id == "apple" else destination
+        ),
+    )
+    result = {}
+
+    async def scenario():
+        bus = EventBus()
+        bus.bind_loop(asyncio.get_running_loop())
+        sync = SyncService(SettingsStore(dir=tmp_path), bus)
+        service = TransferService(SettingsStore(dir=tmp_path), bus, sync)
+        result["preview"] = service.preview(
+            "https://music.apple.com/tr/playlist/public-mix/pl.u-public"
+        )
+        job = service.submit({
+            "source_provider": "apple",
+            "source_playlist_id": "pl.u-public",
+            "dest_provider": "deezer",
+            "dest_playlist_id": "p1",
+        })
+        result["job"] = await _await_job(service, job["id"])
+
+    asyncio.run(scenario())
+
+    assert result["preview"]["name"] == "Public mix"
+    assert result["preview"]["count"] == 1
+    assert result["job"]["status"] == "done"
+    assert result["job"]["added"] == 1
+    assert added == ["deezer-track"]
+    assert calls
+    assert all("/me/library/" not in url for _method, url in calls)
+
+
 def test_preview_rejects_text_that_is_not_a_playlist_link(tmp_path):
     svc = TransferService(SettingsStore(dir=tmp_path), EventBus(), None)
     with pytest.raises(TransferPreviewError):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -86,6 +86,10 @@ def test_accounts_list_all_unconfigured(tmp_path, monkeypatch):
     for keys in PROVIDER_KEYS.values():
         for key in keys:
             monkeypatch.delenv(key, raising=False)
+    # The app lifespan normally loads an operator's local .env. This test
+    # models a clean install and must not perform live status checks with that
+    # machine-local configuration.
+    monkeypatch.setattr("songmirror.web.load_dotenv", lambda: False)
     with TestClient(_app(tmp_path)) as client:
         accounts = client.get("/api/accounts").json()
         assert {a["provider"] for a in accounts} == {
@@ -145,6 +149,38 @@ def test_account_profile_api_adds_labels_isolates_secrets_and_removes(tmp_path):
         assert client.delete(f"/api/accounts/{profile['id']}").json() == {"ok": True}
         assert not profile_dir.exists()
         assert profile["id"] not in {a["id"] for a in client.get("/api/accounts").json()}
+
+
+def test_accounts_report_catalog_only_apple_capabilities(tmp_path, monkeypatch):
+    from songmirror.services.accounts.apple import (
+        CATALOG_ONLY_CAPABILITIES,
+        CATALOG_ONLY_DETAIL,
+        AppleConnector,
+    )
+    from songmirror.services.accounts.base import ConnStatus
+
+    monkeypatch.setattr(
+        AppleConnector,
+        "status",
+        lambda _self: ConnStatus(
+            "connected",
+            CATALOG_ONLY_DETAIL,
+            CATALOG_ONLY_CAPABILITIES,
+        ),
+    )
+
+    with TestClient(_app(tmp_path)) as client:
+        accounts = client.get("/api/accounts").json()
+
+    apple = next(account for account in accounts if account["provider"] == "apple")
+    assert apple["id"].startswith("profile_default_")
+    assert apple["state"] == "connected"
+    assert apple["detail"] == CATALOG_ONLY_DETAIL
+    assert apple["capabilities"] == {
+        "library_read": False,
+        "library_write": False,
+        "public_playlist_read": True,
+    }
 
 
 def test_settings_roundtrip_masks_secrets(tmp_path):
@@ -242,6 +278,11 @@ def test_spotify_connect_accepts_web_session_without_oauth_redirect(tmp_path, mo
         "kind": "token_paste",
         "state": "connected",
         "detail": "signed-in web session · no developer API",
+        "capabilities": {
+            "library_read": True,
+            "library_write": True,
+            "public_playlist_read": True,
+        },
     }
 
 


### PR DESCRIPTION
## Summary

- accept Apple's exact CloudLibrary 40015 denial by validating the storefront and reporting catalog-only capabilities
- route public `pl.*` links directly through catalog reads while preserving authentication errors and clear failures for library-only actions
- keep catalog-only accounts out of library browsing, sync, pairing, and destination controls while preserving paid-account behavior

## Verification

- `uv run pytest -q` (539 passed, 1 skipped)
- `uv run pytest tests/test_connectors.py tests/test_new_providers.py tests/test_playlists.py tests/test_transfers.py tests/test_web.py -q` (198 passed)
- `pnpm -C frontend exec tsc --noEmit`
- `pnpm -C frontend lint`
- `CI=1 pnpm -C frontend test:e2e:ci` (131 checks, 0 horizontal-overflow failures)

Closes #45