### PR TITLE
feat(sync): add public multi-source merge jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Self-hosted, always-on **playlist sync for Spotify, TIDAL, Qobuz, Deezer, Amazon Music, Apple Music, and YouTube Music** — plus a local, Jellyfin-ready audio mirror.<br/>
 A free, open-source, **self-hosted alternative to Soundiiz, TuneMyMusic, and FreeYourMusic** that _you_ own and run.
 
-**One-way, authoritative-group, or full bidirectional (N-way) sync · one-off playlist transfers · ISRC-accurate matching · all from your browser**
+**One-way, multi-source merge, authoritative-group, or full bidirectional (N-way) sync · one-off playlist transfers · ISRC-accurate matching · all from your browser**
 
 [Quick Start](#-quick-start) · [Features](#-features) · [Screenshots](#-screenshots) · [Docker](#-always-running-docker) · [How it works](#-how-it-works) · [Report Bug][github-issues-link] · [Request Feature][github-issues-link]
 
@@ -53,6 +53,7 @@ A free, open-source, **self-hosted alternative to Soundiiz, TuneMyMusic, and Fre
 - [🐳 Always running: Docker](#-always-running-docker)
 - [⚙️ How it works](#-how-it-works)
   - [Matching](#matching)
+  - [Multi-source merge sync](#multi-source-merge-sync)
   - [Authoritative groups](#authoritative-groups)
   - [Bidirectional (N-way) sync](#bidirectional-n-way-sync)
 - [📦 Playlist metadata backups](#-playlist-metadata-backups)
@@ -87,6 +88,7 @@ SongMirror keeps your playlists identical everywhere without manual re-adding, o
 - 🔁 **True mirroring, not append-only** — adds _and_ removals. Choose a source of truth (Spotify by default) and the others follow it.
 - ⇆ **Authoritative groups** — trust two or more services (for example Spotify + Apple Music) while every other selected service remains a destination-only mirror.
 - ⇄ **Bidirectional N-way sync** — an add or removal on _any_ connected service propagates to all the others, echo-free, behind removal guards.
+- ⇉ **Multi-source merge sync** — schedule the deduplicated union of library playlists and public playlist URLs into one destination, without saving or following the public lists.
 - ♥ **Liked and favorite tracks** — sync each service's built-in liked collection across all seven music providers, either into the destination's own favorites or a new named playlist.
 - 🎯 **ISRC-accurate matching** — exact recording identity where available, with Unicode-aware fuzzy title/artist/duration fallbacks (feat-credit drift, "- 2015 Remaster" suffixes, non-Latin scripts, video-only uploads — all handled).
 - 🎛️ **Multiple named syncs** — set up as many independent syncs as you like, each with its own services, playlists, schedule, and safety caps.
@@ -118,7 +120,7 @@ SongMirror keeps your playlists identical everywhere without manual re-adding, o
 
 <img src="./.github/assets/dashboard.png" alt="SongMirror dashboard showing sync status, configured jobs, live activity, and health for Spotify, TIDAL, Qobuz, Deezer, Amazon Music, Apple Music, YouTube Music, and Jellyfin" width="82%">
 
-**Set up any number of syncs — one-way, authoritative-group, or bidirectional — in a short wizard**
+**Set up any number of syncs — one-way, multi-source merge, authoritative-group, or bidirectional — in a short wizard**
 
 <img src="./.github/assets/sync-wizard.png" alt="The SongMirror setup wizard selecting services for a bidirectional sync across Spotify, TIDAL, Qobuz, Deezer, Amazon Music, Apple Music, and YouTube Music" width="82%">
 
@@ -238,6 +240,17 @@ Same hierarchy the cross-service tools use ([TuneLink](https://tommcfarlin.com/c
    - **Video-only tracks** — YouTube search falls back to the `videos` filter for indie/OST tracks that live on YT only as uploads.
 
 The **duration anchor** unlocks the looser title match, so a different version (`Runaway - Piano Version`) or a wrong-artist cover isn't accepted when its length disagrees. Tracks with no confident match are reported and skipped.
+
+### Multi-source merge sync
+
+A **Merge sources** job combines one or more explicit playlists into one chosen destination. Each source can come from a connected account's library or a pasted public provider URL; the latter is resolved to a provider and playlist id once, so the playlist does not need to be saved or followed and scheduled runs do not replay an arbitrary URL.
+
+- **One membership union** — all constituents are read before the destination is reconciled. Shared ISRCs are one recording; without an ISRC, exact/conservative title, artist, version, and duration evidence deduplicates overlaps.
+- **Deterministic order** — source descriptor priority first, then the order returned by each source playlist. The first occurrence owns the destination position and display metadata; later copies only enrich missing identity metadata.
+- **Union-safe removals** — a destination track can be removed only when a complete pass finds it absent from every constituent source. A failed, truncated, malformed, unavailable, or unknowably empty source disables every removal for that pass, while safe additions from readable sources may continue.
+- **Append-only by default** — leave **Remove tracks absent from every source** off to keep all destination-only tracks. Turning it on opts into the normal per-pass removal cap after the complete-read guard passes.
+
+Merge jobs currently target one provider playlist; the separate Spotify-led local download/Jellyfin mirror is not available for an aggregate job.
 
 ### Authoritative groups
 
@@ -459,6 +472,7 @@ Removals are destructive, so they're guarded:
 - A chronology repair stages a duplicate copy before retiring the original. On a service whose delete takes every copy of a song, that keeper count has to be right, so Apple Music re-reads until the staged copies are visible and refuses to retire anything against a read that still trails its own writes. Deezer skips the repair entirely and always appends: it has no positional insert either, so replaying an order it cannot express is not worth the risk to the destination. The transfer form greys its order switch out there and says why.
 - **Net-loss protection** — a target-side track resembling a source track that has no match on that service is held, not deleted.
 - Any provider authentication failure aborts that provider's pass immediately — no partial deletes on expired tokens.
+- A merge job must finish every constituent source read before deleting from its destination; any partial/failed source snapshot forces that pass into append-only behavior.
 
 <div align="right">
 

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -2940,6 +2940,81 @@ async function main() {
     }
 
     // -----------------------------------------------------------------
+    // Merge sync: combine one library source with a public playlist that
+    // is absent from the library, choose one writable destination, and
+    // persist the explicit append-only strategy plus ordered descriptors.
+    // -----------------------------------------------------------------
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'light'))
+      const page = await context.newPage()
+      let createdMergeSync = null
+      await installMocks(page)
+      await page.route('**/api/syncs', async (route) => {
+        if (route.request().method() === 'POST') createdMergeSync = route.request().postDataJSON()
+        await route.fallback()
+      })
+
+      await page.setViewportSize({ width: 1280, height: 1000 })
+      await page.goto(BASE_URL + '/sync', { waitUntil: 'networkidle' })
+      await page.getByRole('button', { name: 'New sync', exact: true }).click()
+      const dialog = page.getByRole('dialog')
+      await dialog.getByLabel('Name', { exact: false }).fill('Chart mashup')
+      await dialog.getByText('Merge sources →', { exact: true }).click()
+
+      await dialog.getByRole('radio', { name: 'Services', exact: true }).click()
+      await dialog.getByLabel('Destination service', { exact: true }).selectOption('apple')
+      await dialog.getByLabel('Existing destination playlist', { exact: true }).click()
+      await page.getByRole('option', { name: /Rainy Day/ }).click()
+
+      await dialog.getByRole('radio', { name: 'Playlists', exact: true }).click()
+      await dialog.getByLabel('Source service', { exact: true }).selectOption('spotify')
+      await dialog.getByLabel('Source playlist', { exact: true }).click()
+      await page.getByRole('option', { name: /Road Trip 2025/ }).click()
+      await dialog.getByRole('button', { name: 'Add source', exact: true }).click()
+
+      await dialog.getByRole('radio', { name: 'Paste a link', exact: true }).click()
+      await dialog.getByLabel('Public playlist link', { exact: true }).fill(
+        'https://open.spotify.com/playlist/pl_public_link',
+      )
+      await dialog.getByRole('button', { name: 'Open and add source', exact: true }).click()
+      await dialog.getByText("Someone Else's Mix", { exact: true }).waitFor()
+      const orderedSources = dialog.getByRole('list', { name: 'Merge sources in priority order' })
+      const sourceCount = await orderedSources.getByRole('listitem').count()
+
+      const appendOnlyToggle = dialog.getByRole('switch', {
+        name: 'Remove tracks absent from every source', exact: false,
+      })
+      await dialog.getByRole('radio', { name: 'Limits & downloads', exact: true }).click()
+      const appendOnlyExplicit = (await appendOnlyToggle.getAttribute('aria-checked')) === 'false'
+      await dialog.getByRole('button', { name: 'Create sync', exact: true }).click()
+      await dialog.waitFor({ state: 'hidden' })
+
+      const mergePayloadOk =
+        sourceCount === 2 &&
+        appendOnlyExplicit &&
+        createdMergeSync?.mode === 'merge' &&
+        createdMergeSync?.removal_strategy === 'append_only' &&
+        createdMergeSync?.destination?.provider === 'apple' &&
+        createdMergeSync?.destination?.playlist_id === 'pl_apple_4' &&
+        createdMergeSync?.sources?.[0]?.kind === 'library' &&
+        createdMergeSync?.sources?.[0]?.playlist_id === 'pl_spotify_1' &&
+        createdMergeSync?.sources?.[1]?.kind === 'public' &&
+        createdMergeSync?.sources?.[1]?.playlist_id === 'pl_public_link'
+      console.log(`${mergePayloadOk ? 'ok        ' : 'FAIL      '} merge wizard persists ordered library/public sources, one destination, and append-only strategy (got ${JSON.stringify(createdMergeSync)})`)
+      if (!mergePayloadOk) results.push({ label: 'wizard merge payload', overflow: true })
+
+      const mergeCard = page.locator('h3', { hasText: 'Chart mashup' }).locator('xpath=ancestor::div[contains(@class,"rounded-card")][1]')
+      const mergeSummary = await mergeCard.innerText()
+      const mergeSummaryOk = mergeSummary.includes('Merge') && mergeSummary.includes('2 sources') && mergeSummary.includes('append-only')
+      console.log(`${mergeSummaryOk ? 'ok        ' : 'FAIL      '} merge card summarizes aggregate endpoints and append-only behavior`)
+      if (!mergeSummaryOk) results.push({ label: 'merge card summary', overflow: true })
+      await checkOverflow(page, 'Merge sync card after create @ 1280', results)
+
+      await context.close()
+    }
+
+    // -----------------------------------------------------------------
     // Sync "queuing": passes are serialized backend-side, but that no longer
     // means every OTHER job's "Sync now"/"Preview" gets disabled while one
     // runs - only the running job's own buttons, and a queued job's own

--- a/frontend/src/components/sync/MergeFields.tsx
+++ b/frontend/src/components/sync/MergeFields.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from 'react'
+import { LuArrowDown, LuArrowUp, LuLink, LuPlus, LuX } from 'react-icons/lu'
+
+import { api, errorMessage } from '@/api'
+import { useProviderPlaylists } from '@/hooks/useProviderPlaylists'
+import { capabilitiesOf } from '@/lib/accountCapabilities'
+import { tagLabel } from '@/lib/constants'
+import type { Account, SyncDestination, SyncSource } from '@/types'
+
+import { Button } from '../ui/Button'
+import { PlaylistPickerField } from '../ui/PlaylistPickerField'
+import { Segmented } from '../ui/Segmented'
+import { SelectField } from '../ui/SelectField'
+import { TextField } from '../ui/TextField'
+
+const DESTINATION_MODES = [
+  { value: 'existing', label: 'Existing playlist' },
+  { value: 'create', label: 'Create new' },
+]
+
+const SOURCE_MODES = [
+  { value: 'library', label: 'Your library' },
+  { value: 'link', label: 'Paste a link' },
+]
+
+function peers(accounts: Account[]) {
+  return accounts.filter((account) => account.state === 'connected' && account.transferable)
+}
+
+export function MergeDestinationFields({
+  accounts,
+  destination,
+  onChange,
+}: {
+  accounts: Account[]
+  destination: SyncDestination | null
+  onChange: (destination: SyncDestination | null) => void
+}) {
+  const connected = useMemo(
+    () => peers(accounts).filter((account) => capabilitiesOf(account).library_write),
+    [accounts],
+  )
+  const ids = useMemo(() => connected.map((account) => account.id), [connected])
+  const { entries } = useProviderPlaylists(ids)
+  const [mode, setMode] = useState<'existing' | 'create'>(
+    destination && !destination.playlist_id ? 'create' : 'existing',
+  )
+  const provider = destination?.provider ?? ''
+  const writable = (entries[provider]?.playlists ?? []).filter((playlist) => playlist.owned !== false)
+
+  function setProvider(next: string) {
+    onChange(next ? { provider: next, playlist_id: '', name: '' } : null)
+  }
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      <p className="text-xs leading-relaxed text-text-3">
+        The combined membership is reconciled once against this one writable playlist.
+      </p>
+      <SelectField
+        label="Destination service"
+        options={[
+          { value: '', label: 'Choose a service…' },
+          ...connected.map((account) => ({ value: account.id, label: account.name })),
+        ]}
+        value={provider}
+        onChange={(event) => setProvider(event.target.value)}
+      />
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[12.5px] font-semibold text-text-2">Destination playlist</span>
+        <Segmented
+          ariaLabel="Merge destination playlist"
+          options={DESTINATION_MODES}
+          value={mode}
+          onChange={(value) => {
+            const next = value as 'existing' | 'create'
+            setMode(next)
+            if (provider) onChange({ provider, playlist_id: '', name: '' })
+          }}
+        />
+      </div>
+      {mode === 'existing' ? (
+        <PlaylistPickerField
+          label="Existing destination playlist"
+          playlists={writable}
+          loading={entries[provider]?.loading}
+          value={destination?.playlist_id ?? ''}
+          disabled={!provider}
+          onChange={(playlistId) => {
+            const playlist = writable.find((item) => item.id === playlistId)
+            onChange({ provider, playlist_id: playlistId, name: playlist?.name ?? '' })
+          }}
+        />
+      ) : (
+        <TextField
+          label="New destination playlist name"
+          required
+          disabled={!provider}
+          value={destination?.name ?? ''}
+          onChange={(event) => onChange({ provider, playlist_id: '', name: event.target.value })}
+          help="Created on the first real run; its provider id is then saved into this job."
+        />
+      )}
+    </div>
+  )
+}
+
+export function MergeSourcesFields({
+  accounts,
+  sources,
+  destination,
+  onChange,
+}: {
+  accounts: Account[]
+  sources: SyncSource[]
+  destination: SyncDestination | null
+  onChange: (sources: SyncSource[]) => void
+}) {
+  const connected = useMemo(() => peers(accounts), [accounts])
+  const librarySources = useMemo(
+    () => connected.filter((account) => capabilitiesOf(account).library_read),
+    [connected],
+  )
+  const publicSources = useMemo(
+    () => connected.filter((account) => capabilitiesOf(account).public_playlist_read),
+    [connected],
+  )
+  const ids = useMemo(() => librarySources.map((account) => account.id), [librarySources])
+  const { entries } = useProviderPlaylists(ids)
+  const [mode, setMode] = useState<'library' | 'link'>('library')
+  const [provider, setProvider] = useState('')
+  const [playlistId, setPlaylistId] = useState('')
+  const [link, setLink] = useState('')
+  const [opening, setOpening] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const selectedPlaylist = entries[provider]?.playlists.find((playlist) => playlist.id === playlistId)
+  const destinationConflict = sources.some(
+    (source) => source.provider === destination?.provider && source.playlist_id === destination?.playlist_id,
+  )
+
+  function append(source: SyncSource) {
+    if (sources.some((item) => item.provider === source.provider && item.playlist_id === source.playlist_id)) {
+      setError('That playlist is already a source.')
+      return false
+    }
+    if (destination?.provider === source.provider && destination.playlist_id === source.playlist_id) {
+      setError('The destination cannot also be a source.')
+      return false
+    }
+    onChange([...sources, source])
+    setError(null)
+    return true
+  }
+
+  function addLibrarySource() {
+    if (!selectedPlaylist) return
+    if (append({
+      provider,
+      playlist_id: selectedPlaylist.id,
+      name: selectedPlaylist.name,
+      kind: 'library',
+      external_url: selectedPlaylist.external_url || '',
+    })) {
+      setPlaylistId('')
+    }
+  }
+
+  async function addPublicSource() {
+    const url = link.trim()
+    if (!url) return
+    setOpening(true)
+    setError(null)
+    try {
+      const preview = await api.previewTransferSource(url, provider)
+      if (append({
+        provider: preview.account,
+        playlist_id: preview.playlist_id,
+        name: preview.name,
+        kind: 'public',
+        external_url: preview.external_url || url,
+      })) {
+        setLink('')
+      }
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setOpening(false)
+    }
+  }
+
+  function move(index: number, offset: number) {
+    const nextIndex = index + offset
+    if (nextIndex < 0 || nextIndex >= sources.length) return
+    const next = [...sources]
+    ;[next[index], next[nextIndex]] = [next[nextIndex], next[index]]
+    onChange(next)
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="text-xs leading-relaxed text-text-3">
+          Add one or more library playlists or public links. Priority order is stable: each source keeps its provider
+          order, and the first occurrence of an overlapping track wins.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-control border border-border bg-surface-2/40 p-3.5">
+        <Segmented
+          ariaLabel="Merge source type"
+          options={SOURCE_MODES}
+          value={mode}
+          onChange={(value) => {
+            const nextMode = value as 'library' | 'link'
+            setMode(nextMode)
+            const allowed = nextMode === 'library' ? librarySources : publicSources
+            if (!allowed.some((account) => account.id === provider)) setProvider('')
+            setPlaylistId('')
+            setError(null)
+          }}
+        />
+        {mode === 'library' ? (
+          <>
+            <SelectField
+              label="Source service"
+              options={[
+                { value: '', label: 'Choose a service…' },
+                ...librarySources.map((account) => ({ value: account.id, label: account.name })),
+              ]}
+              value={provider}
+              onChange={(event) => {
+                setProvider(event.target.value)
+                setPlaylistId('')
+              }}
+            />
+            <PlaylistPickerField
+              label="Source playlist"
+              playlists={entries[provider]?.playlists ?? []}
+              loading={entries[provider]?.loading}
+              value={playlistId}
+              disabled={!provider}
+              onChange={setPlaylistId}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              icon={<LuPlus className="size-3.5" aria-hidden="true" />}
+              disabled={!selectedPlaylist}
+              onClick={addLibrarySource}
+            >
+              Add source
+            </Button>
+          </>
+        ) : (
+          <>
+            <SelectField
+              label="Open with account"
+              help="The link must belong to the selected account's service."
+              options={[
+                { value: '', label: 'Choose an account…' },
+                ...publicSources.map((account) => ({ value: account.id, label: account.name })),
+              ]}
+              value={provider}
+              onChange={(event) => {
+                setProvider(event.target.value)
+                setPlaylistId('')
+                setError(null)
+              }}
+            />
+            <TextField
+              label="Public playlist link"
+              help="It must be readable through a connected service, but does not need to be saved or followed."
+              placeholder="https://open.spotify.com/playlist/…"
+              value={link}
+              onChange={(event) => {
+                setLink(event.target.value)
+                setError(null)
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  void addPublicSource()
+                }
+              }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              icon={<LuLink className="size-3.5" aria-hidden="true" />}
+              loading={opening}
+              disabled={!provider || !link.trim() || opening}
+              onClick={() => void addPublicSource()}
+            >
+              Open and add source
+            </Button>
+          </>
+        )}
+        {error && <p className="text-xs leading-relaxed text-danger">{error}</p>}
+      </div>
+
+      {sources.length === 0 ? (
+        <p className="rounded-control border border-dashed border-border-strong px-3 py-2.5 text-xs text-text-3">
+          Add at least one source playlist.
+        </p>
+      ) : (
+        <ol aria-label="Merge sources in priority order" className="flex flex-col gap-2">
+          {sources.map((source, index) => (
+            <li key={`${source.provider}:${source.playlist_id}`} className="flex items-center gap-2 rounded-control border border-border px-3 py-2.5">
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-accent-soft font-mono text-[10px] font-bold text-accent">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[13px] font-semibold text-text">{source.name || source.playlist_id}</span>
+                <span className="block font-mono text-[10px] text-text-3">
+                  {connected.find((account) => account.id === source.provider)?.name ?? tagLabel(source.provider)} ·{' '}
+                  {source.kind === 'public' ? 'public link' : 'library'}
+                </span>
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`Move ${source.name || source.playlist_id} up`}
+                disabled={index === 0}
+                onClick={() => move(index, -1)}
+                icon={<LuArrowUp className="size-3.5" aria-hidden="true" />}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`Move ${source.name || source.playlist_id} down`}
+                disabled={index === sources.length - 1}
+                onClick={() => move(index, 1)}
+                icon={<LuArrowDown className="size-3.5" aria-hidden="true" />}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`Remove ${source.name || source.playlist_id}`}
+                onClick={() => onChange(sources.filter((_, itemIndex) => itemIndex !== index))}
+                icon={<LuX className="size-3.5" aria-hidden="true" />}
+              />
+            </li>
+          ))}
+        </ol>
+      )}
+      {destinationConflict && (
+        <p className="text-xs leading-relaxed text-danger">
+          The destination cannot also be one of the source playlists. Choose a different destination or remove it
+          from this list.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -26,7 +26,18 @@ import {
   syncPeersOf,
 } from '@/lib/syncSummary'
 import { PlaylistFilterField } from '../settings/PlaylistFilterField'
-import type { Account, LikedTrackRoute, LikedTrackRoutes, SyncJob, SyncJobUpsertRequest, SyncMode } from '@/types'
+import { MergeDestinationFields, MergeSourcesFields } from './MergeFields'
+import type {
+  Account,
+  LikedTrackRoute,
+  LikedTrackRoutes,
+  MergeRemovalStrategy,
+  SyncDestination,
+  SyncJob,
+  SyncJobUpsertRequest,
+  SyncMode,
+  SyncSource,
+} from '@/types'
 
 // Kept as strings locally (not the SyncJob numbers) so they compose directly
 // with TextField and the existing string-based validators; converted to
@@ -49,6 +60,9 @@ interface JobFormState {
   max_removals: string
   apply_large_removals: boolean
   download: boolean
+  sources: SyncSource[]
+  destination: SyncDestination | null
+  removal_strategy: MergeRemovalStrategy
 }
 
 const NEW_JOB_DEFAULTS: JobFormState = {
@@ -68,6 +82,9 @@ const NEW_JOB_DEFAULTS: JobFormState = {
   max_removals: '25',
   apply_large_removals: false,
   download: false,
+  sources: [],
+  destination: null,
+  removal_strategy: 'append_only',
 }
 
 function formFromJob(job: SyncJob | null): JobFormState {
@@ -85,11 +102,14 @@ function formFromJob(job: SyncJob | null): JobFormState {
     liked_routes: { ...(job.liked_routes ?? {}) },
     interval: job.interval,
     max_adds: String(job.max_adds),
-    mirror_removals: job.max_removals > 0,
+    mirror_removals: job.mode === 'merge' ? job.removal_strategy === 'mirror' : job.max_removals > 0,
     // Keep a sane cap staged so switching mirroring on doesn't start from 0.
     max_removals: job.max_removals > 0 ? String(job.max_removals) : '25',
     apply_large_removals: job.apply_large_removals,
     download: job.download,
+    sources: [...(job.sources ?? [])],
+    destination: job.destination ? { ...job.destination } : null,
+    removal_strategy: job.removal_strategy ?? 'append_only',
   }
 }
 
@@ -392,6 +412,12 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
         const providers = new Set(parseCsv(prev.providers))
         if (prev.source) providers.add(prev.source)
         next.providers = csvInPeerOrder(providers)
+      } else if (mode === 'merge') {
+        next.sync_playlists = true
+        next.liked_tracks = false
+        next.liked_routes = {}
+        next.download = false
+        next.mirror_removals = next.removal_strategy === 'mirror'
       }
       if (next.liked_tracks) {
         next.liked_routes = normalizedLikedRoutes(next.liked_routes, parseCsv(next.providers), next.source)
@@ -543,12 +569,29 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
           return route?.kind === 'native' || (route?.kind === 'playlist' && route.name.trim().length > 0)
         }))
   const resourceSelectionValid = form.sync_playlists || form.liked_tracks
+  const mergeDestinationValid =
+    form.mode !== 'merge' ||
+    Boolean(form.destination?.provider && (form.destination.playlist_id || form.destination.name.trim()))
+  const mergeSourcesValid =
+    form.mode !== 'merge' ||
+    (form.sources.length > 0 &&
+      !form.sources.some(
+        (source) =>
+          source.provider === form.destination?.provider && source.playlist_id === form.destination?.playlist_id,
+      ))
   const formValid =
-    nameValid && intervalValid && maxAddsValid && maxRemovalsValid && groupValid && likedRoutesValid && resourceSelectionValid
+    nameValid && intervalValid && maxAddsValid && maxRemovalsValid && groupValid &&
+    likedRoutesValid && resourceSelectionValid && mergeDestinationValid && mergeSourcesValid
 
   // Only Direction's name (always valid) aside, Schedule (interval) and
   // Limits (caps) are the only steps with a bad state to block Next on.
-  const stepValid = [groupValid, true, likedRoutesValid && resourceSelectionValid, intervalValid, maxAddsValid && maxRemovalsValid]
+  const stepValid = [
+    groupValid,
+    mergeDestinationValid,
+    form.mode === 'merge' ? mergeSourcesValid : likedRoutesValid && resourceSelectionValid,
+    intervalValid,
+    maxAddsValid && maxRemovalsValid,
+  ]
   const isLastStep = step === STEPS.length - 1
 
   const previewJob: SyncJob = {
@@ -568,6 +611,11 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     max_removals: form.mirror_removals ? Number(form.max_removals) || 0 : 0,
     apply_large_removals: form.mirror_removals && form.apply_large_removals,
     download: form.download,
+    sources: form.sources,
+    destination: form.destination,
+    removal_strategy: form.mode === 'merge'
+      ? (form.mirror_removals ? 'mirror' : 'append_only')
+      : form.removal_strategy,
   }
   const summaryRows = buildSyncSummaryRows(previewJob, syncPeers, settings?.DOWNLOAD_DIR)
 
@@ -580,18 +628,28 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
         name: form.name.trim(),
         enabled: form.enabled,
         mode: form.mode,
-        source: form.source,
+        source: form.mode === 'merge' ? (form.sources[0]?.provider || form.source) : form.source,
         authorities: form.authorities,
-        providers: form.providers,
+        providers: form.mode === 'merge'
+          ? [...new Set([
+              ...form.sources.map((source) => source.provider),
+              ...(form.destination?.provider ? [form.destination.provider] : []),
+            ])].join(',')
+          : form.providers,
         playlists: form.playlists,
-        sync_playlists: form.sync_playlists,
-        liked_tracks: form.liked_tracks,
-        liked_routes: form.liked_routes,
+        sync_playlists: form.mode === 'merge' ? true : form.sync_playlists,
+        liked_tracks: form.mode === 'merge' ? false : form.liked_tracks,
+        liked_routes: form.mode === 'merge' ? {} : form.liked_routes,
         interval: form.interval,
         max_adds: Number(form.max_adds),
         max_removals: form.mirror_removals ? Number(form.max_removals) : 0,
         apply_large_removals: form.mirror_removals && form.apply_large_removals,
-        download: form.download,
+        download: form.mode === 'merge' ? false : form.download,
+        sources: form.mode === 'merge' ? form.sources : [],
+        destination: form.mode === 'merge' ? form.destination : null,
+        removal_strategy: form.mode === 'merge'
+          ? (form.mirror_removals ? 'mirror' : 'append_only')
+          : form.removal_strategy,
       }
       if (job) await api.updateSync(job.id, values)
       else await api.createSync(values)
@@ -670,7 +728,14 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                   onChange={() => selectMode('group')}
                   title="Authority group ⇆"
                   description="Two or more trusted services contribute changes; every other selected service only mirrors them."
-                  className="sm:col-span-2"
+                />
+                <RadioCard
+                  name="sync-mode"
+                  value="merge"
+                  checked={form.mode === 'merge'}
+                  onChange={() => selectMode('merge')}
+                  title="Merge sources →"
+                  description="Combine multiple library playlists or public links into one scheduled destination playlist."
                 />
               </div>
 
@@ -769,39 +834,55 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
           )}
 
           {step === 1 && (
-            <div className="flex flex-wrap gap-2">
-              {syncPeers.map((account) => {
-                const locked = lockedProviderIds.has(account.id)
-                const checked = locked || enabledProviders.has(account.id)
-                const role =
-                  form.mode === 'group'
-                    ? account.id === syncSource && authorityIds.has(account.id)
-                      ? 'order'
-                      : authorityIds.has(account.id)
-                        ? 'authority'
-                        : checked
-                          ? 'mirror'
-                          : undefined
-                    : form.mode === 'oneway' && account.id === syncSource
-                      ? 'source'
-                      : form.liked_tracks && account.id === syncSource
+            form.mode === 'merge' ? (
+              <MergeDestinationFields
+                accounts={accounts}
+                destination={form.destination}
+                onChange={(destination) => setField('destination', destination)}
+              />
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {syncPeers.map((account) => {
+                  const locked = lockedProviderIds.has(account.id)
+                  const checked = locked || enabledProviders.has(account.id)
+                  const role =
+                    form.mode === 'group'
+                      ? account.id === syncSource && authorityIds.has(account.id)
+                        ? 'order'
+                        : authorityIds.has(account.id)
+                          ? 'authority'
+                          : checked
+                            ? 'mirror'
+                            : undefined
+                      : form.mode === 'oneway' && account.id === syncSource
                         ? 'source'
-                      : undefined
-                return (
-                  <ProviderChip
-                    key={account.id}
-                    account={account}
-                    checked={checked}
-                    locked={locked}
-                    role={role}
-                    onToggle={() => toggleProvider(account.id)}
-                  />
-                )
-              })}
-            </div>
+                        : form.liked_tracks && account.id === syncSource
+                          ? 'source'
+                        : undefined
+                  return (
+                    <ProviderChip
+                      key={account.id}
+                      account={account}
+                      checked={checked}
+                      locked={locked}
+                      role={role}
+                      onToggle={() => toggleProvider(account.id)}
+                    />
+                  )
+                })}
+              </div>
+            )
           )}
 
           {step === 2 && (
+            form.mode === 'merge' ? (
+              <MergeSourcesFields
+                accounts={accounts}
+                sources={form.sources}
+                destination={form.destination}
+                onChange={(sources) => setField('sources', sources)}
+              />
+            ) : (
             <div className="flex flex-col gap-4">
               <PlaylistFilterField
                 value={form.playlists}
@@ -889,6 +970,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                 </section>
               )}
             </div>
+            )
           )}
 
           {step === 3 && (
@@ -955,9 +1037,11 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     className="flex-1"
                     checked={form.mirror_removals}
                     onChange={(v) => setField('mirror_removals', v)}
-                    label="Mirror removals"
+                    label={form.mode === 'merge' ? 'Remove tracks absent from every source' : 'Mirror removals'}
                     description={
-                      form.mode === 'group'
+                      form.mode === 'merge'
+                        ? 'Off: append-only; destination-only tracks are always kept. On: remove a track only after a complete pass confirms it is absent from every source.'
+                        : form.mode === 'group'
                         ? 'Off (default): removals and mirror-only tracks are kept. On: confirmed removals from either authority—and tracks found only on mirrors—are pruned everywhere, capped per pass.'
                         : form.mode === 'nway'
                           ? 'Off (default): a track removed on one service is kept on the others. On: confirmed removals from any service sync too, capped per pass.'
@@ -967,7 +1051,12 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                   <Tooltip
                     content={
                       <>
-                        {form.mode === 'group' ? (
+                        {form.mode === 'merge' ? (
+                          <>
+                            Every source must be read completely before a removal is allowed. Any failed or partial
+                            source read disables all removals for that pass.
+                          </>
+                        ) : form.mode === 'group' ? (
                           <>
                             A confirmed removal on <span className="font-semibold text-text">either authority</span>, or
                             a track added only to a mirror, is removed across the group. Mirror edits never become
@@ -987,7 +1076,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                   >
                     <button
                       type="button"
-                      aria-label="About mirroring removals"
+                      aria-label={form.mode === 'merge' ? 'About aggregate removals' : 'About mirroring removals'}
                       className="cursor-help rounded-full p-1 text-text-3 transition-colors duration-fast hover:text-warning focus-visible:text-warning"
                     >
                       <LuInfo size={15} />
@@ -1005,12 +1094,19 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
               </div>
 
               <div className="border-t border-border pt-3.5">
-                <Toggle
-                  checked={form.download}
-                  onChange={(v) => setField('download', v)}
-                  label="Download this sync's playlists"
-                  description="Uses the folder and format configured in Settings → Download mirror."
-                />
+                {form.mode === 'merge' ? (
+                  <p className="text-xs leading-relaxed text-text-3">
+                    Aggregate jobs write one provider playlist. The separate download mirror currently follows
+                    ordinary Spotify-led playlist jobs and is unavailable here.
+                  </p>
+                ) : (
+                  <Toggle
+                    checked={form.download}
+                    onChange={(v) => setField('download', v)}
+                    label="Download this sync's playlists"
+                    description="Uses the folder and format configured in Settings → Download mirror."
+                  />
+                )}
               </div>
 
               <div className="flex flex-col gap-2.5 rounded-control border border-border bg-surface-2/40 p-3.5">

--- a/frontend/src/hooks/useSyncs.ts
+++ b/frontend/src/hooks/useSyncs.ts
@@ -12,7 +12,7 @@ function isSyncJobArray(value: unknown): value is SyncJob[] {
         typeof job.id === 'string' &&
         typeof job.name === 'string' &&
         typeof job.enabled === 'boolean' &&
-        (job.mode === 'oneway' || job.mode === 'group' || job.mode === 'nway') &&
+        (job.mode === 'oneway' || job.mode === 'group' || job.mode === 'nway' || job.mode === 'merge') &&
         ('authorities' in job ? typeof job.authorities === 'string' : true),
     )
   )

--- a/frontend/src/lib/syncSummary.ts
+++ b/frontend/src/lib/syncSummary.ts
@@ -63,6 +63,35 @@ export function buildSyncSummaryRows(job: SyncJob, peers: Account[], downloadDir
 
   rows.push({ label: 'Schedule', value: job.enabled ? `Every ${job.interval || '?'}` : 'Manual' })
 
+  if (job.mode === 'merge') {
+    const providerName = (id: string) => peers.find((peer) => peer.id === id)?.name ?? id
+    const sources = job.sources ?? []
+    const sourceNames = sources.map((source) => source.name || `${providerName(source.provider)} playlist`)
+    const sourceLabel =
+      sourceNames.length === 0
+        ? 'no sources selected'
+        : sourceNames.length <= 3
+          ? sourceNames.join(' + ')
+          : `${sourceNames.slice(0, 3).join(' + ')} +${sourceNames.length - 3} more`
+    const destination = job.destination
+    const destinationLabel = destination
+      ? `${destination.name || 'chosen playlist'} on ${providerName(destination.provider)}`
+      : 'no destination selected'
+    rows.push({ label: 'Direction', value: `Merge · ${sources.length} source${sources.length === 1 ? '' : 's'} → ${destinationLabel}` })
+    rows.push({ label: 'Sources', value: sourceLabel })
+
+    const removalNote = job.apply_large_removals ? ' (large removals drained in batches)' : ''
+    rows.push({
+      label: 'Limits',
+      value:
+        job.removal_strategy === 'mirror'
+          ? `≤${job.max_adds} adds, ≤${job.max_removals} removals / pass${removalNote}`
+          : `≤${job.max_adds} adds / pass · append-only`,
+    })
+    rows.push({ label: 'Downloads', value: 'Off for aggregate playlists' })
+    return rows
+  }
+
   const enabled = enabledProvidersOf(job, peers)
   const lockedId = lockedSourceOf(job)
   const authorities = authorityProvidersOf(job)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -195,6 +195,21 @@ export interface PassSummary {
   ok: boolean
   error: string | null
   per_target: TargetSummary[]
+  /** Merge-only constituent read/dedupe/deletion-guard accounting. */
+  aggregate?: AggregatePassSummary
+}
+
+export interface AggregatePassSummary {
+  sources: number
+  sources_read: number
+  sources_failed: number
+  input_tracks: number
+  union_tracks: number
+  duplicates: number
+  removal_strategy: MergeRemovalStrategy
+  removals_guarded: boolean
+  destination_provider: string
+  destination_playlist_id: string
 }
 
 /** One entry of GET /api/sync/status's `jobs` array — this job's own
@@ -214,6 +229,10 @@ export interface SyncJobStatus {
   pending: 'pause' | 'stop' | null
   next_run_at: number | null
   last: PassSummary | null
+  sync_mode?: SyncMode
+  source_count?: number
+  destination?: SyncDestination | null
+  removal_strategy?: MergeRemovalStrategy
 }
 
 export interface SyncStatus {
@@ -238,7 +257,30 @@ export interface SyncStatus {
   jobs: SyncJobStatus[]
 }
 
-export type SyncMode = 'oneway' | 'group' | 'nway'
+export type SyncMode = 'oneway' | 'group' | 'nway' | 'merge'
+
+export type SyncSourceKind = 'library' | 'public'
+export type MergeRemovalStrategy = 'append_only' | 'mirror'
+
+/** One ordered merge constituent. Public links are resolved once to the same
+ * provider/id shape used by library rows, so scheduled runs never depend on a
+ * source being followed or saved. */
+export interface SyncSource {
+  /** Stable account profile id (legacy payloads may contain a provider id). */
+  provider: string
+  playlist_id: string
+  name: string
+  kind: SyncSourceKind
+  external_url: string
+}
+
+/** A blank playlist_id creates `name` on the first execute pass. */
+export interface SyncDestination {
+  /** Stable account profile id (legacy payloads may contain a provider id). */
+  provider: string
+  playlist_id: string
+  name: string
+}
 
 export type LikedTrackRoute =
   | { kind: 'native' }
@@ -278,6 +320,11 @@ export interface SyncJob {
    * instead of being held back. Default false (held back for safety). */
   apply_large_removals: boolean
   download: boolean
+  /** Ordered constituent sources and one destination for merge mode. Empty/null
+   * on legacy one-way, authority-group, and N-way jobs. */
+  sources: SyncSource[]
+  destination: SyncDestination | null
+  removal_strategy: MergeRemovalStrategy
 }
 
 /** POST /api/syncs (create) / PUT /api/syncs/{id} (merge-update) body —

--- a/songmirror/engine/aggregation.py
+++ b/songmirror/engine/aggregation.py
@@ -1,0 +1,157 @@
+"""Deterministic membership union for multi-source merge syncs.
+
+Source priority is explicit and durable: descriptors are visited in stored
+order, and each provider's playlist rows are visited in their returned order.
+The first copy of a recording therefore owns its display metadata and position;
+later copies only enrich missing identity metadata. Additions are emitted in
+that exact order (``added_at`` is cleared so the one-way reconciler does not
+re-sort unrelated providers' timestamps).
+
+Deduplication prefers a shared normalized ISRC. Without one, exact normalized
+title/artist evidence must also pass the conservative recording check, including
+duration and creative-version qualifiers. This is intentionally stricter than
+fuzzy destination-removal protection: a false negative is an extra candidate,
+while a false positive silently loses a constituent source track.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from .matching import (
+    catalog_name,
+    normalize_isrc,
+    same_catalog_recording,
+    spotify_track_keys,
+    track_key,
+)
+from .targets.base import _normalize
+
+
+@dataclass
+class AggregateSourceSnapshot:
+    """One completely or partially read source playlist, in descriptor order."""
+
+    provider: str
+    playlist_id: str
+    tracks: list[dict]
+    track_id_of: Callable[[dict], object]
+
+
+@dataclass
+class AggregateTracks:
+    tracks: list[dict]
+    input_tracks: int
+    duplicates: int
+
+
+def _synthetic_id(track, provider, provider_track_id):
+    isrc = normalize_isrc(track.get("isrc"))
+    if isrc:
+        return f"isrc:{isrc}"
+    if provider_track_id is not None and str(provider_track_id):
+        return f"{provider}:{provider_track_id}"
+    return f"key:{track_key(track.get('name', ''), track.get('artist', ''))}"
+
+
+def aggregate_source_tracks(
+    snapshots: Iterable[AggregateSourceSnapshot],
+) -> AggregateTracks:
+    """Return the deterministic, recording-deduplicated union of snapshots."""
+    union = []
+    by_isrc = {}
+    by_provider_id = {}
+    by_key = {}
+    by_name = {}
+    input_tracks = 0
+
+    for source_rank, snapshot in enumerate(snapshots):
+        for playlist_position, raw in enumerate(snapshot.tracks):
+            input_tracks += 1
+            normalized = _normalize(raw, snapshot.provider)
+            normalized["_aggregate_source_rank"] = source_rank
+            normalized["_playlist_position"] = playlist_position
+            # Cross-provider added-at values answer different questions and
+            # cannot define a truthful mashup chronology. Descriptor order and
+            # playlist position are the documented stable ordering contract.
+            normalized["added_at"] = ""
+            provider_track_id = snapshot.track_id_of(raw)
+            provider_identity = (
+                (snapshot.provider, str(provider_track_id))
+                if provider_track_id is not None and str(provider_track_id)
+                else None
+            )
+            isrc = normalize_isrc(normalized.get("isrc"))
+            keys = sorted(spotify_track_keys(normalized))
+
+            # A provider catalog id is conclusive within that provider and also
+            # catches repeated occurrences from two constituent playlists even
+            # when one read has weaker or newly edited display metadata.
+            duplicate_index = (
+                by_provider_id.get(provider_identity)
+                if provider_identity is not None
+                else None
+            )
+            if duplicate_index is None and isrc:
+                duplicate_index = by_isrc.get(isrc)
+            if duplicate_index is None:
+                candidates = sorted({
+                    *(by_key[key] for key in keys if key in by_key),
+                    *by_name.get(catalog_name(normalized.get("name", "")), ()),
+                })
+                duplicate_index = next(
+                    (
+                        index
+                        for index in candidates
+                        if not (
+                            isrc
+                            and normalize_isrc(union[index].get("isrc"))
+                            and isrc != normalize_isrc(union[index].get("isrc"))
+                        )
+                        and same_catalog_recording(normalized, union[index])
+                    ),
+                    None,
+                )
+
+            if duplicate_index is None:
+                normalized["id"] = _synthetic_id(
+                    normalized, snapshot.provider, provider_track_id
+                )
+                normalized["_provider_ids"] = (
+                    {snapshot.provider: str(provider_track_id)}
+                    if provider_track_id is not None and str(provider_track_id)
+                    else {}
+                )
+                duplicate_index = len(union)
+                union.append(normalized)
+            else:
+                representative = union[duplicate_index]
+                if provider_track_id is not None and str(provider_track_id):
+                    representative.setdefault("_provider_ids", {}).setdefault(
+                        snapshot.provider, str(provider_track_id)
+                    )
+                # Let a later ISRC-rich provider strengthen an earlier public
+                # row without changing which source owns the ordering/labels.
+                if isrc and not normalize_isrc(representative.get("isrc")):
+                    representative["isrc"] = isrc
+                    representative["id"] = f"isrc:{isrc}"
+                if representative.get("duration_ms") is None and normalized.get("duration_ms") is not None:
+                    representative["duration_ms"] = normalized["duration_ms"]
+
+            if isrc:
+                by_isrc.setdefault(isrc, duplicate_index)
+            if provider_identity is not None:
+                by_provider_id.setdefault(provider_identity, duplicate_index)
+            # Index every copy's exact keys. Provider credit variations can
+            # bridge a later third source even though the first copy lacks that
+            # particular per-artist key.
+            for key in keys:
+                by_key.setdefault(key, duplicate_index)
+            by_name.setdefault(catalog_name(normalized.get("name", "")), set()).add(
+                duplicate_index
+            )
+
+    return AggregateTracks(
+        tracks=union,
+        input_tracks=input_tracks,
+        duplicates=input_tracks - len(union),
+    )

--- a/songmirror/engine/config.py
+++ b/songmirror/engine/config.py
@@ -17,7 +17,7 @@ DEFAULT_CACHE_FILE = "apple_resolve_cache.json"
 DEFAULT_SONG_CACHE_FILE = "song_cache.db"
 DEFAULT_STOREFRONT = "us"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:8888/callback"
-DEFAULT_SYNC_MODE = "oneway"                          # oneway | group | nway
+DEFAULT_SYNC_MODE = "oneway"                          # oneway | group | nway | merge
 DEFAULT_PROVIDERS = "spotify,tidal,qobuz,deezer,amazon,apple,ytmusic"  # participating providers
 DEFAULT_SYNC_SOURCE = "spotify"                       # one-way source of truth (any connected provider)
 DEFAULT_SPOTIFY_CACHE_FILE = "spotify_resolve_cache.json"
@@ -89,6 +89,13 @@ class Options:
     sync_playlists: bool = True
     liked_tracks: bool = False
     liked_routes: dict = field(default_factory=dict)
+    # Web-created merge jobs resolve public URLs once and pass durable provider
+    # playlist descriptors into the engine. These defaults keep CLI and every
+    # stored pre-merge job byte-for-byte on the legacy execution paths.
+    sources: list[dict] = field(default_factory=list)
+    destination: dict | None = None
+    removal_strategy: str = "append_only"
+    sync_job_id: str = ""
 
 
 def parse_args(argv=None):
@@ -122,9 +129,9 @@ def parse_args(argv=None):
     p.add_argument("--song-cache-file", default=os.getenv("SONG_CACHE_FILE", DEFAULT_SONG_CACHE_FILE),
                    help=f"Ever-growing SQLite song archive (default: {DEFAULT_SONG_CACHE_FILE}).")
     p.add_argument("--sync-mode", default=os.getenv("SYNC_MODE", DEFAULT_SYNC_MODE),
-                   choices=("oneway", "group", "nway"),
+                   choices=("oneway", "group", "nway", "merge"),
                    help="oneway = one source; group = selected authorities feed mirrors; "
-                        "nway = every provider is bidirectional.")
+                        "nway = every provider is bidirectional; merge = web job with explicit playlists.")
     p.add_argument("--providers", default=os.getenv("PROVIDERS", DEFAULT_PROVIDERS),
                    help=f"Providers participating in sync, comma-separated (default: {DEFAULT_PROVIDERS}).")
     p.add_argument("--sync-source", default=os.getenv("SYNC_SOURCE", DEFAULT_SYNC_SOURCE),

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -14,6 +14,7 @@ from contextlib import nullcontext
 from dotenv import load_dotenv
 
 from . import archive, spotify, spotify_cookie
+from .aggregation import AggregateSourceSnapshot, aggregate_source_tracks
 from .config import spotify_write_backend
 from .logs import fmt_counts, fmt_secs, log, log_note, log_section, log_summary, log_warn, paint
 from .targets import (
@@ -140,9 +141,10 @@ def _summary_entry(name, agg):
     return entry
 
 
-def _summary(opts, per_target, started, *, ok=True, error=None, interrupted=None):
+def _summary(opts, per_target, started, *, ok=True, error=None, interrupted=None,
+             aggregate=None):
     """The value the web layer renders after a pass. The CLI ignores it."""
-    return {
+    summary = {
         "mode": opts.sync_mode,
         "execute": opts.execute,
         "duration_s": round(time.monotonic() - started, 1),
@@ -151,6 +153,288 @@ def _summary(opts, per_target, started, *, ok=True, error=None, interrupted=None
         "interrupted": interrupted,  # "pause" | "stop" when a Stop/Pause cut the pass short
         "per_target": per_target,
     }
+    if aggregate is not None:
+        summary["aggregate"] = aggregate
+    return summary
+
+
+def _merge_failure(agg, source, message):
+    """Record one bounded, user-facing source failure in an aggregate pass."""
+    agg["failed"] += 1
+    if len(agg["failures"]) < FAILURE_DETAIL:
+        agg["failures"].append({
+            "playlist": source.get("name") or source.get("playlist_id") or "Source",
+            "provider": source.get("provider", ""),
+            "error": str(message),
+        })
+
+
+def _run_merge(opts, sp, should_continue=None):
+    """Read every explicit source and reconcile their union once.
+
+    A failed, truncated, malformed, unavailable, or unknowably-empty source is
+    allowed to contribute whatever valid rows it did return, but disables every
+    destination removal for this pass. This is the fail-closed property that
+    independent source→destination jobs cannot provide.
+    """
+    ctrl = should_continue or (lambda: "run")
+    descriptors = list(getattr(opts, "sources", None) or [])
+    destination_spec = dict(getattr(opts, "destination", None) or {})
+    aggregate = {
+        "sources": len(descriptors),
+        "sources_read": 0,
+        "sources_failed": 0,
+        "input_tracks": 0,
+        "union_tracks": 0,
+        "duplicates": 0,
+        "removal_strategy": getattr(opts, "removal_strategy", "append_only"),
+        "removals_guarded": False,
+        "destination_provider": destination_spec.get("provider", ""),
+        "destination_playlist_id": destination_spec.get("playlist_id", ""),
+    }
+    destination_label = destination_spec.get("name") or destination_spec.get("playlist_id") or "Destination"
+    agg = {
+        "name": destination_label,
+        "pairs": 0, "added": 0, "removed": 0, "missing": 0, "held": 0,
+        "uncertain_matches": 0, "deferred": 0, "removals_skipped": 0,
+        "chronology_replayed": 0, "created": 0, "skipped": 0, "failed": 0,
+        "read_anomalies": 0, "held_removals": [], "change_diagnostics": [],
+        "failures": [],
+    }
+
+    providers = {}
+    destination_identity = destination_spec.get("provider")
+
+    def provider(provider_id):
+        if provider_id not in providers:
+            providers[provider_id] = build_one(
+                provider_id,
+                opts,
+                sp,
+                sync_peer=provider_id == destination_identity,
+            )
+        return providers[provider_id]
+
+    snapshots = []
+    incomplete = False
+    for descriptor in descriptors:
+        if ctrl() != "run":
+            incomplete = True
+            break
+        try:
+            source = provider(descriptor.get("provider"))
+        except Exception as exc:
+            incomplete = True
+            _merge_failure(agg, descriptor, str(exc) or repr(exc))
+            log_warn(
+                f"aggregate source {descriptor.get('name') or descriptor.get('playlist_id')}: "
+                f"provider setup failed ({exc!r}); removals disabled for this pass",
+                tag=descriptor.get("provider") or "sync",
+            )
+            continue
+        if source is None:
+            incomplete = True
+            _merge_failure(agg, descriptor, "source provider is not connected")
+            continue
+        playlist = None
+        try:
+            playlist = source.find_playlist(descriptor.get("playlist_id"))
+            if playlist is None:
+                playlist = source.fetch_playlist(descriptor.get("playlist_id"))
+            if playlist is None:
+                raise RuntimeError(
+                    "playlist could not be opened; it may be private or no longer available"
+                )
+            reader = getattr(
+                source, "playlist_tracks_for_transfer", source.playlist_tracks
+            )
+            rows = list(reader(playlist))
+        except Exception as exc:
+            incomplete = True
+            _merge_failure(agg, descriptor, str(exc) or repr(exc))
+            log_warn(
+                f"aggregate source {descriptor.get('name') or descriptor.get('playlist_id')}: "
+                f"read failed ({exc!r}); removals disabled for this pass",
+                tag=getattr(source, "tag", "sync"),
+            )
+            continue
+
+        valid_rows = [
+            row for row in rows
+            if isinstance(row, dict)
+            and str(row.get("name") or "").strip()
+            and not row.get("unavailable")
+        ]
+        invalid_count = len(rows) - len(valid_rows)
+        invalid_count_value = False
+        try:
+            expected_count = source.playlist_count(playlist)
+            expected_count_value = (
+                int(expected_count) if expected_count is not None else None
+            )
+            invalid_count_value = (
+                expected_count_value is not None and expected_count_value < 0
+            )
+        except Exception as exc:
+            expected_count = f"unavailable: {exc}"
+            expected_count_value = None
+            invalid_count_value = True
+        count_shortfall = (
+            expected_count_value is not None
+            and expected_count_value > len(rows)
+        )
+        unknowable_empty = expected_count is None and not rows
+        if invalid_count or invalid_count_value or count_shortfall or unknowable_empty:
+            incomplete = True
+            agg["read_anomalies"] += 1
+            reasons = []
+            if invalid_count:
+                reasons.append(f"{invalid_count} unavailable or malformed entries")
+            if count_shortfall:
+                reasons.append(f"expected {expected_count} rows but received {len(rows)}")
+            if invalid_count_value:
+                reasons.append(f"provider returned an invalid track count ({expected_count!r})")
+            if unknowable_empty:
+                reasons.append("empty response with no authoritative track count")
+            message = "; ".join(reasons)
+            _merge_failure(agg, descriptor, message)
+            log_warn(
+                f"aggregate source {source.playlist_name(playlist)} was incomplete ({message}); "
+                "removals disabled for this pass",
+                tag=source.tag,
+            )
+        else:
+            aggregate["sources_read"] += 1
+        snapshots.append(AggregateSourceSnapshot(
+            provider=target_provider(source, source.source),
+            playlist_id=str(descriptor.get("playlist_id") or ""),
+            tracks=valid_rows,
+            track_id_of=source.track_id,
+        ))
+
+    aggregate["sources_failed"] = agg["failed"]
+    try:
+        merged = aggregate_source_tracks(snapshots)
+    except Exception as exc:
+        aggregate["removals_guarded"] = True
+        error = f"aggregate source rows could not be normalized: {exc}"
+        _merge_failure(agg, {"name": destination_label}, error)
+        log_warn(error, tag="sync")
+        return [_summary_entry(destination_label, agg)], aggregate, False, error
+    aggregate.update({
+        "input_tracks": merged.input_tracks,
+        "union_tracks": len(merged.tracks),
+        "duplicates": merged.duplicates,
+    })
+    if not snapshots:
+        aggregate["removals_guarded"] = True
+        error = "no aggregate source could be read"
+        log_warn(error, tag="sync")
+        return [_summary_entry(destination_label, agg)], aggregate, False, error
+
+    try:
+        destination = provider(destination_spec.get("provider"))
+    except Exception as exc:
+        _merge_failure(agg, {"name": destination_label, **destination_spec}, str(exc) or repr(exc))
+        aggregate["removals_guarded"] = True
+        log_warn(f"aggregate destination setup failed: {exc!r}", tag=destination_spec.get("provider") or "sync")
+        return [_summary_entry(destination_label, agg)], aggregate, False, str(exc) or repr(exc)
+    if destination is None:
+        _merge_failure(agg, {"name": destination_label, **destination_spec},
+                       "destination provider is not connected")
+        aggregate["removals_guarded"] = True
+        return [_summary_entry(destination_label, agg)], aggregate, False, "destination provider is not connected"
+
+    destination_playlist = None
+    destination_id = str(destination_spec.get("playlist_id") or "")
+    try:
+        if destination_id:
+            # A destination must remain a library playlist so its ownership and
+            # editability flags are available. Public fetch fallback is source-only.
+            destination_playlist = destination.find_playlist(destination_id)
+            if destination_playlist is None:
+                raise RuntimeError("destination playlist was not found in the connected library")
+        elif opts.execute:
+            destination_playlist = destination.create({
+                "name": destination_label,
+                "description": f"Aggregate of {len(descriptors)} playlists.",
+            })
+            agg["created"] = 1
+            destination_id = str(destination.playlist_id(destination_playlist) or "")
+            aggregate["destination_playlist_id"] = destination_id
+            log_note(
+                f"created {destination.name} aggregate playlist '{destination_label}'",
+                tag=destination.tag,
+            )
+        else:
+            log_note(
+                f"{destination_label}: destination would be created on --execute",
+                tag=destination.tag,
+            )
+            agg["skipped"] = 1
+            aggregate["removals_guarded"] = True
+            return [_summary_entry(destination.name, agg)], aggregate, agg["failed"] == 0, None
+        if not destination.is_editable(destination_playlist):
+            raise RuntimeError("destination playlist is not editable")
+    except Exception as exc:
+        _merge_failure(agg, {"name": destination_label, **destination_spec}, str(exc) or repr(exc))
+        aggregate["removals_guarded"] = True
+        log_warn(f"aggregate destination failed: {exc!r}", tag=destination.tag)
+        return [_summary_entry(destination.name, agg)], aggregate, False, str(exc) or repr(exc)
+
+    strategy = getattr(opts, "removal_strategy", "append_only")
+    removals_guarded = incomplete or strategy == "append_only"
+    aggregate["removals_guarded"] = removals_guarded
+    effective_max_removals = 0 if removals_guarded else opts.max_removals
+    source_label = f"{len(descriptors)}-source union"
+    cache = load_cache(destination.cache_file)
+    songs = archive.connect(opts.song_cache_file)
+    try:
+        result = mirror_pair(
+            destination,
+            merged.tracks,
+            {"id": f"merge:{getattr(opts, 'sync_job_id', '')}", "name": destination_label},
+            destination_playlist,
+            cache,
+            songs,
+            execute=opts.execute,
+            max_removals=effective_max_removals,
+            max_adds=opts.max_adds,
+            drain_removals=opts.apply_large_removals,
+            should_continue=ctrl,
+            source_key=f"merge:{getattr(opts, 'sync_job_id', '') or destination_id}",
+            source_name=source_label,
+            name=destination_label,
+            # A known-empty union is meaningful only after every source was
+            # read completely; legacy one-way keeps its empty-read guard.
+            allow_empty_source=not incomplete,
+        )
+    except Exception as exc:
+        _merge_failure(agg, {"name": destination_label, **destination_spec}, str(exc) or repr(exc))
+        log_warn(f"aggregate reconcile failed: {exc!r}", tag=destination.tag)
+        return [_summary_entry(destination.name, agg)], aggregate, False, str(exc) or repr(exc)
+    finally:
+        save_cache(destination.cache_file, cache)
+        songs.close()
+
+    agg["pairs"] = 1
+    for key in (
+        "added", "removed", "missing", "held", "uncertain_matches", "deferred",
+        "removals_skipped", "chronology_replayed",
+    ):
+        agg[key] += result.get(key, 0)
+    _collect_held(agg["held_removals"], result.get("held_removals", []))
+    _collect_diagnostics(agg["change_diagnostics"], result.get("change_diagnostics", []))
+    per_target = _summary_entry(destination.name, agg)
+    per_target["aggregate"] = dict(aggregate)
+    ok = agg["failed"] == 0
+    error = (
+        f"{agg['failed']} aggregate source read{'s' if agg['failed'] != 1 else ''} "
+        "were incomplete; removals were disabled"
+        if agg["failed"]
+        else None
+    )
+    return [per_target], aggregate, ok, error
 
 
 def _load_links(opts=None):
@@ -425,21 +709,43 @@ def run_pass(opts, should_continue=None):
     with _ENV_LOCK:
         load_dotenv(os.getenv("SONGMIRROR_ENV_FILE") or ".env", override=True)
     profiles = getattr(opts, "account_profiles", None)
+    merge_mode = opts.sync_mode == "merge"
     wanted_providers = _wanted_providers(opts)
     if profiles is not None:
-        participant_ids = list(dict.fromkeys(profiles.expand_ids(opts.providers)))
+        if merge_mode:
+            opts.sources = [
+                {**source, "provider": profiles.canonical_id(source.get("provider"))}
+                for source in (getattr(opts, "sources", None) or [])
+            ]
+            if getattr(opts, "destination", None) is not None:
+                opts.destination = {
+                    **opts.destination,
+                    "provider": profiles.canonical_id(opts.destination.get("provider")),
+                }
+            participant_ids = list(dict.fromkeys([
+                *(source.get("provider") for source in opts.sources),
+                (opts.destination or {}).get("provider"),
+            ]))
+            participant_ids = [identity for identity in participant_ids if identity]
+        else:
+            participant_ids = list(dict.fromkeys(profiles.expand_ids(opts.providers)))
+            opts.sync_source = profiles.canonical_id(opts.sync_source)
+            opts.authorities = ",".join(profiles.expand_ids(opts.authorities))
+            opts.liked_routes = {
+                profiles.canonical_id(identity): route
+                for identity, route in (getattr(opts, "liked_routes", None) or {}).items()
+            }
         wanted_providers = set(participant_ids)
         opts.providers = ",".join(participant_ids)
-        opts.sync_source = profiles.canonical_id(opts.sync_source)
-        opts.authorities = ",".join(profiles.expand_ids(opts.authorities))
-        opts.liked_routes = {
-            profiles.canonical_id(identity): route
-            for identity, route in (getattr(opts, "liked_routes", None) or {}).items()
-        }
         spotify_requested = not wanted_providers or any(
             profiles.provider_of(identity) == "spotify" for identity in wanted_providers
         )
     else:
+        if merge_mode:
+            wanted_providers = {
+                *(source.get("provider") for source in (getattr(opts, "sources", None) or [])),
+                (getattr(opts, "destination", None) or {}).get("provider"),
+            } - {None, ""}
         spotify_requested = not wanted_providers or "spotify" in wanted_providers
     # Group mode's order authority also supplies playlist names and ordering.
     # It remains writable because additions from another authority flow back.
@@ -448,8 +754,18 @@ def run_pass(opts, should_continue=None):
     # N-way/group execute, or a one-way execute where another provider is the
     # source and Spotify is one of the targets.
     source_provider_type = profiles.provider_of(source_provider) if profiles is not None else source_provider
-    spotify_is_target = (opts.sync_mode == "oneway" and source_provider_type != "spotify"
-                         and spotify_requested)
+    destination_identity = (getattr(opts, "destination", None) or {}).get("provider")
+    destination_provider_type = (
+        profiles.provider_of(destination_identity) if profiles is not None
+        else destination_identity
+    )
+    spotify_is_target = (
+        (opts.sync_mode == "oneway" and source_provider_type != "spotify" and spotify_requested)
+        or (
+            merge_mode
+            and destination_provider_type == "spotify"
+        )
+    )
     sp = None
     cookie_spotify = spotify_write_backend() == "cookie" and spotify_cookie.configured()
     if profiles is None and (source_provider == "spotify" or spotify_requested):
@@ -463,6 +779,23 @@ def run_pass(opts, should_continue=None):
                 if source_provider == "spotify":
                     raise
                 log_note(f"Spotify skipped: {exc}", tag="spotify")
+
+    if merge_mode:
+        mode = paint("EXECUTE", "green", "bold") if opts.execute else paint("DRY RUN", "yellow", "bold")
+        log(paint("═══ Omni playlist mirror ═══", "bold", "cyan"))
+        log(f"  mode: {mode}{paint('   ⇉ MERGE', 'magenta', 'bold')}")
+        log(f"  sources: {paint(str(len(getattr(opts, 'sources', None) or [])), 'bold')} constituent playlist(s)")
+        per_target, aggregate, ok, error = _run_merge(opts, sp, ctrl)
+        c = ctrl()
+        return _summary(
+            opts,
+            per_target,
+            pass_started,
+            ok=ok,
+            error=error,
+            interrupted=(None if c == "run" else c),
+            aggregate=aggregate,
+        )
 
     # The library whose playlists drive this pass: a configured participant for
     # N-way; the chosen source/order authority for one-way and group modes.

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -238,9 +238,18 @@ def _run_merge(opts, sp, should_continue=None):
             continue
         playlist = None
         try:
-            playlist = source.find_playlist(descriptor.get("playlist_id"))
-            if playlist is None:
+            if descriptor.get("kind") == "public":
+                # A resolved public source must not depend on the signed-in
+                # user's library scan. This is required for catalog-only URLs
+                # (notably Apple) and avoids turning an unrelated library read
+                # failure into a failed public snapshot.
                 playlist = source.fetch_playlist(descriptor.get("playlist_id"))
+            else:
+                playlist = source.find_playlist(descriptor.get("playlist_id"))
+                if playlist is None:
+                    # A formerly followed/library playlist can remain publicly
+                    # readable after it leaves the library.
+                    playlist = source.fetch_playlist(descriptor.get("playlist_id"))
             if playlist is None:
                 raise RuntimeError(
                     "playlist could not be opened; it may be private or no longer available"

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -612,7 +612,8 @@ def _enrich_hard_isrcs(songs, source_key, source_tracks):
 
 def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, execute, max_removals,
                 max_adds, drain_removals=False, should_continue=None, source_key="spotify",
-                source_provider=None, source_name="Spotify", name=None):
+                source_provider=None, source_name="Spotify", name=None,
+                allow_empty_source=False):
     """Reconcile one source→target playlist pair. Returns a stats dict; `clean`
     is True when everything applied with no guard tripped.
 
@@ -645,6 +646,18 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         source_id: set(target_ids)
         for source_id, target_ids in target.expected_ids(sp_tracks, links, cache).items()
     }
+    # Aggregate rows remember the physical ids supplied by every constituent
+    # provider. A same-provider merge can therefore prove membership directly
+    # instead of searching its own catalog, and a duplicate seen in several
+    # sources can use whichever copy belongs to this destination.
+    target_provider = getattr(target, "provider", None) or target.source
+    for track in sp_tracks:
+        provider_ids = track.get("_provider_ids") or {}
+        direct_id = provider_ids.get(target.source)
+        if direct_id is None:
+            direct_id = provider_ids.get(target_provider)
+        if direct_id is not None and track.get("id"):
+            expected_by_source.setdefault(track["id"], set()).add(direct_id)
     to_add, to_remove = compute_diff(
         sp_tracks, tgt_tracks, expected_by_source, target.track_id
     )
@@ -666,8 +679,11 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
             stopped_early = True  # Pause/Stop — defer the rest; keep the pass "not clean" below
             break
         label = f"{track['name']} - {', '.join(track['artists'])}"
-        tid = links.get(track.get("id"))
-        method = "link" if tid else None
+        tid = (track.get("_provider_ids") or {}).get(target.source)
+        method = "source id" if tid else None
+        if not tid:
+            tid = links.get(track.get("id"))
+            method = "link" if tid else None
         try:
             if tid:
                 validator = getattr(target, "validate_link", None)
@@ -773,7 +789,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
     removals, uncertain_matches = match_unresolved_removals(to_remove, not_found)
     held = [existing for existing, _unresolved in uncertain_matches]
     removals_skipped, held_back = 0, []
-    if not sp_tracks and tgt_tracks:
+    if not sp_tracks and tgt_tracks and not allow_empty_source:
         log_warn(f"{source_name} returned 0 tracks but {target.name} has {len(tgt_tracks)}; skipping all removals this pass", tag=tag)
         removals, guard = [], True
     elif len(removals) > max_removals:

--- a/songmirror/services/sync_service.py
+++ b/songmirror/services/sync_service.py
@@ -17,6 +17,7 @@ through the EventBus.
 import asyncio
 import os
 import time
+from dataclasses import asdict
 
 from ..engine import logs
 from ..engine.config import DEFAULT_INTERVAL, parse_args, parse_interval
@@ -68,6 +69,10 @@ class SyncService:
         opts.sync_playlists = job.sync_playlists
         opts.liked_tracks = job.liked_tracks
         opts.liked_routes = job.liked_routes
+        opts.sources = [asdict(source) for source in job.sources]
+        opts.destination = asdict(job.destination) if job.destination is not None else None
+        opts.removal_strategy = job.removal_strategy
+        opts.sync_job_id = job.id
         opts.max_adds = job.max_adds
         opts.max_removals = job.max_removals
         opts.apply_large_removals = job.apply_large_removals
@@ -97,10 +102,33 @@ class SyncService:
                 self._control = "run"
                 self._interrupted.pop(job_id, None)
                 try:
-                    self._emit("section", f"{job.name}: pass started ({'execute' if execute else 'dry run'})", "sync")
+                    if job.mode == "merge" and job.destination is not None:
+                        detail = (
+                            f"{len(job.sources)} source{'s' if len(job.sources) != 1 else ''} → "
+                            f"{job.destination.name or job.destination.playlist_id}"
+                        )
+                        self._emit(
+                            "section",
+                            f"{job.name}: aggregate pass started ({'execute' if execute else 'dry run'}; {detail})",
+                            "sync",
+                        )
+                    else:
+                        self._emit("section", f"{job.name}: pass started ({'execute' if execute else 'dry run'})", "sync")
                     summary = await _run_pass_async(self._opts_for(job, execute),
                                                     should_continue=lambda: self._control)
                     summary.update(job_id=job_id, job_name=job.name)
+                    aggregate = summary.get("aggregate") or {}
+                    created_destination_id = aggregate.get("destination_playlist_id")
+                    if (
+                        execute
+                        and created_destination_id
+                        and job.destination is not None
+                        and not job.destination.playlist_id
+                    ):
+                        # Creation is part of the serialized pass, so no later
+                        # scheduled/manual run can race this durable id update.
+                        job.destination.playlist_id = str(created_destination_id)
+                        self._syncs.upsert(job)
                     self._last[job_id] = self._last_any = summary
                     if summary.get("interrupted"):
                         self._interrupted[job_id] = "paused" if summary["interrupted"] == "pause" else "stopped"
@@ -216,8 +244,9 @@ class SyncService:
         }
 
     def _job_status(self, job):
-        return {
+        status = {
             "id": job.id, "name": job.name, "enabled": job.enabled,
+            "sync_mode": job.mode,
             "running": self._running_job == job.id,
             # Triggered but waiting behind the shared lock for the running pass to
             # finish — passes are serialized (shared caches/archive/rate limits),
@@ -231,6 +260,13 @@ class SyncService:
             "next_run_at": self._next_run.get(job.id),
             "last": self._last.get(job.id),
         }
+        if job.mode == "merge":
+            status.update({
+                "source_count": len(job.sources),
+                "destination": asdict(job.destination) if job.destination is not None else None,
+                "removal_strategy": job.removal_strategy,
+            })
+        return status
 
     def _interval_s(self, value):
         try:

--- a/songmirror/services/syncs.py
+++ b/songmirror/services/syncs.py
@@ -6,8 +6,10 @@ OWN auto-sync interval. The download mirror stays global (SettingsStore's
 DOWNLOAD_DIR/LOCAL_MIRROR_FORMAT) — a job just opts in via `download`.
 
 Persisted to data/syncs.json (owner-only) alongside the other data-dir state.
-The engine is unchanged: SyncService builds an Options per job and runs it, so
-each job is an ordinary pass.
+Most jobs select playlists by name from one or more connected libraries. Merge
+jobs instead persist explicit source and destination descriptors. A source can
+be a library row or a public playlist URL resolved to the same provider/id
+pair; the engine therefore has one durable representation for both kinds.
 """
 
 import json
@@ -19,6 +21,8 @@ from ..engine.config import (
     DEFAULT_INTERVAL, DEFAULT_MAX_ADDS, DEFAULT_MAX_REMOVALS, DEFAULT_PROVIDERS,
     DEFAULT_SYNC_MODE, DEFAULT_SYNC_SOURCE,
 )
+from ..engine.targets import provider_ids
+from .playlist_links import PLAYLIST_LINK_HINT, PlaylistLinkError, parse_playlist_link
 from .settings import _open_private
 
 # Before named jobs stored an explicit provider list, an empty value meant
@@ -30,10 +34,39 @@ LEGACY_NAMED_JOB_PROVIDERS = "spotify,apple,ytmusic"
 
 
 @dataclass
+class SyncSource:
+    """One ordered constituent of a merge job.
+
+    ``kind`` is presentation metadata: both library and public sources execute
+    by provider + playlist id. Keeping the resolved public URL makes an edited
+    job understandable without making a scheduled pass re-parse or follow it.
+    """
+
+    provider: str
+    playlist_id: str
+    name: str = ""
+    kind: str = "library"                 # library | public
+    external_url: str = ""
+
+
+@dataclass
+class SyncDestination:
+    """The single writable playlist receiving a merge job's membership union.
+
+    An empty playlist id means create ``name`` on the first execute pass. Once
+    created, SyncService persists the returned id before a later pass can run.
+    """
+
+    provider: str
+    playlist_id: str = ""
+    name: str = ""
+
+
+@dataclass
 class SyncJob:
     name: str = "Sync"
     enabled: bool = True                      # participates in scheduled auto-sync
-    mode: str = DEFAULT_SYNC_MODE             # oneway | group | nway
+    mode: str = DEFAULT_SYNC_MODE             # oneway | group | nway | merge
     source: str = DEFAULT_SYNC_SOURCE         # one-way source / group order authority
     authorities: str = ""                    # group membership authorities, comma-separated
     providers: str = DEFAULT_PROVIDERS        # comma-separated participating providers
@@ -46,29 +79,168 @@ class SyncJob:
     max_removals: int = DEFAULT_MAX_REMOVALS
     apply_large_removals: bool = False        # drain removals over max_removals across passes (default: hold back)
     download: bool = False                    # opt into the global download mirror
+    sources: list[SyncSource] = field(default_factory=list)  # merge source priority order
+    destination: SyncDestination | None = None               # merge's one writable target
+    removal_strategy: str = "append_only"                    # append_only | mirror
     id: str = ""
 
 
-VALID_SYNC_MODES = {"oneway", "group", "nway"}
+VALID_SYNC_MODES = {"oneway", "group", "nway", "merge"}
+VALID_SOURCE_KINDS = {"library", "public"}
+VALID_REMOVAL_STRATEGIES = {"append_only", "mirror"}
+_PROVIDER_IDS = frozenset(provider_ids())
+
+
+def source_from_value(value, profiles=None):
+    """Normalize an API/stored merge source into :class:`SyncSource`.
+
+    API callers may provide only ``url``/``external_url``. It is parsed with
+    the same allow-listed provider URL parser as one-off transfers; scheduled
+    runs persist and use the resolved id, never the pasted text as a request
+    URL. Already-resolved stored rows do not re-parse on every process start.
+    """
+    if isinstance(value, SyncSource):
+        source = value
+    elif isinstance(value, dict):
+        data = dict(value)
+        pasted_url = str(data.pop("url", "") or "").strip()
+        external_url = str(data.get("external_url") or "").strip()
+        provider = str(data.get("provider") or "").strip()
+        playlist_id = str(data.get("playlist_id") or "").strip()
+        kind = str(data.get("kind") or "").strip()
+        # ``url`` is the API shorthand for a public source. ``external_url``
+        # is also retained on library descriptors for display, so only treat it
+        # as the source of identity when the row says public (or has no ids).
+        parse_url = pasted_url or (
+            external_url if kind == "public" or not (provider and playlist_id) else ""
+        )
+        if parse_url:
+            try:
+                parsed = parse_playlist_link(parse_url)
+            except PlaylistLinkError:
+                raise
+            if parsed is None:
+                raise ValueError(PLAYLIST_LINK_HINT)
+            parsed_provider, parsed_playlist_id = parsed
+            selected_provider = (
+                profiles.provider_of(provider) if profiles is not None else provider
+            )
+            if provider and selected_provider != parsed_provider:
+                raise ValueError("public playlist URL does not match its source provider")
+            if playlist_id and playlist_id != parsed_playlist_id:
+                raise ValueError("public playlist URL does not match its source playlist id")
+            provider = provider or parsed_provider
+            playlist_id = parsed_playlist_id
+            kind = "public"
+        source = SyncSource(
+            provider=provider,
+            playlist_id=playlist_id,
+            name=str(data.get("name") or "").strip(),
+            kind=kind or ("public" if pasted_url else "library"),
+            external_url=external_url or pasted_url,
+        )
+    else:
+        raise ValueError("each merge source must be an object")
+    source.provider = str(source.provider or "").strip()
+    if profiles is not None:
+        source.provider = profiles.canonical_id(source.provider)
+    source.playlist_id = str(source.playlist_id or "").strip()
+    source.name = str(source.name or "").strip()
+    source.kind = str(source.kind or "library").strip()
+    source.external_url = str(source.external_url or "").strip()
+    return source
+
+
+def destination_from_value(value, profiles=None):
+    if value is None or isinstance(value, SyncDestination):
+        destination = value
+    elif isinstance(value, dict):
+        destination = SyncDestination(
+            provider=str(value.get("provider") or "").strip(),
+            playlist_id=str(value.get("playlist_id") or "").strip(),
+            name=str(value.get("name") or "").strip(),
+        )
+    else:
+        raise ValueError("merge destination must be an object")
+    if destination is not None:
+        destination.provider = str(destination.provider or "").strip()
+        if profiles is not None:
+            destination.provider = profiles.canonical_id(destination.provider)
+        destination.playlist_id = str(destination.playlist_id or "").strip()
+        destination.name = str(destination.name or "").strip()
+    return destination
+
+
+def sync_job_from_dict(value, profiles=None):
+    """Load a current or legacy JSON/API row with nested defaults applied."""
+    data = dict(value)
+    data["sources"] = [
+        source_from_value(item, profiles) for item in data.get("sources") or []
+    ]
+    data["destination"] = destination_from_value(data.get("destination"), profiles)
+    return SyncJob(**data)
 
 
 def _provider_ids(value):
     return {part.strip() for part in str(value or "").split(",") if part.strip()}
 
 
-def validate_sync_job(job):
+def validate_sync_job(job, profiles=None):
     """Reject configurations whose direction cannot be reconciled safely.
 
     Existing one-way and N-way jobs do not need an ``authorities`` value. An
     authoritative group does: every authority must participate, and the
     provider whose playlist supplies names/order must itself be authoritative.
     """
+    job.sources = [source_from_value(item, profiles) for item in (job.sources or [])]
+    job.destination = destination_from_value(job.destination, profiles)
+    job.removal_strategy = str(job.removal_strategy or "append_only").strip()
     if job.mode not in VALID_SYNC_MODES:
         raise ValueError(f"mode must be one of: {', '.join(sorted(VALID_SYNC_MODES))}")
     if job.max_adds < 1:
         raise ValueError("max_adds must be at least 1")
     if job.max_removals < 0:
         raise ValueError("max_removals must be at least 0")
+    if job.mode == "merge":
+        if not job.sources:
+            raise ValueError("a merge sync needs at least one source playlist")
+        seen = set()
+        for source in job.sources:
+            provider_type = (
+                profiles.provider_of(source.provider) if profiles is not None
+                else source.provider
+            )
+            if provider_type not in _PROVIDER_IDS:
+                raise ValueError(f"unknown merge source provider: {source.provider or '(missing)'}")
+            if not source.playlist_id:
+                raise ValueError("every merge source needs a playlist id or public playlist URL")
+            if source.kind not in VALID_SOURCE_KINDS:
+                raise ValueError("merge source kind must be library or public")
+            identity = (source.provider, source.playlist_id)
+            if identity in seen:
+                raise ValueError("the same source playlist cannot be added twice")
+            seen.add(identity)
+        destination = job.destination
+        destination_provider = (
+            profiles.provider_of(destination.provider)
+            if profiles is not None and destination is not None
+            else destination.provider if destination is not None else None
+        )
+        if destination is None or destination_provider not in _PROVIDER_IDS:
+            raise ValueError("a merge sync needs a destination provider")
+        if not destination.playlist_id and not destination.name:
+            raise ValueError("a merge destination needs an existing playlist or a new playlist name")
+        if (destination.provider, destination.playlist_id) in seen:
+            raise ValueError("the merge destination cannot also be one of its sources")
+        if job.removal_strategy not in VALID_REMOVAL_STRATEGIES:
+            raise ValueError("removal_strategy must be append_only or mirror")
+        if job.removal_strategy == "mirror" and job.max_removals < 1:
+            raise ValueError("mirror removal strategy needs max_removals of at least 1")
+        if job.liked_tracks:
+            raise ValueError("merge sync sources must be playlists, not liked-track collections")
+        if job.download:
+            raise ValueError("the local download mirror is not available for merge syncs")
+        return job
     if not job.sync_playlists and not job.liked_tracks:
         raise ValueError("select regular playlists, liked tracks, or both")
     if job.liked_tracks:
@@ -119,6 +291,10 @@ class SyncStore:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._profiles = profiles
 
+    @property
+    def profiles(self):
+        return self._profiles
+
     def list(self):
         try:
             with open(self._path, encoding="utf-8") as f:
@@ -145,8 +321,22 @@ class SyncStore:
                         self._profiles.canonical_id(identity): route
                         for identity, route in (data.get("liked_routes") or {}).items()
                     }
+                    data["sources"] = [
+                        {
+                            **source,
+                            "provider": self._profiles.canonical_id(source.get("provider")),
+                        }
+                        for source in (data.get("sources") or [])
+                    ]
+                    if data.get("destination") is not None:
+                        data["destination"] = {
+                            **data["destination"],
+                            "provider": self._profiles.canonical_id(
+                                data["destination"].get("provider")
+                            ),
+                        }
                     migrated = migrated or data != before
-                jobs.append(SyncJob(**data))
+                jobs.append(sync_job_from_dict(data, self._profiles))
             if migrated:
                 self._save(jobs)
             return jobs
@@ -157,7 +347,7 @@ class SyncStore:
         return next((j for j in self.list() if j.id == job_id), None)
 
     def upsert(self, job):
-        validate_sync_job(job)
+        validate_sync_job(job, self._profiles)
         if not job.id:
             job.id = uuid.uuid4().hex[:8]
         jobs = [j for j in self.list() if j.id != job.id]

--- a/songmirror/web/routers/syncs.py
+++ b/songmirror/web/routers/syncs.py
@@ -10,16 +10,17 @@ from dataclasses import asdict
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from ...services.syncs import SyncJob, validate_sync_job
+from ...services.syncs import sync_job_from_dict, validate_sync_job
 
 router = APIRouter()
 
 _FIELDS = {"name", "enabled", "mode", "source", "authorities", "providers", "playlists", "sync_playlists",
            "liked_tracks", "liked_routes",
-           "interval", "max_adds", "max_removals", "apply_large_removals", "download", "id"}
+           "interval", "max_adds", "max_removals", "apply_large_removals", "download",
+           "sources", "destination", "removal_strategy", "id"}
 
 
-def _job_from(values):
+def _job_from(values, profiles=None):
     """SyncJob from a request dict — unknown keys dropped, types coerced."""
     data = {k: v for k, v in values.items() if k in _FIELDS}
     for k in ("max_adds", "max_removals"):
@@ -29,7 +30,7 @@ def _job_from(values):
         if k in data:
             data[k] = bool(data[k])
     try:
-        return validate_sync_job(SyncJob(**data))
+        return validate_sync_job(sync_job_from_dict(data, profiles), profiles)
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -41,7 +42,9 @@ def list_syncs(request: Request):
 
 @router.post("/api/syncs")
 async def create_sync(request: Request, values: dict = Body(...)):
-    job = request.app.state.syncs.upsert(_job_from(values))
+    job = request.app.state.syncs.upsert(
+        _job_from(values, request.app.state.syncs.profiles)
+    )
     await request.app.state.sync.reconcile()
     return asdict(job)
 
@@ -51,7 +54,10 @@ async def update_sync(job_id: str, request: Request, values: dict = Body(...)):
     existing = request.app.state.syncs.get(job_id)
     if existing is None:
         return JSONResponse({"detail": "not found"}, status_code=404)
-    job = request.app.state.syncs.upsert(_job_from({**asdict(existing), **values, "id": job_id}))
+    job = request.app.state.syncs.upsert(_job_from(
+        {**asdict(existing), **values, "id": job_id},
+        request.app.state.syncs.profiles,
+    ))
     await request.app.state.sync.reconcile()
     return asdict(job)
 

--- a/tests/test_merge_sync.py
+++ b/tests/test_merge_sync.py
@@ -44,6 +44,7 @@ class _Provider(MirrorTarget):
         self.public = {}
         self.rows = {}
         self.fail = set()
+        self.find_fail = set()
         self.fetches = []
         self.catalog = {}
 
@@ -59,6 +60,8 @@ class _Provider(MirrorTarget):
         return playlist
 
     def find_playlist(self, playlist_id):
+        if str(playlist_id) in self.find_fail:
+            raise RuntimeError("library directory unavailable")
         return self.library.get(str(playlist_id))
 
     def fetch_playlist(self, playlist_id):
@@ -249,6 +252,7 @@ def test_mixed_library_and_public_sources_reconcile_one_union(monkeypatch, tmp_p
     deezer = _Provider("deezer", tmp_path)
     spotify.add_playlist("library", [_track("One"), _track("Shared", isrc="S1")])
     apple.add_playlist("public", [_track("Shared", isrc="S1"), _track("Two")], public=True)
+    apple.find_fail.add("public")
     destination = deezer.add_playlist("destination", [], name="Mashup")
     _install_providers(monkeypatch, {p.source: p for p in (spotify, apple, deezer)})
 
@@ -262,6 +266,8 @@ def test_mixed_library_and_public_sources_reconcile_one_union(monkeypatch, tmp_p
     ), None)
 
     assert ok is True and error is None
+    # Public descriptors bypass the connected-library lookup entirely. The
+    # test provider would raise if `_run_merge` attempted it.
     assert apple.fetches == ["public"]
     assert aggregate == {
         "sources": 2, "sources_read": 2, "sources_failed": 0,

--- a/tests/test_merge_sync.py
+++ b/tests/test_merge_sync.py
@@ -1,0 +1,431 @@
+"""Public/multi-source sync: descriptors, deterministic union, and fail-closed writes."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from songmirror.engine.aggregation import AggregateSourceSnapshot, aggregate_source_tracks
+from songmirror.engine.runner import _run_merge
+from songmirror.engine.targets.base import MirrorTarget
+from songmirror.services.account_profiles import AccountProfileStore
+from songmirror.services.events import EventBus
+from songmirror.services.settings import SettingsStore
+from songmirror.services.sync_service import SyncService
+from songmirror.services.syncs import (
+    SyncDestination,
+    SyncJob,
+    SyncSource,
+    SyncStore,
+    validate_sync_job,
+)
+from songmirror.web import create_app
+
+
+def _track(value, *, provider_id=None, isrc=None, duration=180_000):
+    return {
+        "id": provider_id or value.lower(),
+        "name": value,
+        "artists": ["Artist"],
+        "artist": "Artist",
+        "duration_ms": duration,
+        "isrc": isrc,
+        "added_at": "2026-01-01T00:00:00Z",
+    }
+
+
+class _Provider(MirrorTarget):
+    def __init__(self, source, tmp_path):
+        self.source = self.tag = source
+        self.name = source.title()
+        self.cache_file = str(tmp_path / f"{source}.json")
+        self.library = {}
+        self.public = {}
+        self.rows = {}
+        self.fail = set()
+        self.fetches = []
+        self.catalog = {}
+
+    def add_playlist(self, playlist_id, rows, *, public=False, name=None):
+        playlist = {
+            "id": playlist_id,
+            "name": name or playlist_id,
+            "count": len(rows),
+            "_owned": not public,
+        }
+        (self.public if public else self.library)[playlist_id] = playlist
+        self.rows[playlist_id] = list(rows)
+        return playlist
+
+    def find_playlist(self, playlist_id):
+        return self.library.get(str(playlist_id))
+
+    def fetch_playlist(self, playlist_id):
+        self.fetches.append(str(playlist_id))
+        return self.public.get(str(playlist_id))
+
+    def playlist_tracks(self, playlist):
+        playlist_id = playlist["id"]
+        if playlist_id in self.fail:
+            raise RuntimeError(f"{playlist_id} unavailable")
+        return list(self.rows[playlist_id])
+
+    def playlist_count(self, playlist):
+        return playlist.get("count")
+
+    def playlist_id(self, playlist):
+        return playlist["id"]
+
+    def playlist_name(self, playlist):
+        return playlist["name"]
+
+    def playlist_description(self, playlist):
+        return ""
+
+    def track_id(self, track):
+        return track.get("id")
+
+    def prefetch(self, tracks, cache):
+        return None
+
+    def resolve(self, track, cache):
+        target_id = f"{self.source}:{track['name'].casefold()}"
+        self.catalog[target_id] = {
+            "id": target_id,
+            "name": track["name"],
+            "artists": list(track["artists"]),
+            "artist": track["artist"],
+            "duration_ms": track.get("duration_ms"),
+            "isrc": track.get("isrc"),
+        }
+        return target_id, "search"
+
+    def add(self, playlist, target_ids):
+        self.rows[playlist["id"]].extend(dict(self.catalog[target_id]) for target_id in target_ids)
+        playlist["count"] = len(self.rows[playlist["id"]])
+
+    def remove(self, playlist, track):
+        rows = self.rows[playlist["id"]]
+        rows.remove(track)
+        playlist["count"] = len(rows)
+
+    def create(self, source_playlist):
+        playlist_id = f"created-{len(self.library) + 1}"
+        return self.add_playlist(playlist_id, [], name=source_playlist["name"])
+
+
+def _opts(tmp_path, sources, destination, *, strategy="mirror"):
+    return SimpleNamespace(
+        sources=sources,
+        destination=destination,
+        removal_strategy=strategy,
+        execute=True,
+        max_removals=25,
+        max_adds=200,
+        apply_large_removals=False,
+        song_cache_file=str(tmp_path / "songs.db"),
+        sync_job_id="merge-job",
+    )
+
+
+def _install_providers(monkeypatch, providers):
+    monkeypatch.setattr(
+        "songmirror.engine.runner.build_one",
+        lambda provider_id, _opts, _sp=None, **_kwargs: providers.get(provider_id),
+    )
+
+
+def test_url_only_source_descriptor_uses_transfer_playlist_parser():
+    job = validate_sync_job(SyncJob(
+        name="Charts",
+        mode="merge",
+        sources=[{"url": "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"}],
+        destination={"provider": "deezer", "playlist_id": "123", "name": "Charts"},
+    ))
+
+    assert job.sources == [SyncSource(
+        provider="spotify",
+        playlist_id="37i9dQZF1DXcBWIGoYBM5M",
+        name="",
+        kind="public",
+        external_url="https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+    )]
+
+
+def test_merge_descriptors_preserve_selected_profiles_and_migrate_legacy_ids(tmp_path):
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    alex = profiles.create("spotify", "Alex")
+    store = SyncStore(dir=tmp_path, profiles=profiles)
+
+    selected = store.upsert(SyncJob(
+        name="Household charts",
+        mode="merge",
+        sources=[{
+            "provider": alex.id,
+            "url": "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+        }],
+        destination={"provider": "apple", "playlist_id": "dest", "name": "Charts"},
+    ))
+
+    assert selected.sources[0].provider == alex.id
+    assert selected.destination.provider == profiles.default_id("apple")
+
+    legacy_dir = tmp_path / "legacy"
+    legacy = SyncStore(dir=legacy_dir).upsert(SyncJob(
+        name="Legacy merge",
+        mode="merge",
+        sources=[SyncSource("spotify", "source", "Source")],
+        destination=SyncDestination("apple", "dest", "Destination"),
+    ))
+    migrated = SyncStore(dir=legacy_dir, profiles=profiles).get(legacy.id)
+
+    assert migrated.sources[0].provider == profiles.default_id("spotify")
+    assert migrated.destination.provider == profiles.default_id("apple")
+
+
+def test_merge_job_api_persists_url_source_and_explicit_strategy(tmp_path):
+    store = SyncStore(dir=tmp_path)
+    with TestClient(create_app(settings=SettingsStore(dir=tmp_path), syncs=store)) as client:
+        response = client.post("/api/syncs", json={
+            "name": "Public charts",
+            "mode": "merge",
+            "sources": [{"url": "https://music.youtube.com/playlist?list=PL-public"}],
+            "destination": {
+                "provider": "apple", "playlist_id": "dest", "name": "Charts",
+            },
+            "removal_strategy": "mirror",
+            "max_removals": 10,
+        })
+
+    assert response.status_code == 200
+    created = response.json()
+    assert created["sources"] == [{
+        "provider": "ytmusic",
+        "playlist_id": "PL-public",
+        "name": "",
+        "kind": "public",
+        "external_url": "https://music.youtube.com/playlist?list=PL-public",
+    }]
+    assert created["removal_strategy"] == "mirror"
+    assert store.get(created["id"]).sources[0].playlist_id == "PL-public"
+
+
+def test_merge_union_dedupes_overlap_and_keeps_source_priority_order():
+    spotify_rows = [_track("First", isrc="US-AAA-26-00001"), _track("Second")]
+    apple_rows = [
+        _track("First", provider_id="apple-first", isrc="USAAA2600001"),
+        _track("Third"),
+    ]
+    merged = aggregate_source_tracks([
+        AggregateSourceSnapshot("spotify", "s", spotify_rows, lambda row: row["id"]),
+        AggregateSourceSnapshot("apple", "a", apple_rows, lambda row: row["id"]),
+    ])
+
+    assert [track["name"] for track in merged.tracks] == ["First", "Second", "Third"]
+    assert merged.input_tracks == 4
+    assert merged.duplicates == 1
+    assert merged.tracks[0]["_provider_ids"] == {
+        "spotify": "first", "apple": "apple-first",
+    }
+
+    same_catalog_id = aggregate_source_tracks([
+        AggregateSourceSnapshot(
+            "spotify", "one", [_track("Original title", provider_id="same-id")],
+            lambda row: row["id"],
+        ),
+        AggregateSourceSnapshot(
+            "spotify", "two", [_track("Renamed edition", provider_id="same-id")],
+            lambda row: row["id"],
+        ),
+    ])
+    assert [track["name"] for track in same_catalog_id.tracks] == ["Original title"]
+    assert same_catalog_id.duplicates == 1
+
+
+def test_mixed_library_and_public_sources_reconcile_one_union(monkeypatch, tmp_path):
+    spotify = _Provider("spotify", tmp_path)
+    apple = _Provider("apple", tmp_path)
+    deezer = _Provider("deezer", tmp_path)
+    spotify.add_playlist("library", [_track("One"), _track("Shared", isrc="S1")])
+    apple.add_playlist("public", [_track("Shared", isrc="S1"), _track("Two")], public=True)
+    destination = deezer.add_playlist("destination", [], name="Mashup")
+    _install_providers(monkeypatch, {p.source: p for p in (spotify, apple, deezer)})
+
+    per_target, aggregate, ok, error = _run_merge(_opts(
+        tmp_path,
+        [
+            {"provider": "spotify", "playlist_id": "library", "name": "Library", "kind": "library"},
+            {"provider": "apple", "playlist_id": "public", "name": "Public", "kind": "public"},
+        ],
+        {"provider": "deezer", "playlist_id": destination["id"], "name": "Mashup"},
+    ), None)
+
+    assert ok is True and error is None
+    assert apple.fetches == ["public"]
+    assert aggregate == {
+        "sources": 2, "sources_read": 2, "sources_failed": 0,
+        "input_tracks": 4, "union_tracks": 3, "duplicates": 1,
+        "removal_strategy": "mirror", "removals_guarded": False,
+        "destination_provider": "deezer", "destination_playlist_id": "destination",
+    }
+    assert per_target[0]["added"] == 3
+    assert [row["name"] for row in deezer.rows["destination"]] == ["One", "Shared", "Two"]
+
+
+def test_removal_waits_until_every_source_drops_track(monkeypatch, tmp_path):
+    first = _Provider("spotify", tmp_path)
+    second = _Provider("apple", tmp_path)
+    destination = _Provider("deezer", tmp_path)
+    first_pl = first.add_playlist("first", [_track("Shared", isrc="S1")])
+    second_pl = second.add_playlist("second", [_track("Shared", isrc="S1")])
+    dest_pl = destination.add_playlist("dest", [], name="Union")
+    _install_providers(monkeypatch, {p.source: p for p in (first, second, destination)})
+    opts = _opts(tmp_path, [
+        {"provider": "spotify", "playlist_id": "first", "name": "First"},
+        {"provider": "apple", "playlist_id": "second", "name": "Second"},
+    ], {"provider": "deezer", "playlist_id": "dest", "name": "Union"})
+
+    _run_merge(opts, None)
+    assert len(destination.rows["dest"]) == 1
+
+    first.rows["first"] = []
+    first_pl["count"] = 0
+    result, _, _, _ = _run_merge(opts, None)
+    assert result[0]["removed"] == 0
+    assert len(destination.rows["dest"]) == 1
+
+    second.rows["second"] = []
+    second_pl["count"] = 0
+    result, aggregate, _, _ = _run_merge(opts, None)
+    assert result[0]["removed"] == 1
+    assert aggregate["union_tracks"] == 0
+    assert destination.rows[dest_pl["id"]] == []
+
+
+def test_append_only_strategy_never_removes_destination_only_track(monkeypatch, tmp_path):
+    source = _Provider("spotify", tmp_path)
+    destination = _Provider("deezer", tmp_path)
+    source.add_playlist("empty", [])
+    destination.add_playlist("dest", [_track("Keep", provider_id="deezer:keep")], name="Append")
+    _install_providers(monkeypatch, {p.source: p for p in (source, destination)})
+
+    result, aggregate, ok, _ = _run_merge(_opts(
+        tmp_path,
+        [{"provider": "spotify", "playlist_id": "empty", "name": "Empty"}],
+        {"provider": "deezer", "playlist_id": "dest", "name": "Append"},
+        strategy="append_only",
+    ), None)
+
+    assert ok is True
+    assert result[0]["removed"] == 0
+    assert result[0]["removals_skipped"] == 1
+    assert aggregate["removals_guarded"] is True
+    assert [track["name"] for track in destination.rows["dest"]] == ["Keep"]
+
+
+def test_failed_source_allows_additions_but_guards_every_removal(monkeypatch, tmp_path):
+    healthy = _Provider("spotify", tmp_path)
+    failed = _Provider("apple", tmp_path)
+    destination = _Provider("deezer", tmp_path)
+    healthy.add_playlist("healthy", [_track("New")])
+    failed.add_playlist("failed", [])
+    failed.fail.add("failed")
+    destination.add_playlist("dest", [_track("Must stay", provider_id="deezer:stay")], name="Guarded")
+    _install_providers(monkeypatch, {p.source: p for p in (healthy, failed, destination)})
+
+    result, aggregate, ok, error = _run_merge(_opts(
+        tmp_path,
+        [
+            {"provider": "spotify", "playlist_id": "healthy", "name": "Healthy"},
+            {"provider": "apple", "playlist_id": "failed", "name": "Failed"},
+        ],
+        {"provider": "deezer", "playlist_id": "dest", "name": "Guarded"},
+    ), None)
+
+    assert ok is False and "removals were disabled" in error
+    assert result[0]["added"] == 1 and result[0]["removed"] == 0
+    assert aggregate["sources_read"] == 1
+    assert aggregate["sources_failed"] == 1
+    assert aggregate["removals_guarded"] is True
+    assert [track["name"] for track in destination.rows["dest"]] == ["Must stay", "New"]
+
+
+def test_sync_store_loads_legacy_defaults_and_round_trips_merge_descriptors(tmp_path):
+    (tmp_path / "syncs.json").write_text(json.dumps([{
+        "id": "legacy", "name": "Legacy", "mode": "oneway", "source": "spotify",
+    }]), encoding="utf-8")
+    store = SyncStore(dir=tmp_path)
+    legacy = store.get("legacy")
+    assert legacy.sources == []
+    assert legacy.destination is None
+    assert legacy.removal_strategy == "append_only"
+
+    merge = store.upsert(SyncJob(
+        name="Mashup", mode="merge", max_removals=10, removal_strategy="mirror",
+        sources=[SyncSource("spotify", "public", "Chart", "public", "https://open.spotify.com/playlist/public")],
+        destination=SyncDestination("deezer", "dest", "Mashup"),
+    ))
+    loaded = store.get(merge.id)
+    assert loaded.sources == merge.sources
+    assert loaded.destination == merge.destination
+
+
+def test_scheduled_and_manual_service_options_and_status_keep_aggregate_shape(monkeypatch, tmp_path):
+    import songmirror.services.sync_service as module
+
+    async def scenario():
+        captured = []
+        scheduled = False
+        service = None
+
+        async def fake_pass(opts, should_continue=None):
+            captured.append(opts)
+            if scheduled:
+                service._stopping = True
+            return {
+                "ok": True,
+                "per_target": [],
+                "aggregate": {
+                    "sources": 2,
+                    "destination_playlist_id": "dest",
+                },
+            }
+
+        monkeypatch.setattr(module, "_run_pass_async", fake_pass)
+        store = SyncStore(dir=tmp_path)
+        job = store.upsert(SyncJob(
+            name="Scheduled merge", mode="merge", interval="1h",
+            sources=[
+                SyncSource("spotify", "one", "One"),
+                SyncSource("apple", "pl.two", "Two", "public", "https://music.apple.com/x/playlist/y/pl.two"),
+            ],
+            destination=SyncDestination("deezer", "", "Mashup"),
+        ))
+        bus = EventBus()
+        bus.bind_loop(asyncio.get_running_loop())
+        service = SyncService(SettingsStore(dir=tmp_path), bus, store)
+        monkeypatch.setattr(module, "next_boundary_delay", lambda _now, _interval: 0)
+
+        scheduled = True
+        await service._job_scheduler(job.id)
+        service._stopping = False
+        scheduled = False
+        await service.run_job(job.id, execute=False)
+        status = service.status()["jobs"][0]
+
+        assert len(captured) == 2
+        assert captured[0].execute is True
+        assert captured[1].execute is False
+        assert captured[0].sources[1]["kind"] == "public"
+        assert captured[0].destination == {
+            "provider": "deezer", "playlist_id": "", "name": "Mashup",
+        }
+        assert captured[0].removal_strategy == "append_only"
+        assert status["sync_mode"] == "merge"
+        assert status["source_count"] == 2
+        assert status["destination"]["playlist_id"] == "dest"
+        assert status["last"]["aggregate"]["sources"] == 2
+        assert store.get(job.id).destination.playlist_id == "dest"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- Add a persisted merge sync mode with ordered library/public source descriptors and one writable destination.
- Resolve public playlist URLs through the existing transfer parser, then read all constituents and reconcile one deterministic, recording-deduplicated membership union.
- Add the complete Sync Wizard flow, aggregate job/card/status summaries, scheduling support, documentation, and regression coverage.

## Semantics and compatibility

Source descriptor order is authoritative, followed by each provider's playlist order. The first occurrence owns position and display metadata; later matches enrich identity. Provider catalog IDs and normalized ISRCs provide hard dedupe evidence, with conservative catalog title/artist/version/duration matching as fallback.

Append-only is the default. Mirror mode permits removals only after every constituent source is read completely. A missing, failed, truncated, malformed, unavailable, or unknowably empty source forces that pass to keep every destination track while still allowing additions from readable sources.

Public URLs are resolved once to provider and playlist IDs, so a source need not be saved or followed and scheduled runs do not replay arbitrary URLs. Newly created destination IDs are persisted after the serialized execute pass. Existing stored jobs load empty sources, no destination, and append-only defaults, while one-way, authority-group, and N-way execution remains on the existing paths.

## Verification

- uv run pytest -q — 536 passed, 1 skipped
- uv run pytest -q tests/test_merge_sync.py — 9 passed
- pnpm run build — passed
- pnpm run lint — passed
- pnpm run test:e2e:ci — 132 checks, 0 horizontal-overflow failures
- docker compose config --quiet — passed
- git diff --check — passed

Closes #46