### PR TITLE
feat(accounts): support multiple provider profiles

### DIFF
--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -124,6 +124,18 @@ const ACCOUNTS = [
   },
 ]
 
+// Profile-aware account contract. The established scenarios keep provider ids
+// as legacy/default aliases so their saved-job fixtures remain meaningful; a
+// focused household scenario below uses two genuinely distinct profile ids.
+for (const account of ACCOUNTS) {
+  account.provider = account.id
+  account.provider_name = account.name
+  account.label = account.name
+  account.is_default = true
+  account.removable = false
+  account.preserves_order = !['deezer', 'jellyfin'].includes(account.provider)
+}
+
 // Global-only now — direction/providers/playlists/interval/caps/download-opt-in
 // all moved to per-job SyncJob records (SYNCS below).
 const SETTINGS = {
@@ -430,6 +442,7 @@ const SHOWCASE_TRANSFER_JOB = {
 // A pasted public playlist link resolves to a source that is NOT in the
 // fixture library, which is the whole point of the feature.
 const LINK_PREVIEW = {
+  account: 'spotify',
   provider: 'spotify',
   playlist_id: 'pl_public_link',
   name: "Someone Else's Mix",
@@ -465,7 +478,7 @@ async function installMocks(page, opts = {}) {
   // Fresh per installation (one per test context/page) so CRUD mutations in
   // one test never leak into another.
   let syncsData = opts.syncs ?? initialSyncs()
-  const accountsData = opts.accounts ?? ACCOUNTS
+  let accountsData = [...(opts.accounts ?? ACCOUNTS)]
   const settingsData = opts.settings ?? SETTINGS
   const playlistsData = opts.playlists ?? PLAYLISTS
   const delays = opts.delays ?? {}
@@ -497,6 +510,30 @@ async function installMocks(page, opts = {}) {
     if (p === '/api/accounts' && method === 'GET') {
       await delay('accounts')
       return json(accountsData)
+    }
+    if (p === '/api/accounts' && method === 'POST') {
+      const body = req.postDataJSON() ?? {}
+      const provider = String(body.provider ?? '')
+      const template = accountsData.find((account) => account.provider === provider)
+        ?? ACCOUNTS.find((account) => account.provider === provider)
+      if (!template) return json({ detail: `unknown provider: ${provider}` }, 422)
+      const number = accountsData.filter((account) => account.provider === provider).length + 1
+      const providerName = template.provider_name ?? template.name
+      const label = String(body.label ?? '').trim() || `${providerName} ${number}`
+      const created = {
+        ...template,
+        id: `profile_e2e_${provider}_${number}`,
+        provider,
+        provider_name: providerName,
+        label,
+        name: label === providerName ? providerName : `${providerName} · ${label}`,
+        is_default: false,
+        removable: true,
+        state: 'unconfigured',
+        detail: null,
+      }
+      accountsData = [...accountsData, created]
+      return json(created)
     }
     if (/^\/api\/accounts\/[^/]+\/config$/.test(p) && method === 'POST') return json({ ok: true })
     if (/^\/api\/accounts\/[^/]+\/connect$/.test(p) && method === 'POST') {
@@ -1277,6 +1314,7 @@ async function main() {
       const linkModeHidesPickers = serviceSelects === 1   // destination only
       console.log((linkModeHidesPickers ? 'ok        ' : 'FAIL      ') + ' link mode replaces the source pickers with a link field (service selects: ' + serviceSelects + ')')
       if (!linkModeHidesPickers) results.push({ label: 'link mode source pickers', overflow: true })
+      await page.getByLabel('Open with account', { exact: true }).selectOption('spotify')
 
       // A paste that is not a playlist link surfaces the server's own copy.
       await page.getByLabel('Playlist link', { exact: true }).fill('https://open.spotify.com/album/123')
@@ -2479,7 +2517,7 @@ async function main() {
     // -----------------------------------------------------------------
     // YouTube Music "no-quota mode" (browser cookies) - an optional
     // section below the OAuth device flow. Paste raw request headers ->
-    // POST /api/accounts/ytmusic/browser; bad/rejected headers surface the
+    // POST /api/accounts/{profile}/ytmusic/browser; bad/rejected headers surface the
     // error detail, good ones activate it (an "On" badge, a "Switch back to
     // OAuth" button -> DELETE reverts it). installMocks' own /api/accounts
     // is a static fixture (fine everywhere else); this test overrides it
@@ -2501,7 +2539,7 @@ async function main() {
         await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) })
       })
       let lastBrowserPost = null
-      await page.route('**/api/accounts/ytmusic/browser', async (route) => {
+      await page.route('**/api/accounts/ytmusic/ytmusic/browser', async (route) => {
         const method = route.request().method()
         if (method === 'POST') {
           lastBrowserPost = JSON.parse(route.request().postData() || '{}')
@@ -2557,7 +2595,7 @@ async function main() {
       await page.getByRole('button', { name: 'Enable no-quota mode', exact: true }).click()
       await page.waitForSelector('text=No-quota mode is on.')
       const postFiredOk = Boolean(lastBrowserPost && typeof lastBrowserPost.headers === 'string' && lastBrowserPost.headers.includes('cookie:'))
-      console.log(`${postFiredOk ? 'ok        ' : 'FAIL      '} pasting valid headers POSTs {headers} to /api/accounts/ytmusic/browser (got ${JSON.stringify(lastBrowserPost)})`)
+      console.log(`${postFiredOk ? 'ok        ' : 'FAIL      '} pasting valid headers POSTs {headers} to the selected profile endpoint (got ${JSON.stringify(lastBrowserPost)})`)
       if (!postFiredOk) results.push({ label: 'ytmusic noquota post body', overflow: true })
 
       const onBadgeOk = await noQuotaSummary.getByText('On', { exact: true }).isVisible()
@@ -3748,6 +3786,98 @@ async function main() {
 
       await checkOverflow(page, 'Transfers page with Pause/Resume/Stop controls @ 1280', results)
       await shot(page, 'transfers-page-controls')
+      await context.close()
+    }
+
+    // -----------------------------------------------------------------
+    // Household profiles remain distinct end-to-end: Accounts can add a
+    // labeled profile, and Transfers preserves two Spotify profile ids in its
+    // selectors and request instead of collapsing them to provider="spotify".
+    // -----------------------------------------------------------------
+    {
+      const context = await browser.newContext()
+      await context.addInitScript(() => window.localStorage.setItem('songmirror-theme', 'light'))
+      const page = await context.newPage()
+      const spotify = ACCOUNTS.find((account) => account.provider === 'spotify')
+      const defaultSpotify = {
+        ...spotify,
+        id: 'profile_default_spotify',
+        label: 'Spotify',
+        name: 'Spotify',
+        is_default: true,
+        removable: false,
+        state: 'connected',
+      }
+      const alexSpotify = {
+        ...spotify,
+        id: 'profile_alex_spotify',
+        label: 'Alex',
+        name: 'Spotify · Alex',
+        is_default: false,
+        removable: true,
+        state: 'connected',
+      }
+      await installMocks(page, {
+        accounts: [defaultSpotify, alexSpotify],
+        playlists: {
+          [defaultSpotify.id]: [
+            { id: 'spotify-source', name: 'Household source', count: 12, image: '' },
+          ],
+          [alexSpotify.id]: [
+            { id: 'spotify-destination', name: 'Alex destination', count: 3, image: '', owned: true },
+          ],
+        },
+      })
+      let submittedTransfer = null
+      await page.route('**/api/transfers', async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback()
+        submittedTransfer = route.request().postDataJSON()
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ job_id: 'job1' }),
+        })
+      })
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.goto(BASE_URL + '/accounts', { waitUntil: 'networkidle' })
+      await page.getByLabel('New profile label', { exact: true }).fill('Work')
+      await page.getByRole('button', { name: 'Add profile', exact: true }).click()
+      await page.waitForSelector('h3:has-text("Spotify · Work")')
+      const addedOk = await page.getByRole('heading', { name: 'Spotify · Work', exact: true }).isVisible()
+      console.log(`${addedOk ? 'ok        ' : 'FAIL      '} Accounts adds and renders a labeled provider profile`)
+      if (!addedOk) results.push({ label: 'accounts add profile', overflow: true })
+
+      await page.goto(BASE_URL + '/transfers', { waitUntil: 'networkidle' })
+      await page.waitForSelector('h1:has-text("Transfers")')
+      const sourceSelect = page.getByLabel('Service', { exact: true }).first()
+      const sourceOptions = await sourceSelect.locator('option').evaluateAll((options) => (
+        options.map((option) => ({ value: option.value, label: option.textContent ?? '' }))
+      ))
+      const profilesDistinct =
+        sourceOptions.some((option) => option.value === defaultSpotify.id && option.label === 'Spotify')
+        && sourceOptions.some((option) => option.value === alexSpotify.id && option.label === 'Spotify · Alex')
+      console.log(`${profilesDistinct ? 'ok        ' : 'FAIL      '} Transfers keeps same-provider profiles as distinct selector identities`)
+      if (!profilesDistinct) results.push({ label: 'transfer profile identities', overflow: true })
+
+      await sourceSelect.selectOption(defaultSpotify.id)
+      await page.getByLabel('Playlist', { exact: true }).click()
+      await page.getByRole('option', { name: 'Household source' }).click()
+      const destinationSelect = page.getByLabel('Service', { exact: true }).nth(1)
+      await destinationSelect.selectOption(alexSpotify.id)
+      await page.getByLabel('Existing playlist', { exact: true }).click()
+      await page.getByRole('option', { name: 'Alex destination' }).click()
+      await page.getByRole('button', { name: 'Copy playlist', exact: true }).click()
+      await page.getByRole('dialog').getByRole('button', { name: 'Copy playlist', exact: true }).click()
+      await page.waitForTimeout(100)
+      const payloadOk =
+        submittedTransfer?.source_account === defaultSpotify.id
+        && submittedTransfer?.dest_account === alexSpotify.id
+        && submittedTransfer?.source_playlist_id === 'spotify-source'
+        && submittedTransfer?.dest_playlist_id === 'spotify-destination'
+      console.log(`${payloadOk ? 'ok        ' : 'FAIL      '} same-provider transfer submits both selected profile ids`)
+      if (!payloadOk) results.push({ label: 'same-provider transfer profile payload', overflow: true })
+      await checkOverflow(page, 'Household profiles and cross-profile transfer @ 1280', results)
+      await shot(page, 'household-profile-transfer')
       await context.close()
     }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -114,28 +114,33 @@ const json = (body: unknown): RequestInit => ({ method: 'POST', body: JSON.strin
 export const api = {
   // Accounts
   getAccounts: () => request<Account[]>('/api/accounts'),
+  addAccount: (provider: string, label: string) =>
+    request<Account>('/api/accounts', json({ provider, label })),
+  renameAccount: (id: string, label: string) =>
+    request<Account>(`/api/accounts/${id}`, { method: 'PATCH', body: JSON.stringify({ label }) }),
   saveAccountConfig: (id: string, values: Record<string, string>) =>
     request<OkResponse>(`/api/accounts/${id}/config`, json(values)),
   connectAccount: (id: string, values?: Record<string, string>) =>
     request<ConnectResponse>(`/api/accounts/${id}/connect`, { method: 'POST', ...(values ? { body: JSON.stringify(values) } : {}) }),
   pollAccount: (id: string, deviceCode: string, interval: number) =>
     request<PollResponse>(`/api/accounts/${id}/poll`, json({ device_code: deviceCode, interval })),
-  disconnectAccount: (id: string) => request<OkResponse>(`/api/accounts/${id}`, { method: 'DELETE' }),
+  disconnectAccount: (id: string) => request<OkResponse>(`/api/accounts/${id}/disconnect`, { method: 'POST' }),
+  removeAccount: (id: string) => request<OkResponse>(`/api/accounts/${id}`, { method: 'DELETE' }),
   /** YouTube Music-only "no-quota" mode: routes reads/writes through a pasted
    * browser session instead of the (daily-capped) Data API. `headers` is the
    * raw "copy request headers" block from a music.youtube.com XHR. */
-  enableYtmusicBrowserMode: (headers: string) => request<PollResponse>('/api/accounts/ytmusic/browser', json({ headers })),
-  disableYtmusicBrowserMode: () => request<PollResponse>('/api/accounts/ytmusic/browser', { method: 'DELETE' }),
+  enableYtmusicBrowserMode: (id: string, headers: string) => request<PollResponse>(`/api/accounts/${id}/ytmusic/browser`, json({ headers })),
+  disableYtmusicBrowserMode: (id: string) => request<PollResponse>(`/api/accounts/${id}/ytmusic/browser`, { method: 'DELETE' }),
   /** Spotify signed-in web session: routes library reads, playlist reads/writes,
    * and catalog search through the first-party web client without a developer app. */
-  enableSpotifyCookieMode: (spDc: string) => request<PollResponse>('/api/accounts/spotify/cookie', json({ sp_dc: spDc })),
-  disableSpotifyCookieMode: () => request<PollResponse>('/api/accounts/spotify/cookie', { method: 'DELETE' }),
+  enableSpotifyCookieMode: (id: string, spDc: string) => request<PollResponse>(`/api/accounts/${id}/spotify/cookie`, json({ sp_dc: spDc })),
+  disableSpotifyCookieMode: (id: string) => request<PollResponse>(`/api/accounts/${id}/spotify/cookie`, { method: 'DELETE' }),
 
   /** Legacy OAuth-only compatibility endpoints. Cookie-only N-way matching learns
    * Spotify identities from the other ISRC-bearing peers and does not use these. */
-  setSpotifyIsrcApp: (clientId: string, clientSecret: string) =>
-    request<PollResponse>('/api/accounts/spotify/isrc-app', json({ client_id: clientId, client_secret: clientSecret })),
-  clearSpotifyIsrcApp: () => request<PollResponse>('/api/accounts/spotify/isrc-app', { method: 'DELETE' }),
+  setSpotifyIsrcApp: (id: string, clientId: string, clientSecret: string) =>
+    request<PollResponse>(`/api/accounts/${id}/spotify/isrc-app`, json({ client_id: clientId, client_secret: clientSecret })),
+  clearSpotifyIsrcApp: (id: string) => request<PollResponse>(`/api/accounts/${id}/spotify/isrc-app`, { method: 'DELETE' }),
 
   // Settings
   getSettings: () => request<Settings>('/api/settings'),
@@ -226,8 +231,8 @@ export const api = {
     request<OkResponse>(`/api/transfers/${encodeURIComponent(id)}/resolve`, json(body)),
   /** Resolve a pasted public playlist link into a startable transfer source.
    * The link is parsed on the server, so the URL grammar has one home. */
-  previewTransferSource: (url: string) =>
-    request<TransferSourcePreview>('/api/transfers/preview', json({ url })),
+  previewTransferSource: (url: string, sourceAccount: string) =>
+    request<TransferSourcePreview>('/api/transfers/preview', json({ url, source_account: sourceAccount })),
 
   // Resolve mappings (the per-provider match caches)
   getResolveCacheProviders: () => request<ResolveCacheProvider[]>('/api/resolve-cache'),

--- a/frontend/src/components/accounts/AccountCard.tsx
+++ b/frontend/src/components/accounts/AccountCard.tsx
@@ -10,6 +10,7 @@ import { Card } from '../ui/Card'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { ServiceLogo } from '../ui/ServiceLogo'
 import { StatusPill } from '../ui/StatusPill'
+import { TextField } from '../ui/TextField'
 import { ConnectWizardModal } from './ConnectWizardModal'
 
 const SERVICE_BLURBS: Record<string, string> = {
@@ -41,11 +42,15 @@ function borderClass(state: Account['state']): string {
 export function AccountCard({ account, onChanged }: { account: Account; onChanged: () => void }) {
   const [wizardOpen, setWizardOpen] = useState(false)
   const [confirmingDisconnect, setConfirmingDisconnect] = useState(false)
+  const [confirmingRemove, setConfirmingRemove] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
+  const [editingLabel, setEditingLabel] = useState(false)
+  const [label, setLabel] = useState(account.label)
+  const [savingLabel, setSavingLabel] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const isConnected = account.state === 'connected' || account.state === 'expired'
-  const logoId = serviceLogoId(account.id)
+  const logoId = serviceLogoId(account.provider)
 
   async function disconnect() {
     setDisconnecting(true)
@@ -61,6 +66,35 @@ export function AccountCard({ account, onChanged }: { account: Account; onChange
     }
   }
 
+  async function remove() {
+    setDisconnecting(true)
+    setError(null)
+    try {
+      await api.removeAccount(account.id)
+      setConfirmingRemove(false)
+      onChanged()
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setDisconnecting(false)
+    }
+  }
+
+  async function rename() {
+    if (!label.trim()) return
+    setSavingLabel(true)
+    setError(null)
+    try {
+      await api.renameAccount(account.id, label.trim())
+      setEditingLabel(false)
+      onChanged()
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setSavingLabel(false)
+    }
+  }
+
   return (
     <Card className={cn('flex flex-col gap-3.5 p-4 sm:p-5', borderClass(account.state))}>
       <div className="flex flex-wrap items-center gap-2.5">
@@ -69,17 +103,29 @@ export function AccountCard({ account, onChanged }: { account: Account; onChange
             className="grid size-11 shrink-0 place-items-center overflow-hidden rounded-card border border-border bg-surface-2"
             aria-hidden="true"
           >
-            <ServiceLogo service={logoId} className={cn('size-6', tagText(account.id))} />
+            <ServiceLogo service={logoId} className={cn('size-6', tagText(account.provider))} />
           </span>
         ) : (
-          <span className={cn('size-2.5 shrink-0 rounded-full', tagDot(account.id))} aria-hidden="true" />
+          <span className={cn('size-2.5 shrink-0 rounded-full', tagDot(account.provider))} aria-hidden="true" />
         )}
         <h3 className="text-base font-bold text-text">{account.name}</h3>
         <span className="font-mono text-[10px] tracking-wide text-text-3">{AUTH_KIND_LABELS[account.auth_kind]}</span>
         <StatusPill state={account.state} className="ml-auto" />
       </div>
 
-      <p className="text-[13px] leading-relaxed text-text-2">{SERVICE_BLURBS[account.id] ?? ''}</p>
+      <p className="text-[13px] leading-relaxed text-text-2">{SERVICE_BLURBS[account.provider] ?? ''}</p>
+
+      {editingLabel && (
+        <div className="flex items-end gap-2">
+          <TextField label="Profile label" value={label} onChange={(event) => setLabel(event.target.value)} />
+          <Button size="sm" loading={savingLabel} disabled={!label.trim()} onClick={() => void rename()}>
+            Save
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => { setLabel(account.label); setEditingLabel(false) }}>
+            Cancel
+          </Button>
+        </div>
+      )}
 
       {account.detail && account.state !== 'connected' && account.state !== 'error' && (
         <p className="text-xs leading-relaxed text-text-3">{account.detail}</p>
@@ -105,6 +151,16 @@ export function AccountCard({ account, onChanged }: { account: Account; onChange
             Disconnect
           </Button>
         )}
+        {!editingLabel && (
+          <Button variant="ghost" size="sm" onClick={() => setEditingLabel(true)}>
+            Rename
+          </Button>
+        )}
+        {account.removable && (
+          <Button variant="ghost" size="sm" onClick={() => setConfirmingRemove(true)}>
+            Remove
+          </Button>
+        )}
       </div>
 
       <ConnectWizardModal
@@ -127,6 +183,17 @@ export function AccountCard({ account, onChanged }: { account: Account; onChange
         loading={disconnecting}
         onConfirm={() => void disconnect()}
         onCancel={() => setConfirmingDisconnect(false)}
+      />
+
+      <ConfirmDialog
+        open={confirmingRemove}
+        title={`Remove ${account.name}?`}
+        description="This deletes this profile's saved credentials and session files. Syncs that select it will stop until you choose another account."
+        confirmLabel="Remove profile"
+        danger
+        loading={disconnecting}
+        onConfirm={() => void remove()}
+        onCancel={() => setConfirmingRemove(false)}
       />
     </Card>
   )

--- a/frontend/src/components/accounts/ConnectWizardModal.tsx
+++ b/frontend/src/components/accounts/ConnectWizardModal.tsx
@@ -520,7 +520,7 @@ export function ConnectWizardModal({ account, open, onClose, onConnected, onChan
               </>
             )}
 
-            {account.id === 'ytmusic' && <NoQuotaModeSection account={account} onChanged={onChanged} />}
+            {account.provider === 'ytmusic' && <NoQuotaModeSection account={account} onChanged={onChanged} />}
           </>
         )}
       </div>
@@ -545,7 +545,7 @@ function FieldsStep({
   onSubmit: () => void
   submitLabel: string
 }) {
-  const guide = CONNECT_GUIDES[account.id]
+  const guide = CONNECT_GUIDES[account.provider]
   const canKeepBlank = account.auth_kind === 'oauth_redirect' || account.auth_kind === 'oauth_device'
   return (
     <form
@@ -743,7 +743,7 @@ function NoQuotaModeSection({ account, onChanged }: { account: Account; onChange
     setSaving(true)
     setError(null)
     try {
-      const res = await api.enableYtmusicBrowserMode(headers)
+      const res = await api.enableYtmusicBrowserMode(account.id, headers)
       if (res.state === 'connected') onChanged()
       else setError(res.detail || 'Could not enable no-quota mode with those headers.')
     } catch (err) {
@@ -757,7 +757,7 @@ function NoQuotaModeSection({ account, onChanged }: { account: Account; onChange
     setSaving(true)
     setError(null)
     try {
-      await api.disableYtmusicBrowserMode()
+      await api.disableYtmusicBrowserMode(account.id)
       onChanged()
     } catch (err) {
       setError(errorMessage(err))

--- a/frontend/src/components/dashboard/LiveFeed.tsx
+++ b/frontend/src/components/dashboard/LiveFeed.tsx
@@ -100,12 +100,14 @@ function CounterDetails({
   value,
   providers,
   reasons,
+  accounts,
 }: {
   title: string
   description: string
   value: number
   providers: Record<string, number>
   reasons?: Record<string, number>
+  accounts?: Account[] | null
 }) {
   const providerRows = Object.entries(providers).sort((a, b) => b[1] - a[1] || tagLabel(a[0]).localeCompare(tagLabel(b[0])))
   const reasonRows = Object.entries(reasons ?? {}).sort((a, b) => b[1] - a[1])
@@ -121,15 +123,17 @@ function CounterDetails({
           <p className="mb-1.5 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-text-3">By service</p>
           <div className="flex flex-col gap-1.5">
             {providerRows.map(([tag, count]) => {
-              const logo = serviceLogoId(tag)
+              const account = accounts?.find((candidate) => candidate.id === tag)
+              const brand = account?.provider ?? tag
+              const logo = serviceLogoId(brand)
               return (
                 <div key={tag} className="flex items-center gap-2">
                   {logo ? (
-                    <ServiceLogo service={logo} className={cn('size-3.5 shrink-0', tagText(tag))} />
+                    <ServiceLogo service={logo} className={cn('size-3.5 shrink-0', tagText(brand))} />
                   ) : (
-                    <span className={cn('size-2 shrink-0 rounded-full', tagDot(tag))} aria-hidden="true" />
+                    <span className={cn('size-2 shrink-0 rounded-full', tagDot(brand))} aria-hidden="true" />
                   )}
-                  <span className="min-w-0 flex-1 truncate text-[11.5px] text-text-2">{tagLabel(tag)}</span>
+                  <span className="min-w-0 flex-1 truncate text-[11.5px] text-text-2">{account?.name ?? tagLabel(tag)}</span>
                   <span className="font-mono text-[11px] font-bold tabular-nums text-text">{COUNT_FORMATTER.format(count)}</span>
                 </div>
               )
@@ -162,15 +166,16 @@ function matchesKind(event: SyncEvent, filter: KindFilter): boolean {
   return event.kind === filter
 }
 
-function ServiceOptionMark({ tag }: { tag: string }) {
+function ServiceOptionMark({ tag, account }: { tag: string; account?: Account }) {
   if (tag === 'sync') return <LuRefreshCw className="size-3.5 text-accent" />
   if (tag === 'local') return <LuDownload className="size-3.5 text-info" />
   if (tag === 'transfer') return <LuArrowRightLeft className="size-3.5 text-info" />
-  const logo = serviceLogoId(tag)
+  const brand = account?.provider ?? tag
+  const logo = serviceLogoId(brand)
   return logo ? (
-    <ServiceLogo service={logo} className={cn('size-3.5', tagText(tag))} />
+    <ServiceLogo service={logo} className={cn('size-3.5', tagText(brand))} />
   ) : (
-    <span className={cn('size-2 rounded-full', tagDot(tag))} />
+    <span className={cn('size-2 rounded-full', tagDot(brand))} />
   )
 }
 
@@ -206,18 +211,20 @@ export function LiveFeed({ accounts = null, syncs = null }: LiveFeedProps = {}) 
     for (const account of accounts ?? []) {
       if (account.state !== 'unconfigured') ids.add(activitySourceId(account.id))
     }
-    return [...ids].sort((a, b) => tagLabel(a).localeCompare(tagLabel(b)))
+    const label = (id: string) => accounts?.find((account) => account.id === id)?.name ?? tagLabel(id)
+    return [...ids].sort((a, b) => label(a).localeCompare(label(b)))
   }, [accounts, events, syncs])
   const sourceOptions = useMemo<Array<FilterSelectOption<string>>>(() => {
-    const services = sources.filter((tag) => serviceLogoId(tag) !== null)
-    const internal = sources.filter((tag) => serviceLogoId(tag) === null)
+    const accountFor = (tag: string) => accounts?.find((account) => account.id === tag)
+    const services = sources.filter((tag) => serviceLogoId(accountFor(tag)?.provider ?? tag) !== null)
+    const internal = sources.filter((tag) => serviceLogoId(accountFor(tag)?.provider ?? tag) === null)
     return [
       { value: 'all', label: 'All sources', leading: <LuLayers3 className="size-3.5 text-text-3" /> },
       ...services.map((tag) => ({
         value: tag,
-        label: tagLabel(tag),
+        label: accountFor(tag)?.name ?? tagLabel(tag),
         group: 'Music services',
-        leading: <ServiceOptionMark tag={tag} />,
+        leading: <ServiceOptionMark tag={tag} account={accountFor(tag)} />,
       })),
       ...internal.map((tag) => ({
         value: tag,
@@ -227,17 +234,18 @@ export function LiveFeed({ accounts = null, syncs = null }: LiveFeedProps = {}) 
         leading: <ServiceOptionMark tag={tag} />,
       })),
     ]
-  }, [sources])
+  }, [accounts, sources])
 
   const visibleEvents = useMemo(() => {
     const filtered = events.filter((event) => {
       if (source !== 'all' && activitySourceId(event.tag) !== source) return false
       if (!matchesKind(event, kind)) return false
       if (!deferredQuery) return true
-      return `${event.message} ${tagLabel(event.tag)} ${event.kind}`.toLocaleLowerCase().includes(deferredQuery)
+      const label = accounts?.find((account) => account.id === event.tag)?.name ?? tagLabel(event.tag)
+      return `${event.message} ${label} ${event.kind}`.toLocaleLowerCase().includes(deferredQuery)
     })
     return sort === 'newest' ? filtered.slice().reverse() : filtered
-  }, [deferredQuery, events, kind, sort, source])
+  }, [accounts, deferredQuery, events, kind, sort, source])
 
   const filtered = query.trim() !== '' || source !== 'all' || kind !== 'all'
 
@@ -267,6 +275,7 @@ export function LiveFeed({ accounts = null, syncs = null }: LiveFeedProps = {}) 
                   value={counters[counter.key]}
                   providers={breakdown[counter.key]}
                   reasons={counter.key === 'held' ? holdReasons : undefined}
+                  accounts={accounts}
                 />
               )}
             />
@@ -348,6 +357,7 @@ export function LiveFeed({ accounts = null, syncs = null }: LiveFeedProps = {}) 
 
       <EventFeedList
         events={visibleEvents}
+        accounts={accounts}
         newestFirst={sort === 'newest'}
         emptyTitle={filtered ? 'No matching activity' : 'No activity yet'}
         emptyDescription={filtered

--- a/frontend/src/components/dashboard/YourServices.tsx
+++ b/frontend/src/components/dashboard/YourServices.tsx
@@ -28,13 +28,13 @@ export function YourServices({ accounts, status }: { accounts: Account[] | null;
         <ul className="flex flex-col divide-y divide-border border-t border-border">
           {accounts.map((a) => {
             const target = status?.last?.per_target.find((t) => t.name === a.name)
-            const logoId = serviceLogoId(a.id)
+            const logoId = serviceLogoId(a.provider)
             return (
               <li key={a.id} className="flex items-center gap-3 px-4 py-3">
                 {logoId ? (
-                  <ServiceLogo service={logoId} className={cn('size-4 shrink-0', tagText(a.id))} />
+                  <ServiceLogo service={logoId} className={cn('size-4 shrink-0', tagText(a.provider))} />
                 ) : (
-                  <span className={cn('size-[9px] shrink-0 rounded-full', tagDot(a.id))} aria-hidden="true" />
+                  <span className={cn('size-[9px] shrink-0 rounded-full', tagDot(a.provider))} aria-hidden="true" />
                 )}
                 <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold text-text">{a.name}</span>
                 {target && (target.added > 0 || target.removed > 0) && (

--- a/frontend/src/components/events/EventFeedList.tsx
+++ b/frontend/src/components/events/EventFeedList.tsx
@@ -1,7 +1,7 @@
 import { LuChevronDown, LuChevronUp } from 'react-icons/lu'
 
 import { useStickToBottom } from '@/hooks/useStickToBottom'
-import type { SyncEvent } from '@/types'
+import type { Account, SyncEvent } from '@/types'
 
 import { EmptyState } from '../ui/EmptyState'
 import { EventRow } from './EventRow'
@@ -12,6 +12,7 @@ interface EventFeedListProps {
   emptyDescription: string
   ariaLabel: string
   newestFirst?: boolean
+  accounts?: Account[] | null
 }
 
 /** The scrollable, auto-following list of event rows shared by the
@@ -20,7 +21,7 @@ interface EventFeedListProps {
  * chat-log pattern - but leaves their scroll position alone once they've
  * scrolled up to read older lines, surfacing a floating "jump to newest"
  * button instead of yanking them back down. */
-export function EventFeedList({ events, emptyTitle, emptyDescription, ariaLabel, newestFirst = false }: EventFeedListProps) {
+export function EventFeedList({ events, emptyTitle, emptyDescription, ariaLabel, newestFirst = false, accounts }: EventFeedListProps) {
   const { containerRef, isAtBottom, newCount, scrollToBottom } = useStickToBottom<HTMLUListElement>(
     events.length,
     newestFirst ? 'top' : 'bottom',
@@ -43,7 +44,11 @@ export function EventFeedList({ events, emptyTitle, emptyDescription, ariaLabel,
           // No backend id exists, so combine immutable event fields. The index
           // only disambiguates genuinely identical lines and sorting can safely
           // reverse the list without lending one row another row's identity.
-          <EventRow key={`${event.ts}:${event.kind}:${event.tag}:${event.message}:${i}`} event={event} />
+          <EventRow
+            key={`${event.ts}:${event.kind}:${event.tag}:${event.message}:${i}`}
+            event={event}
+            account={accounts?.find((candidate) => candidate.id === event.tag)}
+          />
         ))}
       </ul>
       {!isAtBottom && (

--- a/frontend/src/components/events/EventRow.tsx
+++ b/frontend/src/components/events/EventRow.tsx
@@ -14,7 +14,7 @@ import {
 import { cn } from '@/lib/cn'
 import { KIND_STYLES, serviceLogoId, tagDot, tagLabel, tagText } from '@/lib/constants'
 import { formatClock } from '@/lib/format'
-import type { EventKind, SyncEvent } from '@/types'
+import type { Account, EventKind, SyncEvent } from '@/types'
 
 import { ServiceLogo } from '../ui/ServiceLogo'
 
@@ -36,9 +36,11 @@ const EVENT_KIND_ICONS: Record<Exclude<EventKind, 'section'>, IconType> = {
  * mobile-wrap behavior keeps working (message drops to its own line below
  * `sm`, verified overflow-free at 320px); the column proportions match the
  * spec at `sm` and up either way. */
-export function EventRow({ event }: { event: SyncEvent }) {
+export function EventRow({ event, account }: { event: SyncEvent; account?: Account }) {
   const style = KIND_STYLES[event.kind]
-  const logoId = serviceLogoId(event.tag)
+  const brand = account?.provider ?? event.tag
+  const label = account?.name ?? tagLabel(event.tag)
+  const logoId = serviceLogoId(brand)
 
   if (event.kind === 'section') {
     return (
@@ -76,15 +78,15 @@ export function EventRow({ event }: { event: SyncEvent }) {
       >
         {logoId ? (
           <>
-            <ServiceLogo service={logoId} className={cn('size-3.5 shrink-0', tagText(event.tag))} />
+            <ServiceLogo service={logoId} className={cn('size-3.5 shrink-0', tagText(brand))} />
             {/* The icon alone (no visible label) needs a text alternative —
                 ServiceLogo's own glyphs are aria-hidden. */}
-            <span className="sr-only">{tagLabel(event.tag)}</span>
+            <span className="sr-only">{label}</span>
           </>
         ) : (
           <>
-            <span className={cn('size-[7px] shrink-0 rounded-full', tagDot(event.tag))} aria-hidden="true" />
-            {event.tag}
+            <span className={cn('size-[7px] shrink-0 rounded-full', tagDot(brand))} aria-hidden="true" />
+            {account ? label : event.tag}
           </>
         )}
       </span>

--- a/frontend/src/components/playlists/LinkCard.tsx
+++ b/frontend/src/components/playlists/LinkCard.tsx
@@ -106,12 +106,13 @@ export function LinkCard({ link, accounts, playlistEntries, onEdit, onChanged }:
         <ul className="flex flex-wrap gap-x-3.5 gap-y-1.5 pl-[54px] text-[12.5px] text-text-2 sm:pl-[62px]">
           {memberEntries.map(([providerId, playlistId]) => {
             const isSource = link.direction === 'oneway' && link.source === providerId
+            const provider = accounts.find((account) => account.id === providerId)?.provider ?? providerId
             return (
               <li key={providerId} className="inline-flex items-center gap-1.5">
                 {/* Dot conveys the service at a glance (matches the design);
                     the name stays in the DOM for anyone who can't rely on
                     color alone. */}
-                <span className={cn('size-[7px] shrink-0 rounded-full', tagDot(providerId))} aria-hidden="true" />
+                <span className={cn('size-[7px] shrink-0 rounded-full', tagDot(provider))} aria-hidden="true" />
                 <span className="sr-only">{providerName(accounts, providerId)}: </span>
                 {playlistLabel(playlistEntries, providerId, playlistId)}
                 {isSource && <span className="font-mono text-[10px] text-text-3">SOURCE</span>}

--- a/frontend/src/components/playlists/LinkEditorModal.tsx
+++ b/frontend/src/components/playlists/LinkEditorModal.tsx
@@ -172,13 +172,14 @@ export function LinkEditorModal({ open, onClose, link, accounts, playlistEntries
                     { value: OMIT, label: 'Not included in this pairing' },
                     { value: KEEP, label: `Keep current (${currentRaw === null ? 'create new' : currentRaw})` },
                   ]
-              const logoId = serviceLogoId(id)
+              const provider = accounts.find((account) => account.id === id)?.provider ?? id
+              const logoId = serviceLogoId(provider)
               return (
                 <SelectField
                   key={id}
                   label={connected ? accountName(id) : `${accountName(id)} (not connected)`}
                   help={connected ? undefined : 'Reconnect this service on the Accounts page to change its playlist.'}
-                  icon={logoId ? <ServiceLogo service={logoId} className={`size-4 ${tagText(id)}`} /> : undefined}
+                  icon={logoId ? <ServiceLogo service={logoId} className={`size-4 ${tagText(provider)}`} /> : undefined}
                   options={options}
                   value={memberChoices[id] ?? OMIT}
                   onChange={(e) => setMemberChoice(id, e.target.value)}

--- a/frontend/src/components/playlists/PlaylistDetailModal.tsx
+++ b/frontend/src/components/playlists/PlaylistDetailModal.tsx
@@ -131,11 +131,11 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
       // making the last entry the newest available evidence. YouTube Music's
       // authenticated playlist read is already newest-first, so reversing it
       // would put the oldest track at the top under a misleading label.
-      return provider === 'ytmusic'
+      return account?.provider === 'ytmusic'
         ? left.position - right.position
         : right.position - left.position
     })
-  }, [detail, deferredQuery, order, provider])
+  }, [account?.provider, detail, deferredQuery, order])
 
   const pageCount = Math.max(1, Math.ceil(orderedTracks.length / PAGE_SIZE))
   const safePage = Math.min(page, pageCount)
@@ -310,7 +310,7 @@ export function PlaylistDetailModal({ account, playlist, onClose, onChanged }: P
           <div className="flex items-start gap-2.5 rounded-control border border-warning/30 bg-warning-soft px-3.5 py-3 text-xs leading-relaxed text-text-2">
             <span className="font-mono font-bold text-warning" aria-hidden="true">~</span>
             <p>
-              {provider === 'spotify'
+              {account?.provider === 'spotify'
                 ? 'Spotify is authoritative for your one-way syncs. Manual edits here flow to mirrors on the next run.'
                 : `This changes ${account?.name} directly. If Spotify owns this mirror, make the same edit in Spotify or the next sync will restore it.`}
             </p>

--- a/frontend/src/components/playlists/ProviderPlaylistsCard.tsx
+++ b/frontend/src/components/playlists/ProviderPlaylistsCard.tsx
@@ -31,8 +31,8 @@ export function ProviderPlaylistsCard({
   onRetry: () => void
 }) {
   const connected = account.state === 'connected'
-  const logoId = serviceLogoId(account.id)
-  const homeUrl = serviceHomeUrl(account.id)
+  const logoId = serviceLogoId(account.provider)
+  const homeUrl = serviceHomeUrl(account.provider)
 
   return (
     <Card className="flex flex-col gap-3 p-4 sm:p-5">
@@ -43,7 +43,7 @@ export function ProviderPlaylistsCard({
           title its own full-width line first avoids both. */}
       <div className="flex flex-col items-start gap-1.5">
         <div className="flex w-full items-center gap-2">
-          {logoId && <ServiceLogo service={logoId} className={cn('size-4 shrink-0', tagText(account.id))} />}
+          {logoId && <ServiceLogo service={logoId} className={cn('size-4 shrink-0', tagText(account.provider))} />}
           <h3 className="min-w-0 flex-1 truncate text-base font-bold text-text">{account.name}</h3>
           {connected && entry && entry.playlists.length > 0 && (
             <span className="shrink-0 font-mono text-[11px] text-text-3">

--- a/frontend/src/components/settings/PlaylistFilterField.tsx
+++ b/frontend/src/components/settings/PlaylistFilterField.tsx
@@ -35,6 +35,7 @@ interface PickerSource {
   /** The provider the list is drawn from — `null` when it's a union across
    * every connected service (Spotify isn't connected). */
   providerId: string | null
+  provider: string | null
   providerLabel: string
   playlists: ProviderPlaylist[]
   loading: boolean
@@ -55,7 +56,9 @@ function usePickerSource(preferredProviderId?: string | null): PickerSource {
   const connected = useMemo(() => accounts?.filter((a: Account) => a.state === 'connected') ?? [], [accounts])
   const connectedIds = useMemo(() => connected.map((a) => a.id), [connected])
   const { entries } = useProviderPlaylists(connectedIds)
-  const pinned = connected.find((a) => a.id === (preferredProviderId || 'spotify'))
+  const pinned = preferredProviderId
+    ? connected.find((a) => a.id === preferredProviderId)
+    : connected.find((a) => a.provider === 'spotify')
 
   return useMemo<PickerSource>(() => {
     const hasConnectedAccounts = connected.length > 0
@@ -64,6 +67,7 @@ function usePickerSource(preferredProviderId?: string | null): PickerSource {
       const entry = entries[pinned.id]
       return {
         providerId: pinned.id,
+        provider: pinned.provider,
         providerLabel: pinned.name,
         playlists: entry?.playlists ?? [],
         loading: !entry || entry.loading,
@@ -73,7 +77,7 @@ function usePickerSource(preferredProviderId?: string | null): PickerSource {
     }
 
     if (!hasConnectedAccounts) {
-      return { providerId: null, providerLabel: '', playlists: [], loading: false, error: null, hasConnectedAccounts }
+      return { providerId: null, provider: null, providerLabel: '', playlists: [], loading: false, error: null, hasConnectedAccounts }
     }
 
     const seen = new Map<string, ProviderPlaylist>()
@@ -89,6 +93,7 @@ function usePickerSource(preferredProviderId?: string | null): PickerSource {
 
     return {
       providerId: null,
+      provider: null,
       providerLabel: 'your connected services',
       playlists: [...seen.values()].sort((a, b) => a.name.localeCompare(b.name)),
       loading: !allSettled && seen.size === 0,
@@ -241,7 +246,7 @@ export function PlaylistFilterField({
     onChange(joinCsv(selectedNames.filter((n) => casefold(n) !== key)))
   }
 
-  const likedTracksLabel = providerLikedTracksLabel(source.providerId, source.providerLabel)
+  const likedTracksLabel = providerLikedTracksLabel(source.provider, source.providerLabel)
   const showLikedTracks = includeLikedTracks && Boolean(source.providerId) && Boolean(onLikedTracksChange)
   const isEmpty = selectedNames.length === 0 && !likedTracksSelected
   const syncingAllWithLiked = likedTracksSelected && syncAllRegularPlaylists && selectedNames.length === 0

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -149,7 +149,7 @@ function ProviderChip({
   role?: 'source' | 'order' | 'authority' | 'mirror'
   onToggle: () => void
 }) {
-  const logoId = serviceLogoId(account.id)
+  const logoId = serviceLogoId(account.provider)
   const connected = account.state === 'connected'
 
   return (
@@ -175,9 +175,9 @@ function ProviderChip({
       )}
     >
       {logoId ? (
-        <ServiceLogo service={logoId} className={cn('size-4 shrink-0', connected && tagText(account.id))} />
+        <ServiceLogo service={logoId} className={cn('size-4 shrink-0', connected && tagText(account.provider))} />
       ) : (
-        <span className={cn('size-2 shrink-0 rounded-full', tagDot(account.id))} aria-hidden="true" />
+        <span className={cn('size-2 shrink-0 rounded-full', tagDot(account.provider))} aria-hidden="true" />
       )}
       {account.name}
       {role && connected && checked && (
@@ -194,7 +194,7 @@ function ProviderChip({
  * source of truth" picker — same visual language as ProviderChip, but
  * exclusive-choice (radio) rather than a toggle set. */
 function SourceChip({ account, selected, onSelect }: { account: Account; selected: boolean; onSelect: () => void }) {
-  const logoId = serviceLogoId(account.id)
+  const logoId = serviceLogoId(account.provider)
   const connected = account.state === 'connected'
 
   return (
@@ -215,9 +215,9 @@ function SourceChip({ account, selected, onSelect }: { account: Account; selecte
       )}
     >
       {logoId ? (
-        <ServiceLogo service={logoId} className={cn('size-4 shrink-0', connected && tagText(account.id))} />
+        <ServiceLogo service={logoId} className={cn('size-4 shrink-0', connected && tagText(account.provider))} />
       ) : (
-        <span className={cn('size-2 shrink-0 rounded-full', tagDot(account.id))} aria-hidden="true" />
+        <span className={cn('size-2 shrink-0 rounded-full', tagDot(account.provider))} aria-hidden="true" />
       )}
       {account.name}
       {!connected && <span className="font-normal text-text-3">not connected</span>}
@@ -308,10 +308,9 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     if (!job) {
       // Snapshot the connected peers now. Persisting an empty sentinel would
       // make this job silently gain every provider connected in the future.
-      initial.providers = syncPeersOf(accounts)
-        .filter((account) => account.state === 'connected')
-        .map((account) => account.id)
-        .join(',')
+      const connected = syncPeersOf(accounts).filter((account) => account.state === 'connected')
+      initial.providers = connected.map((account) => account.id).join(',')
+      initial.source = connected.find((account) => account.provider === 'spotify')?.id ?? connected[0]?.id ?? initial.source
     }
     setForm(initial)
     setStep(0)
@@ -330,12 +329,13 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   }
 
   const syncPeers = syncPeersOf(accounts)
-  const jellyfinConnected = accounts.some((a) => a.id === 'jellyfin' && a.state === 'connected')
+  const jellyfinConnected = accounts.some((a) => a.provider === 'jellyfin' && a.state === 'connected')
 
   // One-way uses this as its source of truth. In group mode it is the order
   // authority: playlist names and sequence follow it, while membership can be
   // changed on any authority.
   const syncSource = form.source || 'spotify'
+  const sourceAccount = syncPeers.find((account) => account.id === syncSource)
   const authorityIds = authorityProvidersOf({ mode: form.mode, authorities: form.authorities })
   const lockedProviderIds = lockedProvidersOf({
     mode: form.mode,
@@ -344,7 +344,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   })
   if (form.liked_tracks) lockedProviderIds.add(syncSource)
   const nonSpotifySourceConflict =
-    form.mode !== 'nway' && syncSource !== 'spotify' && (form.download || jellyfinConnected)
+    form.mode !== 'nway' && sourceAccount?.provider !== 'spotify' && (form.download || jellyfinConnected)
 
   const enabledProviders = enabledProvidersOf({ providers: form.providers }, syncPeers)
   const connectedPeerIds = new Set(syncPeers.filter((account) => account.state === 'connected').map((account) => account.id))
@@ -358,10 +358,13 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
       const next = { ...prev, mode }
       const connected = syncPeers.filter((account) => account.state === 'connected').map((account) => account.id)
       if (mode === 'group') {
+        const spotifyAccount = syncPeers.find(
+          (account) => account.state === 'connected' && account.provider === 'spotify',
+        )?.id
         const source = connected.includes(prev.source)
           ? prev.source
-          : connected.includes('spotify')
-            ? 'spotify'
+          : spotifyAccount
+            ? spotifyAccount
             : connected[0] || prev.source
         const authorities = new Set(parseCsv(prev.authorities).filter((id) => connected.includes(id)))
         if (source) authorities.add(source)
@@ -451,10 +454,11 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
     ? syncSource
     : form.mode !== 'nway'
       ? syncSource
-      : (enabledProviders.has('spotify') ? 'spotify' : syncPeers.find((a) => enabledProviders.has(a.id))?.id) || null
+      : (syncPeers.find((account) => account.provider === 'spotify' && enabledProviders.has(account.id))?.id
+        ?? syncPeers.find((account) => enabledProviders.has(account.id))?.id) || null
 
   const likedSourceName = syncPeers.find((account) => account.id === syncSource)?.name ?? syncSource
-  const likedPlaylistSuggestion = providerLikedTracksLabel(syncSource, likedSourceName)
+  const likedPlaylistSuggestion = providerLikedTracksLabel(sourceAccount?.provider, likedSourceName)
   const likedDestinations = syncPeers.filter(
     (account) => enabledProviders.has(account.id) && account.id !== syncSource,
   )
@@ -828,10 +832,10 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                         return (
                           <div key={account.id} className="flex flex-col gap-2">
                             <div className="flex items-center gap-2 text-[12.5px] font-semibold text-text-2">
-                              {serviceLogoId(account.id) ? (
-                                <ServiceLogo service={serviceLogoId(account.id)!} className={cn('size-4', tagText(account.id))} />
+                              {serviceLogoId(account.provider) ? (
+                                <ServiceLogo service={serviceLogoId(account.provider)!} className={cn('size-4', tagText(account.provider))} />
                               ) : (
-                                <span className={cn('size-2 rounded-full', tagDot(account.id))} aria-hidden="true" />
+                                <span className={cn('size-2 rounded-full', tagDot(account.provider))} aria-hidden="true" />
                               )}
                               {account.name}
                             </div>
@@ -845,7 +849,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                                 value="native"
                                 checked={route.kind === 'native'}
                                 onChange={() => setLikedRoute(account.id, { kind: 'native' })}
-                                title={`Use ${account.name} ${nativeLikedTracksName(account.id)}`}
+                                title={`Use ${account.name} ${nativeLikedTracksName(account.provider)}`}
                                 description="Sync directly into this service's built-in liked collection."
                               />
                               <RadioCard

--- a/frontend/src/components/transfers/TransferProgress.tsx
+++ b/frontend/src/components/transfers/TransferProgress.tsx
@@ -15,7 +15,7 @@ import { ServiceLogo } from '../ui/ServiceLogo'
 import { LoadingStatus, Skeleton } from '../ui/Skeleton'
 import { Spinner } from '../ui/Spinner'
 
-function EndpointBadge({ provider, playlistName }: { provider: string; playlistName: string }) {
+function EndpointBadge({ provider, accountName, playlistName }: { provider: string; accountName?: string; playlistName: string }) {
   const logoId = serviceLogoId(provider)
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5">
@@ -25,7 +25,7 @@ function EndpointBadge({ provider, playlistName }: { provider: string; playlistN
         <span className={cn('size-2 shrink-0 rounded-full', tagDot(provider))} aria-hidden="true" />
       )}
       <span className="min-w-0 truncate font-semibold text-text">{playlistName}</span>
-      <span className="shrink-0 text-xs font-normal text-text-3">({tagLabel(provider)})</span>
+      <span className="shrink-0 text-xs font-normal text-text-3">({accountName || tagLabel(provider)})</span>
     </span>
   )
 }
@@ -192,9 +192,9 @@ export function TransferProgress({
     <Card className="flex flex-col gap-4 p-4 sm:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm">
-          <EndpointBadge provider={job.source.provider} playlistName={job.source.playlist_name} />
+          <EndpointBadge provider={job.source.provider} accountName={job.source.name} playlistName={job.source.playlist_name} />
           <LuArrowRight className="size-3.5 shrink-0 text-text-3" aria-hidden="true" />
-          <EndpointBadge provider={job.dest.provider} playlistName={job.dest.playlist_name} />
+          <EndpointBadge provider={job.dest.provider} accountName={job.dest.name} playlistName={job.dest.playlist_name} />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Pill toneClasses={style.badge} label={style.label} pulsing={isRunning} />

--- a/frontend/src/components/transfers/TransferSetupForm.tsx
+++ b/frontend/src/components/transfers/TransferSetupForm.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { api, errorMessage } from '@/api'
 import type { ProviderPlaylistsEntry } from '@/hooks/useProviderPlaylists'
 import { cn } from '@/lib/cn'
-import { serviceLogoId, tagLabel, tagText } from '@/lib/constants'
+import { serviceLogoId, tagText } from '@/lib/constants'
 import type { Account, StartTransferRequest, TransferSourcePreview } from '@/types'
 
 import { Button } from '../ui/Button'
@@ -34,11 +34,11 @@ const SOURCE_MODE_OPTIONS = [
   { value: 'link', label: 'Paste a link' },
 ]
 
-/** A provider id's brand mark, tinted with its identity color — undefined
- * (no icon) for an unset or unrecognized id. */
-function serviceIcon(providerId: string) {
-  const logoId = serviceLogoId(providerId)
-  return logoId ? <ServiceLogo service={logoId} className={`size-4 ${tagText(providerId)}`} /> : undefined
+/** A profile's provider brand mark, tinted with its provider identity color. */
+function serviceIcon(account: Account | undefined) {
+  const provider = account?.provider ?? ''
+  const logoId = serviceLogoId(provider)
+  return logoId ? <ServiceLogo service={logoId} className={`size-4 ${tagText(provider)}`} /> : undefined
 }
 
 export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
@@ -64,6 +64,8 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
   // Same-provider transfers are allowed (e.g. copy a followed Spotify list into a
   // new owned Spotify playlist), so the destination service list isn't filtered.
   const destProviderOptions = transferable
+  const sourceAccount = transferable.find((account) => account.id === sourceProvider)
+  const destAccount = transferable.find((account) => account.id === destProvider)
 
   // Default "create new"'s name to the source playlist's name — re-derives
   // whenever the source playlist or the create-new choice changes, but a
@@ -99,7 +101,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
     : destMode === 'create'
       ? 'A new playlist has nothing to reorder — copies land in source order.'
       : !destSupportsOrder
-        ? `${tagLabel(destProvider)} can't replay order safely, so copies land at the end of the playlist.`
+        ? `${destAccount?.name ?? 'This account'} can't replay order safely, so copies land at the end of the playlist.`
         : 'Slower, and writes every track after the oldest new one again. Off: copies land at the end.'
 
   // Copying a playlist into itself is a no-op — block only the exact same-provider,
@@ -115,19 +117,18 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
 
   async function handlePreview() {
     const url = sourceLink.trim()
-    if (!url) return
+    if (!url || !sourceProvider) return
     setPreviewing(true)
     setPreviewError(null)
     try {
-      const resolved = await api.previewTransferSource(url)
+      const resolved = await api.previewTransferSource(url, sourceProvider)
       setPreview(resolved)
       // A resolved link fills in exactly what the library picker would have, so
       // everything downstream (confirm, start, progress) is unchanged.
-      setSourceProvider(resolved.provider)
+      setSourceProvider(resolved.account)
       setSourcePlaylistId(resolved.playlist_id)
     } catch (err) {
       setPreview(null)
-      setSourceProvider('')
       setSourcePlaylistId('')
       setPreviewError(errorMessage(err))
     } finally {
@@ -140,7 +141,6 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
     // A link edited after resolving is no longer the thing that was resolved.
     if (preview) {
       setPreview(null)
-      setSourceProvider('')
       setSourcePlaylistId('')
     }
     setPreviewError(null)
@@ -159,9 +159,9 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
     setError(null)
     try {
       const body: StartTransferRequest = {
-        source_provider: sourceProvider,
+        source_account: sourceProvider,
         source_playlist_id: sourcePlaylistId,
-        dest_provider: destProvider,
+        dest_account: destProvider,
         dest_playlist_id: destMode === 'create' ? null : destPlaylistId,
         dest_name: destMode === 'create' ? destName.trim() : (destPlaylist?.name ?? ''),
         preserve_order: canPreserveOrder && preserveOrder,
@@ -187,8 +187,8 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
 
       {transferable.length < 2 ? (
         <p className="text-sm text-text-3">
-          Connect at least 2 transferable services on the Accounts page to copy a playlist between
-          them. Browse-only services like Jellyfin can't be a transfer endpoint.
+          Connect at least 2 transferable accounts on the Accounts page to copy a playlist between
+          them. Browse-only accounts like Jellyfin can't be a transfer endpoint.
         </p>
       ) : (
         <>
@@ -220,7 +220,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                   <>
                     <SelectField
                       label="Service"
-                      icon={serviceIcon(sourceProvider)}
+                      icon={serviceIcon(sourceAccount)}
                       options={[{ value: '', label: 'Choose a service…' }, ...transferable.map((a) => ({ value: a.id, label: a.name }))]}
                       value={sourceProvider}
                       onChange={(e) => {
@@ -239,6 +239,19 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                   </>
                 ) : (
                   <>
+                    <SelectField
+                      label="Open with account"
+                      help="The link must belong to the selected account's service."
+                      icon={serviceIcon(sourceAccount)}
+                      options={[{ value: '', label: 'Choose an account…' }, ...transferable.map((a) => ({ value: a.id, label: a.name }))]}
+                      value={sourceProvider}
+                      onChange={(e) => {
+                        setSourceProvider(e.target.value)
+                        setSourcePlaylistId('')
+                        setPreview(null)
+                        setPreviewError(null)
+                      }}
+                    />
                     <TextField
                       label="Playlist link"
                       help="A public playlist URL from any connected service. It does not have to be saved in your library."
@@ -256,13 +269,13 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                       <Button
                         variant="secondary"
                         onClick={() => void handlePreview()}
-                        disabled={!sourceLink.trim() || previewing}
+                        disabled={!sourceProvider || !sourceLink.trim() || previewing}
                       >
                         {previewing ? 'Opening…' : 'Open link'}
                       </Button>
                       {preview && (
                         <span className="flex min-w-0 items-center gap-1.5 text-xs text-text-3">
-                          {serviceIcon(preview.provider)}
+                          {serviceIcon(sourceAccount)}
                           <span className="truncate font-semibold text-text-2">{preview.name}</span>
                         </span>
                       )}
@@ -315,7 +328,7 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
                         : 'Pick a source service first.'
                       : undefined
                   }
-                  icon={serviceIcon(destProvider)}
+                  icon={serviceIcon(destAccount)}
                   options={[
                     { value: '', label: 'Choose a service…' },
                     ...destProviderOptions.map((a) => ({ value: a.id, label: a.name })),
@@ -403,11 +416,11 @@ export function TransferSetupForm({ accounts, entries, onStarted }: Props) {
         title="Copy this playlist?"
         description={
           sourcePlaylist
-            ? `"${sourcePlaylist.name}" will be copied from ${tagLabel(sourceProvider)} to ${
+            ? `"${sourcePlaylist.name}" will be copied from ${sourceAccount?.name ?? 'the source account'} to ${
                 destMode === 'create'
                   ? `a new playlist named "${destName.trim()}"`
                   : `"${destPlaylist?.name ?? ''}"`
-              } on ${tagLabel(destProvider)}. Existing tracks on the destination are kept, this only adds.${
+              } on ${destAccount?.name ?? 'the destination account'}. Existing tracks on the destination are kept, this only adds.${
                 canPreserveOrder && preserveOrder
                   ? ' Tracks already there will be rewritten to keep Recently Added order, which takes longer.'
                   : ''

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -10,6 +10,8 @@ function isAccountArray(value: unknown): value is Account[] {
         account !== null &&
         typeof account === 'object' &&
         typeof account.id === 'string' &&
+        typeof account.provider === 'string' &&
+        typeof account.label === 'string' &&
         typeof account.name === 'string' &&
         typeof account.state === 'string' &&
         Array.isArray(account.fields) &&

--- a/frontend/src/lib/syncSummary.ts
+++ b/frontend/src/lib/syncSummary.ts
@@ -100,15 +100,16 @@ export function buildSyncSummaryRows(job: SyncJob, peers: Account[], downloadDir
 
   if (job.liked_tracks) {
     const sourceId = job.source || 'spotify'
-    const sourceName = peers.find((peer) => peer.id === sourceId)?.name ?? sourceId
-    const sourceLabel = providerLikedTracksLabel(sourceId, sourceName)
+    const sourcePeer = peers.find((peer) => peer.id === sourceId)
+    const sourceName = sourcePeer?.name ?? sourceId
+    const sourceLabel = providerLikedTracksLabel(sourcePeer?.provider, sourceName)
     const destinations = peers
       .filter((peer) => enabled.has(peer.id) && peer.id !== sourceId)
       .map((peer) => {
         const route = job.liked_routes?.[peer.id]
         return route?.kind === 'playlist'
           ? `${peer.name} “${route.name}”`
-          : providerLikedTracksLabel(peer.id, peer.name)
+          : providerLikedTracksLabel(peer.provider, peer.name)
       })
     const arrow = job.mode === 'oneway' ? '→' : '⇄'
     rows.push({

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -1,10 +1,41 @@
+import { useState } from 'react'
+
+import { api, errorMessage } from '@/api'
 import { AccountCard } from '@/components/accounts/AccountCard'
+import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { SelectField } from '@/components/ui/SelectField'
 import { LoadingStatus, Skeleton } from '@/components/ui/Skeleton'
+import { TextField } from '@/components/ui/TextField'
 import { useAccounts } from '@/hooks/useAccounts'
+
+const PROVIDERS = [
+  ['spotify', 'Spotify'], ['tidal', 'TIDAL'], ['qobuz', 'Qobuz'], ['deezer', 'Deezer'],
+  ['amazon', 'Amazon Music'], ['apple', 'Apple Music'], ['ytmusic', 'YouTube Music'],
+  ['jellyfin', 'Jellyfin'],
+] as const
 
 export default function Accounts() {
   const { accounts, loading, error, refresh } = useAccounts()
+  const [adding, setAdding] = useState(false)
+  const [provider, setProvider] = useState('spotify')
+  const [label, setLabel] = useState('')
+  const [addError, setAddError] = useState<string | null>(null)
+
+  async function addProfile() {
+    setAdding(true)
+    setAddError(null)
+    try {
+      await api.addAccount(provider, label.trim())
+      setLabel('')
+      await refresh()
+    } catch (err) {
+      setAddError(errorMessage(err))
+    } finally {
+      setAdding(false)
+    }
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -14,6 +45,26 @@ export default function Accounts() {
           Credentials never leave this machine. They're stored in SongMirror's own data folder.
         </p>
       </div>
+
+      <Card className="flex flex-col gap-3 p-4 sm:flex-row sm:items-end">
+        <SelectField
+          label="Provider"
+          value={provider}
+          onChange={(event) => setProvider(event.target.value)}
+          options={PROVIDERS.map(([value, name]) => ({ value, label: name }))}
+        />
+        <TextField
+          label="New profile label"
+          help="Use a household member or purpose, such as Alex or Work."
+          placeholder="e.g. Alex"
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+        />
+        <Button loading={adding} onClick={() => void addProfile()}>
+          Add profile
+        </Button>
+      </Card>
+      {addError && <p className="rounded-control bg-danger-soft px-3 py-2 text-sm text-danger">Could not add profile: {addError}</p>}
 
       {error && <p className="rounded-control bg-danger-soft px-3 py-2 text-sm text-danger">Could not load accounts: {error}</p>}
 

--- a/frontend/src/pages/ResolveMappings.tsx
+++ b/frontend/src/pages/ResolveMappings.tsx
@@ -256,7 +256,8 @@ function GuideStep({ number, title, children }: { number: string; title: string;
 }
 
 function ProviderTab({ row, active, onSelect }: { row: ResolveCacheProvider; active: boolean; onSelect: () => void }) {
-  const logoId = serviceLogoId(row.id)
+  const provider = row.provider ?? row.id
+  const logoId = serviceLogoId(provider)
   return (
     <button
       type="button"
@@ -271,7 +272,7 @@ function ProviderTab({ row, active, onSelect }: { row: ResolveCacheProvider; act
           : 'border-border bg-surface text-text-3 hover:bg-surface-2 hover:text-text-2',
       )}
     >
-      {logoId && <ServiceLogo service={logoId} className={`size-4 ${tagText(row.id)}`} />}
+      {logoId && <ServiceLogo service={logoId} className={`size-4 ${tagText(provider)}`} />}
       <span className={cn('text-sm', active ? 'font-bold' : 'font-semibold')}>{row.name}</span>
       <span className={cn('font-mono text-xs', active ? 'text-accent' : 'text-text-3')}>{row.total}</span>
     </button>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,7 +19,14 @@ export interface AccountField {
 }
 
 export interface Account {
+  /** Stable selectable profile id. Never equal to a provider type id. */
   id: string
+  /** Connector/catalog type shared by one or more profiles. */
+  provider: string
+  provider_name: string
+  label: string
+  is_default: boolean
+  removable: boolean
   name: string
   auth_kind: AuthKind
   fields: AccountField[]
@@ -376,7 +383,9 @@ export interface LinkUpsertRequest {
 export type TransferStatus = 'queued' | 'running' | 'done' | 'error' | 'busy' | 'paused' | 'stopped'
 
 export interface TransferEndpoint {
+  account: string
   provider: string
+  name?: string
   playlist_id: string
   playlist_name: string
 }
@@ -417,9 +426,9 @@ export interface TransferJob {
  * named `dest_name` on the destination instead of copying into an existing
  * one. */
 export interface StartTransferRequest {
-  source_provider: string
+  source_account: string
   source_playlist_id: string
-  dest_provider: string
+  dest_account: string
   dest_playlist_id: string | null
   dest_name: string
   /** Repair the destination's date-added order when a copied track is older
@@ -445,6 +454,7 @@ export interface TransferControlResponse {
 
 /** POST /api/transfers/preview: what a pasted playlist link resolves to. */
 export interface TransferSourcePreview {
+  account: string
   provider: string
   playlist_id: string
   name: string
@@ -457,6 +467,7 @@ export interface TransferSourcePreview {
 /** GET /api/resolve-cache: one provider's cached-mapping counts. */
 export interface ResolveCacheProvider {
   id: string
+  provider?: string
   name: string
   total: number
   /** Mappings a person set by hand in the transfer conflict editor. */

--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -177,6 +177,30 @@ ON playlist_track_cache (provider, track_id)
 """,
 ]
 
+# Columns whose values historically held a provider type (``spotify``,
+# ``tidal``, ...), but now hold an account-profile identity. Profile-aware
+# archive opens migrate them every time because an older headless CLI may write
+# fresh legacy rows into a database after the first web-app upgrade.
+_PROFILE_ID_COLUMNS = (
+    ("songs", "source"),
+    ("links", "target"),
+    ("sync_state", "target"),
+    ("playlist_state", "source"),
+    ("playlist_state_meta", "source"),
+    ("playlist_pending_removal", "source"),
+    ("track_identity", "source"),
+    ("track_identity_history", "source"),
+    ("playlist_order", "source"),
+)
+
+_GROUP_KEY_COLUMNS = (
+    ("sync_state", "pair"),
+    ("playlist_state", "playlist"),
+    ("playlist_state_meta", "playlist"),
+    ("playlist_pending_removal", "playlist"),
+    ("playlist_order", "playlist"),
+)
+
 UPSERT = """
 INSERT INTO songs (source, id, isrc, name, artist, album, duration_ms, meta, first_seen, last_seen)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -191,7 +215,7 @@ def _now():
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def connect(path):
+def connect(path, source_aliases=None):
     # Connections are opened on the coordinator thread and then assigned
     # exclusively to one provider worker. check_same_thread=False permits that
     # handoff; separate connections plus the timeout safely serialize file writes.
@@ -239,7 +263,130 @@ def connect(path):
         "SELECT source, track_id, canonical_id, updated FROM track_identity",
     )
     conn.commit()
+    if source_aliases:
+        try:
+            _migrate_profile_namespaces(conn, source_aliases)
+        except Exception:
+            conn.close()
+            raise
     return conn
+
+
+def _table_columns(conn, table):
+    return [row[1] for row in conn.execute(f'PRAGMA table_info("{table}")')]
+
+
+def _insert_remapped_rows(conn, table, column, old, new, *, extra="", params=()):
+    """Copy matching rows with one column replaced, preserving destination rows."""
+    columns = _table_columns(conn, table)
+    quoted = ", ".join(f'"{name}"' for name in columns)
+    selected = ", ".join("?" if name == column else f'"{name}"' for name in columns)
+    conn.execute(
+        f'INSERT OR IGNORE INTO "{table}" ({quoted}) '
+        f'SELECT {selected} FROM "{table}" WHERE "{column}" = ?{extra}',
+        (new, old, *params),
+    )
+
+
+def _remap_column_value(conn, table, column, old, new):
+    if old == new:
+        return
+    _insert_remapped_rows(conn, table, column, old, new)
+    conn.execute(f'DELETE FROM "{table}" WHERE "{column}" = ?', (old,))
+
+
+def _profile_group_key(value, aliases):
+    """Rewrite the authority set embedded in an authoritative-group state key."""
+    value = str(value)
+    if not value.startswith("group:"):
+        return value
+    authorities, separator, logical_key = value.removeprefix("group:").partition(":")
+    if not separator:
+        return value
+    mapped = sorted({aliases.get(identity, identity) for identity in authorities.split(",")})
+    return f"group:{','.join(mapped)}:{logical_key}"
+
+
+def _migrate_playlist_cache(conn, old, new):
+    """Move complete cached ledgers without blending colliding snapshots."""
+    legacy_ids = conn.execute(
+        "SELECT playlist_id FROM playlist_cache WHERE provider = ?", (old,)
+    ).fetchall()
+    for (playlist_id,) in legacy_ids:
+        destination = conn.execute(
+            "SELECT 1 FROM playlist_cache WHERE provider = ? AND playlist_id = ?",
+            (new, playlist_id),
+        ).fetchone()
+        if destination is None:
+            # An orphaned destination track set has no readable header and must
+            # not collide position-by-position with the complete legacy ledger.
+            conn.execute(
+                "DELETE FROM playlist_track_cache WHERE provider = ? AND playlist_id = ?",
+                (new, playlist_id),
+            )
+            _insert_remapped_rows(
+                conn,
+                "playlist_track_cache",
+                "provider",
+                old,
+                new,
+                extra=" AND playlist_id = ?",
+                params=(playlist_id,),
+            )
+            _insert_remapped_rows(
+                conn,
+                "playlist_cache",
+                "provider",
+                old,
+                new,
+                extra=" AND playlist_id = ?",
+                params=(playlist_id,),
+            )
+    # A profile-era destination ledger wins a collision as one atomic snapshot;
+    # never merge extra legacy positions into it.
+    conn.execute("DELETE FROM playlist_track_cache WHERE provider = ?", (old,))
+    conn.execute("DELETE FROM playlist_cache WHERE provider = ?", (old,))
+
+
+def _migrate_profile_namespaces(conn, source_aliases):
+    """Atomically move legacy provider-keyed state to default profile ids.
+
+    Inserts happen before deletes and use ``OR IGNORE`` so current profile-era
+    rows win primary-key collisions. Membership/history tables naturally union
+    non-conflicting evidence. The transaction makes a failed copy fully
+    rollback-safe, and the absence of a one-time marker lets later legacy CLI
+    writes migrate on the next profile-aware open.
+    """
+    aliases = {
+        str(old): str(new)
+        for old, new in source_aliases.items()
+        if old and new and str(old) != str(new)
+    }
+    if not aliases:
+        return
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for old, new in aliases.items():
+            for table, column in _PROFILE_ID_COLUMNS:
+                _remap_column_value(conn, table, column, old, new)
+            _migrate_playlist_cache(conn, old, new)
+
+        # Group reconciliation keys embed a sorted authority set in addition to
+        # carrying a source column. Rewrite both dimensions so established
+        # baselines and pending-removal confirmations survive the upgrade.
+        for table, column in _GROUP_KEY_COLUMNS:
+            values = conn.execute(
+                f'SELECT DISTINCT "{column}" FROM "{table}" '
+                f'WHERE "{column}" LIKE \'group:%\''
+            ).fetchall()
+            for (old_value,) in values:
+                new_value = _profile_group_key(old_value, aliases)
+                if new_value != old_value:
+                    _remap_column_value(conn, table, column, old_value, new_value)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
 
 
 def upsert_many(conn, source, tracks):
@@ -340,6 +487,24 @@ def get_isrcs(conn, source, ids):
         conn, "SELECT id, isrc FROM songs WHERE source = ? AND isrc IS NOT NULL AND id IN ({marks})",
         [source], ids)
     return {k: v for k, v in got.items() if v}
+
+
+def get_isrcs_from_sources(conn, sources, ids):
+    """ISRCs for globally stable track ids seen through any selected account.
+
+    Spotify catalog ids are shared by its accounts, but a track may only have
+    been archived through a custom profile. Preserve source order on the rare
+    conflicting row and stop querying once every requested id is satisfied.
+    """
+    wanted = [track_id for track_id in ids if track_id]
+    out = {}
+    for source in dict.fromkeys(source for source in sources if source):
+        remaining = [track_id for track_id in wanted if track_id not in out]
+        if not remaining:
+            break
+        for track_id, isrc in get_isrcs(conn, source, remaining).items():
+            out.setdefault(track_id, isrc)
+    return out
 
 
 def get_snapshots(conn, source, ids):

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -9,6 +9,7 @@ import json
 import os
 import threading
 import time
+from contextlib import nullcontext
 
 from dotenv import load_dotenv
 
@@ -24,8 +25,10 @@ from .targets import (
     mirror_pair,
     nway_order_candidates,
     reconcile,
+    target_provider,
 )
 from .targets.base import _normalize, reconcile_state_key
+from ..services.settings import _ENV_LOCK
 
 
 class _SourceAuthError(TargetAuthError):
@@ -150,12 +153,31 @@ def _summary(opts, per_target, started, *, ok=True, error=None, interrupted=None
     }
 
 
-def _load_links():
+def _load_links(opts=None):
     """Enabled explicit pairings (empty when none configured, so behavior is
     unchanged). Late import keeps the engine's module graph free of the web tier."""
     from ..services.playlists import LinkStore
 
-    return [link for link in LinkStore().list() if link.enabled]
+    profiles = getattr(opts, "account_profiles", None) if opts is not None else None
+    directory = profiles.settings.data_dir if profiles is not None else "data"
+    return [
+        link for link in LinkStore(dir=directory, profiles=profiles).list()
+        if link.enabled
+    ]
+
+
+def _target_activation(target):
+    activate = getattr(target, "activate", None)
+    return activate() if activate is not None else nullcontext()
+
+
+def _archive_connection(path, profiles=None):
+    # Preserve the historical one-argument archive.connect call for headless
+    # users and tests that replace it; only profile-aware runs request namespace
+    # migration.
+    if profiles is None:
+        return archive.connect(path)
+    return archive.connect(path, source_aliases=profiles.archive_aliases())
 
 
 def run_target(target, selected, get_source_tracks, songs, opts, links=None, source=None, should_continue=None):
@@ -243,11 +265,22 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                 raise _SourceAuthError(str(exc)) from exc
 
             try:
+                pair_options = {
+                    "execute": opts.execute,
+                    "max_removals": opts.max_removals,
+                    "max_adds": opts.max_adds,
+                    "drain_removals": opts.apply_large_removals,
+                    "should_continue": should_continue,
+                    "source_key": src_key,
+                    "source_name": source.name,
+                    "name": name,
+                }
+                source_type = target_provider(source)
+                if source_type != src_key:
+                    pair_options["source_provider"] = source_type
                 res = mirror_pair(
                     target, source_tracks, sp_playlist, tgt, cache, songs,
-                    execute=opts.execute, max_removals=opts.max_removals, max_adds=opts.max_adds,
-                    drain_removals=opts.apply_large_removals, should_continue=should_continue,
-                    source_key=src_key, source_name=source.name, name=name,
+                    **pair_options,
                 )
                 agg["pairs"] += 1
                 for k in ("added", "removed", "missing", "held", "deferred",
@@ -323,6 +356,19 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                     except TargetAuthError as exc:
                         raise _SourceAuthError(str(exc)) from exc
                     try:
+                        liked_options = {
+                            "execute": opts.execute,
+                            "max_removals": opts.max_removals,
+                            "max_adds": opts.max_adds,
+                            "drain_removals": opts.apply_large_removals,
+                            "should_continue": should_continue,
+                            "source_key": src_key,
+                            "source_name": source.name,
+                            "name": source_name,
+                        }
+                        source_type = target_provider(source)
+                        if source_type != src_key:
+                            liked_options["source_provider"] = source_type
                         result = mirror_pair(
                             target,
                             source_tracks,
@@ -330,14 +376,7 @@ def run_target(target, selected, get_source_tracks, songs, opts, links=None, sou
                             target_resource,
                             cache,
                             songs,
-                            execute=opts.execute,
-                            max_removals=opts.max_removals,
-                            max_adds=opts.max_adds,
-                            drain_removals=opts.apply_large_removals,
-                            should_continue=should_continue,
-                            source_key=src_key,
-                            source_name=source.name,
-                            name=source_name,
+                            **liked_options,
                         )
                         agg["pairs"] += 1
                         for key in (
@@ -383,20 +422,37 @@ def run_pass(opts, should_continue=None):
     # The web app points SONGMIRROR_ENV_FILE at SettingsStore's managed file so wizard
     # saves win; the headless CLI falls back to a plain .env. Either way this
     # picks up re-captured tokens without a restart.
-    load_dotenv(os.getenv("SONGMIRROR_ENV_FILE") or ".env", override=True)
+    with _ENV_LOCK:
+        load_dotenv(os.getenv("SONGMIRROR_ENV_FILE") or ".env", override=True)
+    profiles = getattr(opts, "account_profiles", None)
     wanted_providers = _wanted_providers(opts)
-    spotify_requested = not wanted_providers or "spotify" in wanted_providers
+    if profiles is not None:
+        participant_ids = list(dict.fromkeys(profiles.expand_ids(opts.providers)))
+        wanted_providers = set(participant_ids)
+        opts.providers = ",".join(participant_ids)
+        opts.sync_source = profiles.canonical_id(opts.sync_source)
+        opts.authorities = ",".join(profiles.expand_ids(opts.authorities))
+        opts.liked_routes = {
+            profiles.canonical_id(identity): route
+            for identity, route in (getattr(opts, "liked_routes", None) or {}).items()
+        }
+        spotify_requested = not wanted_providers or any(
+            profiles.provider_of(identity) == "spotify" for identity in wanted_providers
+        )
+    else:
+        spotify_requested = not wanted_providers or "spotify" in wanted_providers
     # Group mode's order authority also supplies playlist names and ordering.
     # It remains writable because additions from another authority flow back.
     source_provider = opts.sync_source if opts.sync_mode in {"oneway", "group"} else None
     # Spotify needs a writable client whenever it's a write destination: any
     # N-way/group execute, or a one-way execute where another provider is the
     # source and Spotify is one of the targets.
-    spotify_is_target = (opts.sync_mode == "oneway" and source_provider != "spotify"
+    source_provider_type = profiles.provider_of(source_provider) if profiles is not None else source_provider
+    spotify_is_target = (opts.sync_mode == "oneway" and source_provider_type != "spotify"
                          and spotify_requested)
     sp = None
     cookie_spotify = spotify_write_backend() == "cookie" and spotify_cookie.configured()
-    if source_provider == "spotify" or spotify_requested:
+    if profiles is None and (source_provider == "spotify" or spotify_requested):
         if cookie_spotify:
             log_note("Spotify is using its signed-in web session (no developer API)", tag="spotify")
         else:
@@ -452,11 +508,13 @@ def run_pass(opts, should_continue=None):
             return _summary(opts, [], pass_started)
         from . import downloads
 
-        downloads.refresh(sp, selected, opts.download_dir)
+        source_sp = getattr(source, "_sp", sp)
+        with _target_activation(source):
+            downloads.refresh(source_sp, selected, opts.download_dir)
         return _summary(opts, [], pass_started)
 
     if opts.sync_mode in {"nway", "group"}:
-        songs = archive.connect(opts.song_cache_file)
+        songs = _archive_connection(opts.song_cache_file, profiles)
         try:
             if opts.sync_mode == "group":
                 per_target = _run_authoritative_group(opts, sp, selected, songs, ctrl)
@@ -466,8 +524,13 @@ def run_pass(opts, should_continue=None):
             songs.close()
         c = ctrl()
         if c == "run":
-            _post_sync(opts, sp, selected, source_is_spotify=source.source == "spotify",
-                       should_continue=ctrl)
+            source_sp = getattr(source, "_sp", sp)
+            with _target_activation(source):
+                _post_sync(
+                    opts, source_sp, selected,
+                    source_is_spotify=target_provider(source) == "spotify",
+                    should_continue=ctrl,
+                )
         return _summary(opts, per_target, pass_started, interrupted=(None if c == "run" else c))
 
     targets = build_targets(opts, sp)
@@ -478,14 +541,18 @@ def run_pass(opts, should_continue=None):
         + (paint(f"   local downloads -> {opts.download_dir}", "grey") if opts.download_dir and opts.execute else ""))
 
     sp_memo, sp_lock = {}, threading.Lock()
-    src_is_spotify = source.source == "spotify"
+    src_is_spotify = target_provider(source) == "spotify"
     # Disk cache of playlist tracks keyed by Spotify's snapshot_id: while a
     # playlist is unchanged its 7-page fetch is served from disk, so passes
     # don't re-hammer Spotify. snapshot_id changes exactly when the playlist
     # does, so there's no staleness. Only Spotify exposes a snapshot id, so the
     # skip optimization applies solely when Spotify is the source.
     sp_snap = {p["id"]: p.get("snapshot_id") for p in selected} if src_is_spotify else {}
-    tracks_cache_file = os.getenv("SPOTIFY_TRACKS_CACHE", "spotify_tracks_cache.json")
+    tracks_cache_file = (
+        source.profile_value("SPOTIFY_TRACKS_CACHE", "spotify_tracks_cache.json")
+        if src_is_spotify and hasattr(source, "profile_value")
+        else os.getenv("SPOTIFY_TRACKS_CACHE", "spotify_tracks_cache.json")
+    )
     tracks_cache = _load_json(tracks_cache_file) if src_is_spotify else {}
     tracks_state = {"dirty": False}
 
@@ -505,7 +572,7 @@ def run_pass(opts, should_continue=None):
                 else:
                     tracks = []
                     for track in raw_tracks:
-                        normalized = _normalize(track, source.source)
+                        normalized = _normalize(track, target_provider(source))
                         normalized["id"] = source.track_id(track)
                         tracks.append(normalized)
                 sp_memo[memo_key] = tracks
@@ -516,7 +583,7 @@ def run_pass(opts, should_continue=None):
             out = []
             reader = source.resource_tracks if is_liked else source.playlist_tracks
             for t in reader(playlist):
-                norm = _normalize(t, source.source)
+                norm = _normalize(t, target_provider(source))
                 norm["id"] = source.track_id(t)
                 out.append(norm)
             return out
@@ -537,7 +604,9 @@ def run_pass(opts, should_continue=None):
                 tracks_state["dirty"] = True
             return tracks
 
-    links = _load_links()  # explicit pairings override same-name matching (one-way)
+    links = (
+        _load_links(opts) if profiles is not None else _load_links()
+    )  # explicit pairings override same-name matching (one-way)
     results, errors = {}, []
 
     def worker(target, songs):
@@ -577,7 +646,10 @@ def run_pass(opts, should_continue=None):
     target_songs = []
     try:
         for target in targets:
-            target_songs.append((target, archive.connect(opts.song_cache_file)))
+            target_songs.append((
+                target,
+                _archive_connection(opts.song_cache_file, profiles),
+            ))
     except BaseException:
         for _, songs in target_songs:
             songs.close()
@@ -625,7 +697,12 @@ def run_pass(opts, should_continue=None):
 
     c = ctrl()
     if c == "run":
-        _post_sync(opts, sp, selected, source_is_spotify=src_is_spotify, should_continue=ctrl)
+        source_sp = getattr(source, "_sp", sp)
+        with _target_activation(source):
+            _post_sync(
+                opts, source_sp, selected, source_is_spotify=src_is_spotify,
+                should_continue=ctrl,
+            )
     per_target = [
         _summary_entry(results[target.tag]["name"], results[target.tag])
         for target in targets

--- a/songmirror/engine/targets/__init__.py
+++ b/songmirror/engine/targets/__init__.py
@@ -1,4 +1,4 @@
-"""Mirror targets: the services a playlist is mirrored across.
+"""Mirror targets: the accounts a playlist is mirrored across.
 
 Adding a provider (Deezer, Tidal, …) is deliberately local:
   1. Write `targets/<svc>.py` with a `MirrorTarget` subclass implementing the
@@ -61,8 +61,14 @@ def _spotify(opts, sp, *, sync_peer=False, songs=None):
         from .. import spotify_cookie
         from ..config import spotify_write_backend
 
-        if spotify_write_backend() != "cookie" or not spotify_cookie.configured():
-            return None
+        if spotify_write_backend() == "cookie" and spotify_cookie.configured():
+            pass
+        else:
+            from .. import spotify
+            try:
+                sp = spotify.client(writable=bool(getattr(opts, "execute", False) and sync_peer))
+            except (RuntimeError, TargetAuthError):
+                return None
     return SpotifyTarget(sp, opts.spotify_cache_file, sync_peer=sync_peer, songs=songs)
 
 
@@ -104,6 +110,82 @@ def provider_ids():
     return tuple(_SOURCE_ORDER)
 
 
+def target_provider(target, default=None):
+    """Underlying provider type for an account-bound or legacy target."""
+    return getattr(target, "provider", None) or getattr(target, "source", None) or default
+
+
+class AccountBoundTarget:
+    """Bind an existing provider target to one independently-authenticated account.
+
+    ``source`` is the engine's durable identity/archive namespace, so it is the
+    profile id. ``provider`` is the protocol/catalog type used by matching.
+    Calls enter the profile runtime because mature adapters still read some
+    credentials through their inherited environment interface.
+    """
+
+    def __init__(self, target, profile, profiles):
+        self._target = target
+        self._profiles = profiles
+        self.account_id = profile.id
+        self.profile_label = profile.label
+        self.provider = target.source
+        self.source = profile.id
+        self.archive_source = profile.id
+        target.archive_source = profile.id
+        self.tag = profile.id
+        self.name = profiles.display_name(profile.id, target.name)
+        self.cache_file = target.cache_file
+
+    def activate(self):
+        return self._profiles.activate(self.account_id)
+
+    def profile_value(self, key, default=None):
+        return self._profiles.settings_for(self.account_id).get(key, default)
+
+    def archive_sources(self, provider):
+        """Every account namespace that can hold this provider's catalog ids."""
+        return tuple(
+            profile.id for profile in self._profiles.list()
+            if profile.provider == provider
+        )
+
+    def __getattr__(self, name):
+        value = getattr(self._target, name)
+        if not callable(value):
+            return value
+
+        def scoped(*args, **kwargs):
+            with self.activate():
+                return value(*args, **kwargs)
+
+        return scoped
+
+
+def _profiles(opts):
+    return getattr(opts, "account_profiles", None)
+
+
+def _identity_parts(identity, opts):
+    profiles = _profiles(opts)
+    if profiles is None:
+        return identity, None, None
+    profile = profiles.resolve(identity)
+    if profile is None:
+        return None, None, profiles
+    return profile.provider, profile, profiles
+
+
+def _participant_ids(opts):
+    profiles = _profiles(opts)
+    raw = [part.strip() for part in (opts.providers or "").split(",") if part.strip()]
+    if profiles is None:
+        return raw or list(_SOURCE_ORDER)
+    if raw:
+        return list(dict.fromkeys(profiles.canonical_id(part) for part in raw))
+    return [profile.id for profile in profiles.list() if profile.provider in _REGISTRY]
+
+
 def target_class(provider_id):
     """A provider's MirrorTarget subclass, or None. Unlike build_one this needs
     no configured account, so it answers class-level questions for a service the
@@ -120,11 +202,18 @@ def nway_order_candidates(opts):
     followed by the job's former source when it participates, then registry
     source order.
     """
-    wanted = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
-    participants = [src for src in _SOURCE_ORDER if not wanted or src in wanted]
-    preferred = ("spotify", getattr(opts, "sync_source", None))
+    profiles = _profiles(opts)
+    participants = _participant_ids(opts)
+    if profiles is None:
+        preferred = ("spotify", getattr(opts, "sync_source", None))
+    else:
+        spotify = next(
+            (identity for identity in participants if profiles.provider_of(identity) == "spotify"),
+            None,
+        )
+        preferred = (spotify, profiles.canonical_id(getattr(opts, "sync_source", None)))
     return tuple(dict.fromkeys(
-        src for src in (*preferred, *participants) if src in participants
+        src for src in (*preferred, *participants) if src and src in participants
     ))
 
 
@@ -134,23 +223,57 @@ def build_targets(opts, sp=None):
     (the same 'empty = all' convention as opts.playlists, and what the UI shows).
     `sp` (the Spotify client) is only needed when the source is a non-Spotify
     provider, so Spotify itself becomes a writable target."""
+    profiles = _profiles(opts)
     source = getattr(opts, "sync_source", None) or "spotify"
-    wanted = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
-    return [t for src in _SOURCE_ORDER if src != source and (not wanted or src in wanted)
-            for t in (_REGISTRY[src](opts, sp, sync_peer=True),) if t]
+    if profiles is not None:
+        source = profiles.canonical_id(source)
+    return [
+        target
+        for identity in _participant_ids(opts)
+        if identity != source
+        for target in (build_one(identity, opts, sp, sync_peer=True),)
+        if target
+    ]
 
 
-def build_one(provider_id, opts, sp=None):
+def build_one(provider_id, opts, sp=None, *, sync_peer=False, songs=None):
     """Construct a single provider by id (None if unknown/unconfigured). Used by
     the web layer to browse or transfer one specific service."""
-    builder = _REGISTRY.get(provider_id)
-    return builder(opts, sp) if builder else None
+    resolved_provider, profile, profiles = _identity_parts(provider_id, opts)
+    builder = _REGISTRY.get(resolved_provider)
+    if builder is None:
+        return None
+    if profile is None:
+        # Preserve the historical two-argument builder interface for direct
+        # callers and tests. Extended kwargs belong to peer construction only.
+        return builder(opts, sp) if not sync_peer and songs is None else builder(
+            opts, sp, sync_peer=sync_peer, songs=songs
+        )
+    with profiles.activate(profile.id):
+        # Apple and Spotify inherited their cache/storefront values through the
+        # parsed CLI Options object rather than reading them in their constructor.
+        # Give those adapters a profile-local copy without mutating the job.
+        import copy
+        import os
+
+        profile_opts = copy.copy(opts)
+        if profile.provider == "spotify":
+            profile_opts.spotify_cache_file = os.getenv(
+                "SPOTIFY_CACHE_FILE", profile_opts.spotify_cache_file
+            )
+        elif profile.provider == "apple":
+            profile_opts.cache_file = os.getenv("APPLE_CACHE_FILE", profile_opts.cache_file)
+            profile_opts.storefront = os.getenv("APPLE_STOREFRONT") or profile_opts.storefront
+        target = builder(profile_opts, None, sync_peer=sync_peer, songs=songs)
+    return AccountBoundTarget(target, profile, profiles) if target is not None else None
 
 
-def is_peer(provider_id):
+def is_peer(provider_id, opts=None):
     """Whether a provider is a sync/transfer peer — i.e. has a MirrorTarget that
     can read and write tracks. False for browse/output-only services like
     Jellyfin, which the download mirror feeds instead of track-level writes."""
+    if opts is not None and _profiles(opts) is not None:
+        provider_id = _profiles(opts).provider_of(provider_id)
     return provider_id in _REGISTRY
 
 
@@ -161,6 +284,9 @@ def build_peers(opts, sp, songs=None):
     chosen) — so a job saved without touching the Services step still syncs rather
     than silently finding zero peers. Needs the Spotify client for the Spotify peer.
     `songs` (the archive conn) backs the Spotify peer's persistent ISRC cache."""
-    wanted = {s.strip() for s in (opts.providers or "").split(",") if s.strip()}
-    return [peer for src in _SOURCE_ORDER if not wanted or src in wanted
-            for peer in (_REGISTRY[src](opts, sp, sync_peer=True, songs=songs),) if peer]
+    return [
+        peer
+        for identity in _participant_ids(opts)
+        for peer in (build_one(identity, opts, sp, sync_peer=True, songs=songs),)
+        if peer
+    ]

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -31,6 +31,11 @@ from ..matching import (
 COLLAPSE_FRACTION = 0.4
 
 
+def _target_provider(target):
+    """Catalog/protocol id, distinct from an account-bound archive identity."""
+    return getattr(target, "provider", None) or target.source
+
+
 class TargetAuthError(RuntimeError):
     """Auth expired / rejected. Fatal for the pass — never a partial write."""
 
@@ -53,6 +58,8 @@ class MirrorTarget:
     name = "target"       # human label, e.g. "Apple Music"
     tag = "target"        # short log tag, e.g. "apple"
     source = "target"     # archive source key, e.g. "apple"
+    provider = ""          # catalog type when source is an account profile id
+    archive_source = None  # account identity for target-internal archive reads
     cache_file = None     # this target's own resolution cache path (ids differ per service)
     # True only when the provider gives every physical playlist entry its own
     # durable id. The manual editor can then delete that exact occurrence
@@ -600,7 +607,8 @@ def _enrich_hard_isrcs(songs, source_key, source_tracks):
 
 
 def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, execute, max_removals,
-                max_adds, drain_removals=False, should_continue=None, source_key="spotify", source_name="Spotify", name=None):
+                max_adds, drain_removals=False, should_continue=None, source_key="spotify",
+                source_provider=None, source_name="Spotify", name=None):
     """Reconcile one source→target playlist pair. Returns a stats dict; `clean`
     is True when everything applied with no guard tripped.
 
@@ -624,7 +632,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
                          [[target.track_id(t), t.get("name", ""), t.get("artist", "")] for t in tgt_tracks])
 
     links = (archive.get_links(songs, target.source, [t.get("id") for t in sp_tracks])
-             if source_key == "spotify" else {})
+             if (source_provider or source_key) == "spotify" else {})
     recovered_links = _recover_archived_links(
         songs, source_key, target, sp_tracks, links)
     links = {**links, **recovered_links}  # fresh conservative archive evidence repairs stale links
@@ -838,7 +846,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         log_miss(f"not on {target.name}: {track['name']} - {', '.join(track['artists'])}", tag=tag)
 
     if execute:
-        if source_key == "spotify":
+        if (source_provider or source_key) == "spotify":
             actual_id = getattr(target, "added_id", lambda target_id: target_id)
             archive.delete_links(songs, target.source, rejected_link_ids)
             archive.set_links(
@@ -849,7 +857,7 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
             )
         for track in removals:
             _resource_call(target, "resource_remove", "remove", tgt_playlist, track)
-    elif source_key == "spotify":
+    elif (source_provider or source_key) == "spotify":
         # A dry run may still warm proven cross-provider mappings, but there is
         # no write-time provider repair to account for.
         archive.set_links(songs, target.source, new_links)
@@ -936,9 +944,18 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
     but cannot overwrite proven memory; the memory otherwise covers for a read
     too degraded to derive one."""
     ids = [target.track_id(t) for t in tracks]
-    rev = ({} if target.source == "spotify"
+    rev = ({} if _target_provider(target) == "spotify"
            else archive.get_reverse_links(songs, target.source, ids))
-    sp_isrc = archive.get_isrcs(songs, "spotify", list(rev.values())) if rev else {}
+    if rev:
+        archive_sources = getattr(target, "archive_sources", None)
+        spotify_sources = (
+            archive_sources("spotify") if callable(archive_sources) else ("spotify",)
+        )
+        sp_isrc = archive.get_isrcs_from_sources(
+            songs, spotify_sources, list(rev.values())
+        )
+    else:
+        sp_isrc = {}
     id2isrc = target.native_isrc_map(cache)  # provider-supplied track_id -> ISRC (Apple, future providers)
     known = {tid: normalize_canonical_id(cid)
              for tid, cid in archive.get_identities(songs, target.source, ids).items()}
@@ -951,7 +968,7 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
         history.setdefault(tid, set()).add(cid)
     out, learned = [], {}
     for playlist_position, t in enumerate(tracks):
-        norm = _normalize(t, target.source)
+        norm = _normalize(t, _target_provider(target))
         norm["_playlist_position"] = playlist_position
         tid = target.track_id(t)
         # The joined credit is the most specific key, so it decides first; the
@@ -1262,7 +1279,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     for p in peers:
         native = p.native_isrc_map(caches[p.source])
         for track in raw_by_source[p.source]:
-            norm = _normalize(track, p.source)
+            norm = _normalize(track, _target_provider(p))
             isrc = normalize_isrc(norm.get("isrc") or native.get(p.track_id(track)))
             if isrc:
                 for key_ in spotify_track_keys(norm):

--- a/songmirror/engine/targets/spotify_target.py
+++ b/songmirror/engine/targets/spotify_target.py
@@ -129,7 +129,9 @@ class SpotifyTarget(MirrorTarget):
         if spotify_write_backend() == "cookie":
             known = None
             if self._sync_peer and self._songs is not None:
-                known = lambda ids: archive.get_isrcs(self._songs, "spotify", ids)  # noqa: E731
+                known = lambda ids: archive.get_isrcs(  # noqa: E731
+                    self._songs, self.archive_source or self.source, ids
+                )
             return spotify_cookie.playlist_tracks(
                 playlist["id"], require_isrc=False, known_isrc=known)
         return spotify.playlist_tracks(self._sp, playlist["id"])

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -465,7 +465,9 @@ class TidalTarget(MirrorTarget):
         if self._songs is None:
             return {}
         try:
-            found = archive.get_snapshots(self._songs, self.source, ids)
+            found = archive.get_snapshots(
+                self._songs, self.archive_source or self.source, ids
+            )
         except Exception as e:
             log_warn(f"archive lookup failed for {len(ids)} delisted track(s): {e!r}", tag=self.tag)
             return {}

--- a/songmirror/services/account_profiles.py
+++ b/songmirror/services/account_profiles.py
@@ -1,0 +1,473 @@
+"""Persistent provider profiles and their isolated runtime configuration.
+
+The provider registry answers *what kind of service* an adapter speaks.  This
+module answers *which signed-in account* it speaks for.  Keeping those identities
+separate lets two Spotify (or Apple, TIDAL, etc.) accounts participate in one
+operation without teaching every connector and target about profile storage.
+
+``profiles.json`` contains metadata only.  Credentials and renewable session
+state live below ``data/profiles/<profile id>/`` in the same owner-private format
+as the legacy settings store.  The deterministic default profiles deliberately
+retain the old settings/environment and file paths as a compatibility adapter;
+old jobs and links that say ``spotify`` resolve to ``profile_default_spotify``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import uuid
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from .settings import SettingsStore, _ENV_LOCK, _open_private
+
+
+PROFILE_ID_PREFIX = "profile_"
+
+# Every provider-owned value read by a connector, target, or authentication
+# helper.  A custom profile clears this entire provider slice before applying its
+# own values, so an unset field can never fall through to another account's env.
+PROVIDER_KEYS = {
+    "spotify": {
+        "SPOTIFY_AUTH_MODE", "SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET",
+        "SPOTIFY_REDIRECT_URI", "SPOTIFY_TOKEN_CACHE", "SPOTIFY_WRITE_BACKEND",
+        "SPOTIFY_SP_DC", "SPOTIFY_SP_DC_FILE", "SPOTIFY_ISRC_CLIENTS",
+        "SPOTIFY_CACHE_FILE", "SPOTIFY_TRACKS_CACHE", "SPOTIFY_OAUTH_OPEN_BROWSER",
+    },
+    "tidal": {
+        "TIDAL_WEB_HEADERS", "TIDAL_WEB_CLIENT_ID", "TIDAL_TOKEN_FILE",
+        "TIDAL_CACHE_FILE", "TIDAL_COUNTRY_CODE", "TIDAL_CLIENT_ID",
+        "TIDAL_OAUTH_STATE", "TIDAL_OAUTH_VERIFIER", "TIDAL_REDIRECT_URI",
+        "TIDAL_RENEWAL_REQUEST",
+    },
+    "qobuz": {
+        "QOBUZ_WEB_REQUEST", "QOBUZ_APP_ID", "QOBUZ_USER_AUTH_TOKEN",
+        "QOBUZ_USER_ID", "QOBUZ_CACHE_FILE",
+    },
+    "deezer": {
+        "DEEZER_WEB_HEADERS", "DEEZER_REFRESH_TOKEN", "DEEZER_WEB_SESSION_FILE",
+        "DEEZER_TOKEN_FILE", "DEEZER_APP_ID", "DEEZER_APP_SECRET", "DEEZER_ARL",
+        "DEEZER_CACHE_FILE", "DEEZER_WEB_ENDPOINT",
+    },
+    "amazon": {
+        "AMAZON_MUSIC_WEB_HEADERS", "AMAZON_MUSIC_RENEWAL_REQUEST",
+        "AMAZON_MUSIC_WEB_SESSION_FILE", "AMAZON_MUSIC_TOKEN_FILE",
+        "AMAZON_MUSIC_API_KEY", "AMAZON_MUSIC_CLIENT_ID",
+        "AMAZON_MUSIC_CLIENT_SECRET", "AMAZON_MUSIC_CACHE_FILE",
+        "AMAZON_MUSIC_WEB_ENDPOINT",
+    },
+    "apple": {
+        "APPLE_BEARER_TOKEN", "APPLE_USER_TOKEN", "APPLE_STOREFRONT",
+        "APPLE_CACHE_FILE",
+    },
+    "ytmusic": {
+        "YTMUSIC_OAUTH_CLIENT_ID", "YTMUSIC_OAUTH_CLIENT_SECRET",
+        "YTMUSIC_AUTH_FILE", "YTMUSIC_BROWSER_AUTH", "YTMUSIC_PREFER_BROWSER",
+        "YTMUSIC_CACHE_FILE",
+    },
+    "jellyfin": {"JELLYFIN_URL", "JELLYFIN_API_KEY", "JELLYFIN_USER_ID"},
+}
+
+_FILE_DEFAULTS = {
+    "spotify": {
+        "SPOTIFY_TOKEN_CACHE": "spotify_token_cache",
+        "SPOTIFY_SP_DC_FILE": "spotify_sp_dc.private",
+        "SPOTIFY_CACHE_FILE": "spotify_resolve_cache.json",
+        "SPOTIFY_TRACKS_CACHE": "spotify_tracks_cache.json",
+    },
+    "tidal": {
+        "TIDAL_TOKEN_FILE": "tidal_token.json",
+        "TIDAL_CACHE_FILE": "tidal_resolve_cache.json",
+    },
+    "qobuz": {"QOBUZ_CACHE_FILE": "qobuz_resolve_cache.json"},
+    "deezer": {
+        "DEEZER_WEB_SESSION_FILE": "deezer_web_session.json",
+        "DEEZER_TOKEN_FILE": "deezer_oauth.json",
+        "DEEZER_CACHE_FILE": "deezer_resolve_cache.json",
+    },
+    "amazon": {
+        "AMAZON_MUSIC_WEB_SESSION_FILE": "amazon_music_web_session.json",
+        "AMAZON_MUSIC_TOKEN_FILE": "amazon_music_oauth.json",
+        "AMAZON_MUSIC_CACHE_FILE": "amazon_music_resolve_cache.json",
+    },
+    "apple": {"APPLE_CACHE_FILE": "apple_resolve_cache.json"},
+    "ytmusic": {
+        "YTMUSIC_AUTH_FILE": "ytmusic_oauth.json",
+        "YTMUSIC_BROWSER_AUTH": "ytmusic_browser.json",
+        "YTMUSIC_CACHE_FILE": "ytmusic_resolve_cache.json",
+    },
+}
+
+_ACTIVE_SPOTIFY_PROFILE: str | None = None
+
+
+@dataclass(frozen=True)
+class AccountProfile:
+    id: str
+    provider: str
+    label: str
+    is_default: bool = False
+
+
+class ProfileSettings:
+    """Settings interface presented to an existing account connector."""
+
+    def __init__(self, profiles: "AccountProfileStore", profile: AccountProfile):
+        self._profiles = profiles
+        self.profile = profile
+        self._local = SettingsStore(
+            dir=profiles.profile_dir(profile.id),
+            project_env=False,
+        )
+
+    @property
+    def data_dir(self):
+        return self._local.data_dir
+
+    @property
+    def env_path(self):
+        return self._local.env_path
+
+    def load(self):
+        values = self._local.load()
+        # The legacy root remains authoritative for compatibility profiles.
+        # This matters when an existing CLI or deployment edits app.env after
+        # profile migration; the one-time local seed must not become stale and
+        # shadow that update.
+        if self.profile.is_default:
+            values.update(self._fallback_values())
+        return values
+
+    def get(self, key, default=None):
+        if self.profile.is_default:
+            fallback = self._fallback_values()
+            if key in fallback:
+                value = fallback[key]
+                return value if value not in (None, "") else default
+        value = self._local.get(key)
+        if value not in (None, ""):
+            return value
+        return default
+
+    def save(self, values):
+        allowed = PROVIDER_KEYS[self.profile.provider]
+        scoped = {key: value for key, value in values.items() if key in allowed}
+        if not scoped:
+            return
+        self._local.save(scoped)
+        # Default-profile writes continue feeding the legacy managed env.  This
+        # keeps the CLI and pre-profile integrations working after a reconnect.
+        if self.profile.is_default:
+            self._profiles.settings.save(scoped)
+
+    def apply_to_env(self):
+        """Compatibility hook for callers that expect a SettingsStore.
+
+        Long-running code should use ``AccountProfileStore.activate`` so values
+        are restored.  Connectors are always invoked inside that context.
+        """
+        with _ENV_LOCK:
+            for key, value in self.environment().items():
+                os.environ[key] = str(value)
+
+    def environment(self):
+        values = self._local.load()
+        if self.profile.is_default:
+            values.update(self._fallback_values())
+        if not self.profile.is_default:
+            root = self.data_dir
+            for key, filename in _FILE_DEFAULTS.get(self.profile.provider, {}).items():
+                values.setdefault(key, str(root / filename))
+        return {key: str(value) for key, value in values.items() if value is not None}
+
+    def _fallback_values(self):
+        if not self.profile.is_default:
+            return {}
+        # Callers such as ``profile_value`` can read a compatibility setting
+        # outside ``activate``. Serialize the fallback snapshot itself so it
+        # can never observe another account's temporary process environment.
+        with _ENV_LOCK:
+            keys = PROVIDER_KEYS[self.profile.provider]
+            root = self._profiles.settings.load()
+            values = {
+                key: root[key]
+                for key in keys
+                if key in root
+            }
+            for key in keys:
+                if key not in values and key in os.environ:
+                    values[key] = os.environ[key]
+            return values
+
+
+class AccountProfileStore:
+    """The profile persistence, migration, and runtime-selection module."""
+
+    def __init__(self, settings: SettingsStore, providers=None):
+        self.settings = settings
+        self._providers = tuple(providers or PROVIDER_KEYS)
+        self._path = Path(settings.data_dir) / "profiles.json"
+        self._profiles_dir = Path(settings.data_dir) / "profiles"
+        self._profiles_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self._profiles_dir, 0o700)
+        except OSError:
+            pass
+        self._profiles = self._read_or_migrate()
+
+    @staticmethod
+    def default_id(provider):
+        return f"{PROFILE_ID_PREFIX}default_{provider}"
+
+    @property
+    def providers(self):
+        return self._providers
+
+    def archive_aliases(self):
+        """Legacy provider archive key -> deterministic compatibility profile."""
+        return {provider: self.default_id(provider) for provider in self._providers}
+
+    def list(self):
+        order = {provider: index for index, provider in enumerate(self._providers)}
+        return sorted(
+            self._profiles.values(),
+            key=lambda profile: (order.get(profile.provider, 999), not profile.is_default, profile.label.casefold()),
+        )
+
+    def get(self, profile_id):
+        return self._profiles.get(str(profile_id))
+
+    def canonical_id(self, identity):
+        """Resolve a profile id or a legacy provider id to a profile id."""
+        identity = str(identity or "")
+        if identity in self._profiles:
+            return identity
+        if identity in self._providers:
+            default_id = self.default_id(identity)
+            if default_id in self._profiles:
+                return default_id
+        return identity
+
+    def resolve(self, identity):
+        return self.get(self.canonical_id(identity))
+
+    def provider_of(self, identity):
+        profile = self.resolve(identity)
+        return profile.provider if profile else (identity if identity in self._providers else None)
+
+    def settings_for(self, identity):
+        profile = self.resolve(identity)
+        if profile is None:
+            raise KeyError(f"unknown account profile: {identity}")
+        return ProfileSettings(self, profile)
+
+    def create(self, provider, label=None):
+        if provider not in self._providers:
+            raise ValueError(f"unknown provider: {provider}")
+        profile = AccountProfile(
+            id=f"{PROFILE_ID_PREFIX}{uuid.uuid4().hex[:12]}",
+            provider=provider,
+            label=self._clean_label(label) or self._next_label(provider),
+        )
+        self._profiles[profile.id] = profile
+        self._save()
+        # Materialize independent file paths before a connector can run.
+        local = SettingsStore(dir=self.profile_dir(profile.id), project_env=False)
+        local.save({
+            key: str(self.profile_dir(profile.id) / filename)
+            for key, filename in _FILE_DEFAULTS.get(provider, {}).items()
+        })
+        return profile
+
+    def rename(self, profile_id, label):
+        profile = self.resolve(profile_id)
+        if profile is None:
+            raise KeyError(profile_id)
+        clean = self._clean_label(label)
+        if not clean:
+            raise ValueError("profile label must not be blank")
+        updated = AccountProfile(profile.id, profile.provider, clean, profile.is_default)
+        self._profiles[profile.id] = updated
+        self._save()
+        return updated
+
+    def remove(self, profile_id):
+        profile = self.resolve(profile_id)
+        if profile is None:
+            raise KeyError(profile_id)
+        if profile.is_default:
+            raise ValueError("the compatibility profile cannot be removed; disconnect it instead")
+        del self._profiles[profile.id]
+        self._save()
+        target = self.profile_dir(profile.id).resolve()
+        root = self._profiles_dir.resolve()
+        if target.parent != root:
+            raise RuntimeError("refusing to remove a profile outside the profiles directory")
+        shutil.rmtree(target, ignore_errors=True)
+
+    def expand_ids(self, value):
+        return [
+            self.canonical_id(part.strip())
+            for part in str(value or "").split(",")
+            if part.strip()
+        ]
+
+    def display_name(self, identity, provider_name=None):
+        profile = self.resolve(identity)
+        if profile is None:
+            return str(provider_name or identity)
+        base = str(provider_name or profile.provider)
+        return base if profile.label == base else f"{base} · {profile.label}"
+
+    def profile_dir(self, profile_id):
+        return self._profiles_dir / str(profile_id)
+
+    @contextmanager
+    def activate(self, identity):
+        """Temporarily expose exactly one profile's provider configuration.
+
+        The legacy engine reads environment variables in several mature provider
+        adapters.  A process-wide re-entrant lock makes that inherited interface
+        safe while a profile-bound target call is active.  Spotify's cookie
+        adapter also owns process globals, so switching profiles resets them.
+        """
+        global _ACTIVE_SPOTIFY_PROFILE
+
+        profile = self.resolve(identity)
+        if profile is None:
+            raise KeyError(f"unknown account profile: {identity}")
+        with _ENV_LOCK:
+            keys = PROVIDER_KEYS[profile.provider]
+            # Compute the default profile's environment only after taking the
+            # lock. Its legacy fallback reads the process environment, which
+            # may otherwise momentarily contain another active profile.
+            values = self.settings_for(profile.id).environment()
+            previous = {key: os.environ.get(key) for key in keys}
+            for key in keys:
+                os.environ.pop(key, None)
+            for key, value in values.items():
+                if key in keys and value != "":
+                    os.environ[key] = value
+            if profile.provider == "spotify" and _ACTIVE_SPOTIFY_PROFILE != profile.id:
+                from ..engine import spotify_cookie
+
+                spotify_cookie.reset_session()
+                _ACTIVE_SPOTIFY_PROFILE = profile.id
+            try:
+                yield profile
+            finally:
+                for key in keys:
+                    os.environ.pop(key, None)
+                for key, value in previous.items():
+                    if value is not None:
+                        os.environ[key] = value
+
+    def _read_or_migrate(self):
+        import json
+
+        profiles = {}
+        rewrite = False
+        try:
+            with open(self._path, encoding="utf-8") as handle:
+                rows = json.load(handle)
+        except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError):
+            rows = []
+            rewrite = True
+        if not isinstance(rows, list):
+            rows = []
+            rewrite = True
+
+        # Treat rows independently. A partially damaged metadata file must not
+        # erase every valid custom profile merely because one row is malformed.
+        for row in rows:
+            try:
+                if not isinstance(row, dict):
+                    raise TypeError("profile row must be an object")
+                profile = AccountProfile(**row)
+            except (TypeError, ValueError, KeyError):
+                rewrite = True
+                continue
+            valid_types = (
+                isinstance(profile.id, str)
+                and isinstance(profile.provider, str)
+                and isinstance(profile.label, str)
+                and isinstance(profile.is_default, bool)
+            )
+            if not valid_types:
+                rewrite = True
+                continue
+            expected_default = self.default_id(profile.provider)
+            safe_id = (
+                profile.id.startswith(PROFILE_ID_PREFIX)
+                and all(char.isalnum() or char in "_-" for char in profile.id)
+            )
+            if (
+                profile.provider in self._providers
+                and profile.label.strip()
+                and safe_id
+                and profile.is_default == (profile.id == expected_default)
+                and profile.id not in profiles
+            ):
+                profiles[profile.id] = profile
+            else:
+                rewrite = True
+
+        changed = rewrite
+        for provider in self._providers:
+            profile_id = self.default_id(provider)
+            if profile_id not in profiles:
+                profiles[profile_id] = AccountProfile(
+                    id=profile_id,
+                    provider=provider,
+                    label=self._provider_label(provider),
+                    is_default=True,
+                )
+                changed = True
+        self._profiles = profiles
+        if changed or not self._path.exists():
+            self._save()
+        self._copy_legacy_settings()
+        return profiles
+
+    def _copy_legacy_settings(self):
+        """Seed default profile files without removing the legacy source."""
+        root_values = self.settings.load()
+        for provider in self._providers:
+            values = {
+                key: root_values[key]
+                for key in PROVIDER_KEYS[provider]
+                if key in root_values
+            }
+            if not values:
+                continue
+            local = SettingsStore(
+                dir=self.profile_dir(self.default_id(provider)),
+                project_env=False,
+            )
+            if not local.load():
+                local.save(values)
+
+    def _save(self):
+        import json
+
+        with _open_private(self._path) as handle:
+            json.dump([asdict(profile) for profile in self.list()], handle, indent=2)
+
+    @staticmethod
+    def _clean_label(label):
+        return " ".join(str(label or "").split())[:80]
+
+    def _next_label(self, provider):
+        base = self._provider_label(provider)
+        count = sum(profile.provider == provider for profile in self._profiles.values())
+        return f"{base} {count + 1}"
+
+    @staticmethod
+    def _provider_label(provider):
+        return {
+            "spotify": "Spotify", "tidal": "TIDAL", "qobuz": "Qobuz",
+            "deezer": "Deezer", "amazon": "Amazon Music", "apple": "Apple Music",
+            "ytmusic": "YouTube Music", "jellyfin": "Jellyfin",
+        }.get(provider, provider)

--- a/songmirror/services/playlists.py
+++ b/songmirror/services/playlists.py
@@ -9,6 +9,7 @@ import json
 import os
 import uuid
 from dataclasses import asdict, dataclass, field
+from contextlib import nullcontext
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import quote
@@ -16,7 +17,7 @@ from urllib.parse import quote
 from ..engine import archive, spotify, spotify_cookie
 from ..engine.config import parse_args, spotify_write_backend
 from ..engine.logs import log_warn
-from ..engine.targets import build_one
+from ..engine.targets import build_one, target_provider
 from .playlist_exports import render_backup
 from .playlist_links import external_url, provider_label
 from .settings import _open_private
@@ -149,11 +150,23 @@ def _track_artist(track):
 
 
 class PlaylistService:
-    def __init__(self, settings):
+    def __init__(self, settings, profiles=None):
         self._settings = settings
+        self._profiles = profiles
+
+    def _provider(self, account_id):
+        return self._profiles.provider_of(account_id) if self._profiles else account_id
+
+    def _account(self, account_id):
+        return self._profiles.canonical_id(account_id) if self._profiles else account_id
+
+    def _label(self, account_id):
+        provider = self._provider(account_id)
+        base = provider_label(provider)
+        return self._profiles.display_name(account_id, base) if self._profiles else base
 
     def _failure(self, provider_id, action, exc):
-        label = provider_label(provider_id)
+        label = self._label(provider_id)
         log_warn(f"{action} failed: {exc!r}", tag=provider_id)
         raise PlaylistBrowseError(
             f"{label} could not {action} right now. Retry; if it continues, reconnect the account."
@@ -162,18 +175,25 @@ class PlaylistService:
     def _target(self, provider_id):
         self._settings.apply_to_env()
         opts = parse_args([])
+        opts.account_profiles = self._profiles
         try:
+            provider = self._provider(provider_id)
             cookie = (
-                provider_id == "spotify"
+                self._profiles is None
+                and provider == "spotify"
                 and spotify_write_backend() == "cookie"
                 and spotify_cookie.configured()
             )
-            sp = spotify.client() if provider_id == "spotify" and not cookie else None
+            sp = (
+                spotify.client()
+                if self._profiles is None and provider == "spotify" and not cookie
+                else None
+            )
             target = build_one(provider_id, opts, sp)
         except Exception as exc:
             self._failure(provider_id, "load playlists", exc)
         if target is None:
-            label = provider_label(provider_id)
+            label = self._label(provider_id)
             raise PlaylistBrowseError(
                 f"{label} is not available. Connect or reconnect the account and retry."
             )
@@ -185,13 +205,19 @@ class PlaylistService:
         cache_file = os.getenv("SONG_CACHE_FILE") or str(
             self._settings.data_dir / "song_cache.db"
         )
-        conn = archive.connect(cache_file)
+        conn = archive.connect(
+            cache_file,
+            source_aliases=(
+                self._profiles.archive_aliases() if self._profiles is not None else None
+            ),
+        )
         try:
             return callback(conn)
         finally:
             conn.close()
 
     def _cached_detail(self, provider_id, playlist_id):
+        provider_id = self._account(provider_id)
         try:
             return self._with_cache(
                 lambda conn: archive.get_playlist_detail_cache(
@@ -203,12 +229,14 @@ class PlaylistService:
             return None
 
     def _cache_detail(self, detail):
+        detail = {**detail, "provider": self._account(detail["provider"])}
         try:
             self._with_cache(lambda conn: archive.set_playlist_detail_cache(conn, detail))
         except Exception as exc:
             log_warn(f"playlist cache write failed: {exc!r}", tag="cache")
 
     def _invalidate_detail(self, provider_id, playlist_id):
+        provider_id = self._account(provider_id)
         try:
             self._with_cache(
                 lambda conn: archive.invalidate_playlist_detail_cache(
@@ -219,6 +247,7 @@ class PlaylistService:
             log_warn(f"playlist cache invalidation failed: {exc!r}", tag="cache")
 
     def _prune_details(self, provider_id, playlist_ids):
+        provider_id = self._account(provider_id)
         try:
             self._with_cache(
                 lambda conn: archive.prune_playlist_detail_cache(
@@ -235,18 +264,21 @@ class PlaylistService:
         change here. `owned` is False only for a followed (non-owned) playlist — a
         provider surfaces those by overriding browse_playlists (Spotify does today).
         Jellyfin is browse-only and lists via its own API."""
-        if provider_id == "jellyfin":
+        if self._provider(provider_id) == "jellyfin":
             from ..engine import jellyfin
-            self._settings.apply_to_env()
-            server = (os.getenv("JELLYFIN_URL") or "").rstrip("/")
-            rows = [{
-                **row,
-                "owned": True,
-                "external_url": (
-                    f"{server}/web/#/details?id={quote(str(row['id']), safe='')}"
-                    if server else ""
-                ),
-            } for row in jellyfin.list_playlists()]
+            activation = self._profiles.activate(provider_id) if self._profiles else nullcontext()
+            with activation:
+                if self._profiles is None:
+                    self._settings.apply_to_env()
+                server = (os.getenv("JELLYFIN_URL") or "").rstrip("/")
+                rows = [{
+                    **row,
+                    "owned": True,
+                    "external_url": (
+                        f"{server}/web/#/details?id={quote(str(row['id']), safe='')}"
+                        if server else ""
+                    ),
+                } for row in jellyfin.list_playlists()]
             return sorted(rows, key=lambda r: (r["name"] or "").casefold())
         target = self._target(provider_id)
         try:
@@ -258,7 +290,7 @@ class PlaylistService:
             self._failure(provider_id, "load playlists", exc)
         rows = [{"id": _pl_id(pl), "name": _pl_name(pl), "count": target.playlist_count(pl),
                  "image": playlist_image(pl), "owned": bool(pl.get("_owned", True)),
-                 "external_url": external_url(provider_id, "playlist", _pl_id(pl))}
+                 "external_url": external_url(target_provider(target, self._provider(provider_id)), "playlist", _pl_id(pl))}
                 for pl in playlists]
         self._prune_details(provider_id, [row["id"] for row in rows])
         return sorted(rows, key=lambda r: (r["name"] or "").casefold())
@@ -297,7 +329,7 @@ class PlaylistService:
                 ),
                 "external_url": (
                     "" if unavailable
-                    else external_url(provider_id, "track", track_id)
+                    else external_url(target_provider(target, provider_id), "track", track_id)
                 ),
             }
             try:
@@ -324,7 +356,7 @@ class PlaylistService:
             "image": playlist_image(playlist),
             "owned": bool(playlist.get("_owned", True)),
             "editable": bool(target.is_editable(playlist)),
-            "external_url": external_url(provider_id, "playlist", playlist_id),
+            "external_url": external_url(target_provider(target, provider_id), "playlist", playlist_id),
             "tracks": tracks,
         }
 
@@ -372,7 +404,7 @@ class PlaylistService:
             and (expected_count is None or cached["count"] == expected_count)
         ):
             return cached
-        if provider_id == "jellyfin":
+        if self._provider(provider_id) == "jellyfin":
             raise PlaylistReadOnlyError(
                 "Jellyfin playlist tracks are managed in Jellyfin. Open the service to edit them."
             )
@@ -382,7 +414,7 @@ class PlaylistService:
             if playlist is None:
                 self._invalidate_detail(provider_id, playlist_id)
                 raise PlaylistNotFoundError(
-                    f"That {provider_label(provider_id)} playlist no longer exists. Refresh Browse."
+                    f"That {self._label(provider_id)} playlist no longer exists. Refresh Browse."
                 )
             return self._read_detail(
                 provider_id,
@@ -403,7 +435,7 @@ class PlaylistService:
         playlist-scoped, so that interoperability format requires playlist_id.
         """
         export_format = str(export_format).casefold()
-        if provider_id == "jellyfin":
+        if self._provider(provider_id) == "jellyfin":
             raise PlaylistReadOnlyError(
                 "Jellyfin playlist tracks are managed in Jellyfin and cannot be exported here."
             )
@@ -419,7 +451,7 @@ class PlaylistService:
                 if playlist is None:
                     self._invalidate_detail(provider_id, playlist_id)
                     raise PlaylistNotFoundError(
-                        f"That {provider_label(provider_id)} playlist no longer exists. Refresh Browse."
+                        f"That {self._label(provider_id)} playlist no longer exists. Refresh Browse."
                     )
                 playlists = [playlist]
             else:
@@ -437,8 +469,8 @@ class PlaylistService:
             ]
             details.sort(key=lambda detail: (detail["name"].casefold(), detail["id"]))
             return render_backup(
-                provider_id,
-                provider_label(provider_id) or getattr(target, "name", provider_id),
+                target_provider(target),
+                self._label(provider_id) or getattr(target, "name", provider_id),
                 details,
                 export_format,
                 filename_scope="all-playlists" if playlist_id is None else None,
@@ -496,7 +528,7 @@ class PlaylistService:
             if playlist is None:
                 self._invalidate_detail(provider_id, playlist_id)
                 raise PlaylistNotFoundError(
-                    f"That {provider_label(provider_id)} playlist no longer exists. Refresh Browse."
+                    f"That {self._label(provider_id)} playlist no longer exists. Refresh Browse."
                 )
             tracks, next_cursor = page_reader(playlist, cursor=cursor)
         except PlaylistServiceError:
@@ -605,14 +637,33 @@ class LinkStore:
     """Explicit pairings persisted to data/links.json (owner-only, alongside the
     other data-dir state)."""
 
-    def __init__(self, dir="data"):
+    def __init__(self, dir="data", profiles=None):
         self._path = Path(dir) / "links.json"
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._profiles = profiles
 
     def list(self):
         try:
             with open(self._path, encoding="utf-8") as f:
-                return [PlaylistLink(**d) for d in json.load(f)]
+                rows = json.load(f)
+            links = []
+            migrated = False
+            for row in rows:
+                data = dict(row)
+                if self._profiles is not None:
+                    members = {
+                        self._profiles.canonical_id(identity): playlist_id
+                        for identity, playlist_id in (data.get("members") or {}).items()
+                    }
+                    source = data.get("source")
+                    canonical_source = self._profiles.canonical_id(source) if source else source
+                    migrated = migrated or members != data.get("members") or canonical_source != source
+                    data["members"] = members
+                    data["source"] = canonical_source
+                links.append(PlaylistLink(**data))
+            if migrated:
+                self._save(links)
+            return links
         except (FileNotFoundError, json.JSONDecodeError):
             return []
 

--- a/songmirror/services/resolve_cache.py
+++ b/songmirror/services/resolve_cache.py
@@ -47,10 +47,14 @@ def _split_key(key):
 class ResolveCacheStore:
     """The resolution caches as an editable table, one file per provider."""
 
-    def __init__(self, settings, sync=None):
+    def __init__(self, settings, sync=None, profiles=None):
         self._settings = settings
         # Consulted only to refuse writes while a pass holds the cache in memory.
         self._sync = sync
+        self._profiles = profiles
+
+    def _provider(self, identity):
+        return self._profiles.provider_of(identity) if self._profiles else identity
 
     # -- paths -----------------------------------------------------------------
     def _path(self, provider_id):
@@ -59,17 +63,29 @@ class ResolveCacheStore:
         Read through the target class so this opens exactly the file the engine
         writes, including any operator override of its environment variable.
         """
-        cls = target_class(provider_id)
+        provider = self._provider(provider_id)
+        cls = target_class(provider)
         if cls is None:
             return None
-        self._settings.apply_to_env()
-        return cls.resolve_cache_path(parse_args([]))
+        if self._profiles is None:
+            self._settings.apply_to_env()
+            return cls.resolve_cache_path(parse_args([]))
+        profile = self._profiles.resolve(provider_id)
+        if profile is None:
+            return None
+        with self._profiles.activate(profile.id):
+            opts = parse_args([])
+            if provider == "spotify":
+                opts.spotify_cache_file = os.getenv("SPOTIFY_CACHE_FILE", opts.spotify_cache_file)
+            elif provider == "apple":
+                opts.cache_file = os.getenv("APPLE_CACHE_FILE", opts.cache_file)
+            return cls.resolve_cache_path(opts)
 
     def _load(self, provider_id):
         path = self._path(provider_id)
         if path is None:
             raise ResolveCacheError(
-                f"{provider_label(provider_id)} does not keep a resolve cache.")
+                f"{provider_label(self._provider(provider_id))} does not keep a resolve cache.")
         return path, load_cache(path)
 
     # -- reads -----------------------------------------------------------------
@@ -81,19 +97,31 @@ class ResolveCacheStore:
         zeroes.
         """
         out = []
-        for provider_id in provider_ids():
+        identities = (
+            [profile.id for profile in self._profiles.list()]
+            if self._profiles else provider_ids()
+        )
+        for provider_id in identities:
             path = self._path(provider_id)
             if path is None or not os.path.exists(path):
                 continue
             cache = load_cache(path)
             search = cache["search"]
-            out.append({
+            row = {
                 "id": provider_id,
-                "name": provider_label(provider_id),
+                "name": (
+                    self._profiles.display_name(
+                        provider_id, provider_label(self._provider(provider_id))
+                    )
+                    if self._profiles else provider_label(provider_id)
+                ),
                 "total": len(search),
                 "manual": sum(1 for key in cache["manual"] if key in search),
                 "unmatched": sum(1 for value in search.values() if not value),
-            })
+            }
+            if self._profiles is not None:
+                row["provider"] = self._provider(provider_id)
+            out.append(row)
         return out
 
     def entries(self, provider_id, *, query="", kind="all", offset=0, limit=50):
@@ -122,7 +150,7 @@ class ResolveCacheStore:
                 "artist": artist,
                 "target_id": "" if target_id is None else str(target_id),
                 "manual": manual,
-                "url": track_url(provider_id, target_id),
+                "url": track_url(self._provider(provider_id), target_id),
             })
         rows.sort(key=lambda row: (row["name"], row["artist"]))
         offset = max(0, int(offset))
@@ -148,14 +176,15 @@ class ResolveCacheStore:
         path, cache = self._load(provider_id)
         if key not in cache["search"]:
             raise ResolveCacheError("That mapping is no longer in the cache. Refresh the list.")
-        cls = target_class(provider_id)
+        provider = self._provider(provider_id)
+        cls = target_class(provider)
         try:
             normalized = cls.normalize_manual_track_id(target_id)
         except ValueError as exc:
             raise ResolveCacheError(str(exc)) from exc
         if not normalized:
             raise ResolveCacheError(
-                f"Paste a {provider_label(provider_id)} track link or id.")
+                f"Paste a {provider_label(provider)} track link or id.")
         cache["search"][key] = normalized
         cache["manual"].add(key)
         cache["dirty"] = True
@@ -167,7 +196,7 @@ class ResolveCacheStore:
             "artist": artist,
             "target_id": normalized,
             "manual": True,
-            "url": track_url(provider_id, normalized),
+            "url": track_url(provider, normalized),
         }
 
     def delete(self, provider_id, key):

--- a/songmirror/services/settings.py
+++ b/songmirror/services/settings.py
@@ -14,7 +14,15 @@ wired in the app factory) makes wizard saves authoritative instead.
 import json
 import os
 import shlex
+import threading
 from pathlib import Path
+
+
+# Provider adapters still inherit part of their runtime configuration through
+# ``os.environ``.  Root settings projection and account-profile activation must
+# therefore serialize on the same lock: otherwise a settings request can swap
+# credentials while a target call is in flight.
+_ENV_LOCK = threading.RLock()
 
 
 def _scalar(v):
@@ -35,7 +43,7 @@ def _open_private(path):
 
 
 class SettingsStore:
-    def __init__(self, dir=None):
+    def __init__(self, dir=None, *, project_env=True):
         # Default to $SONGMIRROR_DATA_DIR (Docker points it at the /data bind mount) so
         # wizard-saved config + OAuth secrets land on the persistent volume, not
         # the container's ephemeral filesystem. Falls back to a local ./data.
@@ -47,6 +55,7 @@ class SettingsStore:
             pass
         self._json = self._dir / "settings.json"
         self.env_path = str(self._dir / "app.env")
+        self._project_env = project_env
         self._data = self._read()
 
     @property
@@ -73,7 +82,8 @@ class SettingsStore:
         with _open_private(self._json) as f:
             json.dump(self._data, f, indent=2)
         self._render_env()
-        self.apply_to_env()
+        if self._project_env:
+            self.apply_to_env()
 
     def _render_env(self):
         lines = [f"{k}={shlex.quote(str(v))}" for k, v in self._data.items() if _scalar(v)]
@@ -82,6 +92,7 @@ class SettingsStore:
 
     def apply_to_env(self):
         """Project scalar settings into the process env (engine reads os.getenv)."""
-        for k, v in self._data.items():
-            if _scalar(v):
-                os.environ[k] = str(v)
+        with _ENV_LOCK:
+            for k, v in self._data.items():
+                if _scalar(v):
+                    os.environ[k] = str(v)

--- a/songmirror/services/sync_service.py
+++ b/songmirror/services/sync_service.py
@@ -36,10 +36,11 @@ def next_boundary_delay(now, interval):
 
 
 class SyncService:
-    def __init__(self, settings, bus, syncs=None):
+    def __init__(self, settings, bus, syncs=None, profiles=None):
         self._settings = settings
         self._bus = bus
         self._syncs = syncs or SyncStore()
+        self._profiles = profiles
         self._running_job = None       # id of the job currently holding the lock, or None
         self._running_mode = None      # "preview" | "execute" while a pass runs
         self._active = set()           # ids running-or-queued, to coalesce duplicate triggers
@@ -57,6 +58,7 @@ class SyncService:
         """Build engine Options from a job + the global download mirror."""
         self._settings.apply_to_env()
         opts = parse_args([])
+        opts.account_profiles = self._profiles
         opts.execute = execute
         opts.sync_mode = job.mode
         opts.sync_source = job.source

--- a/songmirror/services/syncs.py
+++ b/songmirror/services/syncs.py
@@ -114,20 +114,41 @@ def validate_sync_job(job):
 class SyncStore:
     """Named sync jobs persisted to data/syncs.json (owner-only)."""
 
-    def __init__(self, dir="data"):
+    def __init__(self, dir="data", profiles=None):
         self._path = Path(dir) / "syncs.json"
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._profiles = profiles
 
     def list(self):
         try:
             with open(self._path, encoding="utf-8") as f:
                 rows = json.load(f)
             jobs = []
+            migrated = False
             for row in rows:
                 data = dict(row)
                 if not str(data.get("providers") or "").strip():
                     data["providers"] = LEGACY_NAMED_JOB_PROVIDERS
+                    migrated = True
+                if self._profiles is not None:
+                    before = dict(data)
+                    data["source"] = self._profiles.canonical_id(
+                        data.get("source", DEFAULT_SYNC_SOURCE)
+                    )
+                    data["providers"] = ",".join(
+                        self._profiles.expand_ids(data.get("providers", ""))
+                    )
+                    data["authorities"] = ",".join(
+                        self._profiles.expand_ids(data.get("authorities", ""))
+                    )
+                    data["liked_routes"] = {
+                        self._profiles.canonical_id(identity): route
+                        for identity, route in (data.get("liked_routes") or {}).items()
+                    }
+                    migrated = migrated or data != before
                 jobs.append(SyncJob(**data))
+            if migrated:
+                self._save(jobs)
             return jobs
         except (FileNotFoundError, json.JSONDecodeError):
             return []

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -15,7 +15,7 @@ from ..engine.config import parse_args, spotify_write_backend
 from ..engine.logs import log_add, log_miss, log_note, log_warn
 from ..engine.matching import spotify_track_keys, track_key, tracks_oldest_first
 from ..engine.runner import load_cache, save_cache
-from ..engine.targets import build_one, is_peer
+from ..engine.targets import build_one, is_peer, target_provider
 from ..engine.targets.base import (
     MirrorTarget,
     TargetAuthError,
@@ -64,7 +64,7 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, preserv
     raw_source = list(read_source(src_pl))
     unavailable = [track for track in raw_source if track.get("unavailable")]
     src = [
-        _normalize(track, source.source)
+        _normalize(track, target_provider(source))
         for track in raw_source
         if not track.get("unavailable")
     ]
@@ -89,7 +89,7 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, preserv
         if (target_id := target_id_of(track)) is not None
     }
     dst = [
-        _normalize(track, dest.source)
+        _normalize(track, target_provider(dest))
         for track in raw_destination
     ]
     seen = set().union(*(spotify_track_keys(n) for n in dst)) if dst else set()
@@ -108,7 +108,7 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, preserv
     # Same-provider copy (e.g. a followed Spotify list into a new owned one): the
     # track's own id is already valid on the destination, so use it directly instead
     # of re-searching for it (which resolve() does for the cross-provider case).
-    same_provider = source.source == dest.source
+    same_provider = target_provider(source) == target_provider(dest)
     additions, not_found = [], []
     resolved_existing = {}
     completed = True
@@ -243,13 +243,14 @@ class TransferService:
     """One-off cross-service copies, serialized with syncs via SyncService. Jobs
     are in-memory and transient."""
 
-    def __init__(self, settings, bus, sync):
+    def __init__(self, settings, bus, sync, profiles=None):
         self._settings = settings
         self._bus = bus
         self._sync = sync
+        self._profiles = profiles
         self._jobs = {}
 
-    def preview(self, url):
+    def preview(self, url, account_id=None):
         """Resolve a pasted playlist link into a startable transfer source.
 
         Returns {provider, playlist_id, name, description, count, image,
@@ -267,13 +268,29 @@ class TransferService:
         if parsed is None:
             raise TransferPreviewError(PLAYLIST_LINK_HINT)
         provider_id, playlist_id = parsed
+        if self._profiles is not None:
+            if account_id:
+                profile = self._profiles.resolve(account_id)
+                if profile is None:
+                    raise TransferPreviewError("That account profile no longer exists.")
+                if profile.provider != provider_id:
+                    raise TransferPreviewError(
+                        f"That link belongs to {provider_label(provider_id)}, not {profile.label}."
+                    )
+                account_id = profile.id
+            else:
+                account_id = self._profiles.canonical_id(provider_id)
+        else:
+            account_id = provider_id
         label = provider_label(provider_id)
         if not is_peer(provider_id):
             raise TransferPreviewError(
                 f"{label} is browse-only and cannot be a transfer source.")
 
         self._settings.apply_to_env()
-        target = self._build(provider_id, parse_args([]))
+        opts = parse_args([])
+        opts.account_profiles = self._profiles
+        target = self._build(account_id, opts)
         if target is None:
             raise TransferPreviewError(
                 f"{label} is not connected. Connect it on the Accounts page, then paste the link again.")
@@ -293,6 +310,7 @@ class TransferService:
 
         return {
             "provider": provider_id,
+            "account": account_id,
             "playlist_id": str(playlist_id),
             "name": target.playlist_name(playlist),
             "description": target.playlist_description(playlist),
@@ -302,25 +320,48 @@ class TransferService:
         }
 
     def submit(self, spec):
-        """spec: {source_provider, source_playlist_id, dest_provider,
+        """spec: {source_account, source_playlist_id, dest_account,
         dest_playlist_id | None, dest_name, preserve_order}. Returns the job
-        dict (with id)."""
+        dict (with id). Legacy source_provider/dest_provider keys select the
+        corresponding compatibility profiles."""
+        source_account = spec.get("source_account") or spec.get("source_provider")
+        dest_account = spec.get("dest_account") or spec.get("dest_provider")
+        if self._profiles is not None:
+            source_account = self._profiles.canonical_id(source_account)
+            dest_account = self._profiles.canonical_id(dest_account)
+        normalized_spec = {
+            **spec,
+            "source_account": source_account,
+            "dest_account": dest_account,
+        }
+        source_provider = (
+            self._profiles.provider_of(source_account) if self._profiles else source_account
+        )
+        dest_provider = self._profiles.provider_of(dest_account) if self._profiles else dest_account
+        source_name = (
+            self._profiles.display_name(source_account, provider_label(source_provider))
+            if self._profiles else provider_label(source_provider)
+        )
+        dest_name = (
+            self._profiles.display_name(dest_account, provider_label(dest_provider))
+            if self._profiles else provider_label(dest_provider)
+        )
         job = {
             "id": uuid.uuid4().hex[:8], "status": "queued",
-            "source": {"provider": spec["source_provider"],
+            "source": {"account": source_account, "provider": source_provider, "name": source_name,
                        "playlist_id": spec["source_playlist_id"], "playlist_name": ""},
-            "dest": {"provider": spec["dest_provider"],
+            "dest": {"account": dest_account, "provider": dest_provider, "name": dest_name,
                      "playlist_id": spec.get("dest_playlist_id"),
                      "playlist_name": spec.get("dest_name", "")},
             "preserve_order": bool(spec.get("preserve_order")),
             "added": 0, "deferred": 0, "chronology_replayed": 0,
             "unavailable": 0, "conflicts": [], "error": None,
             "total": 0, "processed": 0,  # live progress: source tracks examined / total
-            "_spec": spec,      # kept so resume can re-run the same copy
+            "_spec": normalized_spec,  # kept so resume re-runs the same account pair
             "_control": "run",  # "run" | "pause" | "stop" — polled by the running loop
         }
         self._jobs[job["id"]] = job
-        asyncio.create_task(self._run(job, spec))
+        asyncio.create_task(self._run(job, normalized_spec))
         return job
 
     def get(self, job_id):
@@ -400,13 +441,14 @@ class TransferService:
         job["status"] = "running"
         self._settings.apply_to_env()
         opts = parse_args([])
-        for side, prov in (("source", spec["source_provider"]), ("destination", spec["dest_provider"])):
-            if not is_peer(prov):  # e.g. Jellyfin — browse-only, can't read/write tracks
-                job["status"], job["error"] = "error", f"'{prov}' can't be a transfer {side} — it's a browse-only service."
+        opts.account_profiles = self._profiles
+        for side, account_id in (("source", spec["source_account"]), ("destination", spec["dest_account"])):
+            if not is_peer(account_id, opts):  # e.g. Jellyfin — browse-only
+                job["status"], job["error"] = "error", f"'{account_id}' can't be a transfer {side} — it's a browse-only service."
                 self._emit("warn", f"transfer: {job['error']}", "transfer")
                 return
-        src = self._build(spec["source_provider"], opts)
-        dst = self._build(spec["dest_provider"], opts)
+        src = self._build(spec["source_account"], opts)
+        dst = self._build(spec["dest_account"], opts)
         if src is None or dst is None:
             job["status"], job["error"] = "error", "source or destination not connected"
             self._emit("warn", f"transfer: {job['error']}", "transfer")
@@ -464,6 +506,8 @@ class TransferService:
             self._emit("warn", f"transfer failed: {job['error']}", "transfer")
 
     def _build(self, provider_id, opts):
+        if self._profiles is not None:
+            return build_one(provider_id, opts)
         sp = None
         cookie = (provider_id == "spotify" and spotify_write_backend() == "cookie"
                   and spotify_cookie.configured())

--- a/songmirror/web/__init__.py
+++ b/songmirror/web/__init__.py
@@ -16,6 +16,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from ..services.events import EventBus
+from ..services.account_profiles import AccountProfileStore
 from ..services.playlists import LinkStore
 from ..services.resolve_cache import ResolveCacheStore
 from ..services.settings import SettingsStore
@@ -35,15 +36,18 @@ _DIST = Path(__file__).resolve().parents[2] / "frontend" / "dist"
 
 
 def create_app(settings=None, bus=None, sync_service=None, links=None, transfers=None,
-               syncs=None, resolve_cache=None) -> FastAPI:
+               syncs=None, resolve_cache=None, account_profiles=None) -> FastAPI:
     install_oauth_access_log_filter()
     settings = settings or SettingsStore()
     bus = bus or EventBus()
-    syncs = syncs or SyncStore(dir=Path(settings.env_path).parent)
-    sync_service = sync_service or SyncService(settings, bus, syncs)
-    links = links or LinkStore(dir=Path(settings.env_path).parent)
-    transfers = transfers or TransferService(settings, bus, sync_service)
-    resolve_cache = resolve_cache or ResolveCacheStore(settings, sync_service)
+    account_profiles = account_profiles or AccountProfileStore(settings)
+    syncs = syncs or SyncStore(dir=Path(settings.env_path).parent, profiles=account_profiles)
+    sync_service = sync_service or SyncService(settings, bus, syncs, profiles=account_profiles)
+    links = links or LinkStore(dir=Path(settings.env_path).parent, profiles=account_profiles)
+    transfers = transfers or TransferService(settings, bus, sync_service, profiles=account_profiles)
+    resolve_cache = resolve_cache or ResolveCacheStore(
+        settings, sync_service, profiles=account_profiles
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -63,6 +67,7 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
 
     app = FastAPI(title="SongMirror", lifespan=lifespan)
     app.state.settings = settings
+    app.state.account_profiles = account_profiles
     app.state.bus = bus
     app.state.sync = sync_service
     app.state.syncs = syncs

--- a/songmirror/web/routers/accounts.py
+++ b/songmirror/web/routers/accounts.py
@@ -1,4 +1,9 @@
-"""Account wizard endpoints — connect/inspect each service uniformly."""
+"""Account-profile wizard endpoints.
+
+Provider ids describe connector types; profile ids describe selectable signed-in
+accounts. Legacy provider-id routes remain aliases for each provider's default
+profile so existing clients and OAuth callbacks keep working.
+"""
 
 import html
 import os
@@ -16,22 +21,30 @@ from ...services.accounts.base import ConnStatus, DeviceCode
 router = APIRouter()
 
 
-def _conn(request: Request, cid: str):
-    return CONNECTORS[cid](request.app.state.settings)
+def _profile(request: Request, identity: str):
+    profile = request.app.state.account_profiles.resolve(identity)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="account profile not found")
+    return profile
 
 
-def _preserves_order(cid):
-    """Whether a provider can repair date-added order in an existing playlist.
+def _conn(request: Request, identity: str):
+    profile = _profile(request, identity)
+    profiles = request.app.state.account_profiles
+    store = profiles.settings_for(profile.id)
+    # Spotify chooses its auth flow during construction. Build every connector
+    # under the selected profile so no constructor can inherit another
+    # account's process environment.
+    with profiles.activate(profile.id):
+        return CONNECTORS[profile.provider](store)
 
-    A target opts out by setting ``replay_chronology = None`` (Deezer, whose
-    writes cannot express the repair safely), so this asks the class rather than
-    keeping a second list the two could drift apart on.
-    """
-    cls = target_class(cid)
+
+def _preserves_order(provider):
+    cls = target_class(provider)
     return cls is not None and callable(getattr(cls, "replay_chronology", None))
 
 
-def _redirect_uri(request: Request, cid: str) -> str:
+def _redirect_uri(request: Request, account_id: str) -> str:
     configured = (
         request.app.state.settings.get("SONGMIRROR_PUBLIC_URL")
         or os.getenv("SONGMIRROR_PUBLIC_URL")
@@ -42,7 +55,7 @@ def _redirect_uri(request: Request, cid: str) -> str:
     if configured:
         parts = urlsplit(base)
         try:
-            parts.port  # validate malformed/non-numeric ports too
+            parts.port
         except ValueError as exc:
             raise HTTPException(
                 status_code=500,
@@ -63,149 +76,242 @@ def _redirect_uri(request: Request, cid: str) -> str:
                     "without credentials, a query, or a fragment"
                 ),
             )
-        # Preserve an optional reverse-proxy base path while canonicalizing the
-        # scheme and removing the trailing slash before appending our route.
         base = urlunsplit((parts.scheme.lower(), parts.netloc, parts.path.rstrip("/"), "", ""))
 
-    base = base.rstrip("/")
-    # Spotify (and increasingly others) reject `localhost` for http loopback
-    # OAuth redirects — the explicit 127.0.0.1 loopback IP is required over http.
-    # Force it for the request-derived fallback. A configured public URL is still
-    # normalized too, which catches an accidentally configured localhost alias.
-    base = re.sub(r"://localhost(?=[:/]|$)", "://127.0.0.1", base, count=1)
-    return base + f"/oauth/{cid}/callback"
+    base = re.sub(r"://localhost(?=[:/]|$)", "://127.0.0.1", base.rstrip("/"), count=1)
+    return base + f"/oauth/{account_id}/callback"
+
+
+def _status_payload(request, profile):
+    profiles = request.app.state.account_profiles
+    connector = _conn(request, profile.id)
+    store = profiles.settings_for(profile.id)
+    with profiles.activate(profile.id):
+        status = connector.status()
+        fields = []
+        for field in connector.config_fields:
+            data = asdict(field)
+            current = store.get(field.key) or ""
+            data["value"] = "" if field.secret else current
+            data["configured"] = bool(current)
+            fields.append(data)
+    provider_name = connector.name
+    return {
+        "id": profile.id,
+        "provider": profile.provider,
+        "provider_name": provider_name,
+        "label": profile.label,
+        "name": profiles.display_name(profile.id, provider_name),
+        "is_default": profile.is_default,
+        "removable": not profile.is_default,
+        "auth_kind": connector.auth_kind,
+        "fields": fields,
+        "state": status.state,
+        "detail": status.detail,
+        "transferable": is_peer(profile.provider),
+        "preserves_order": _preserves_order(profile.provider),
+    }
 
 
 @router.get("/api/accounts")
 def list_accounts(request: Request):
-    store = request.app.state.settings
-    out = []
-    for cid, cls in CONNECTORS.items():
-        c = cls(store)
-        st = c.status()
-        fields = []
-        for f in c.config_fields:
-            d = asdict(f)
-            cur = store.get(f.key)
-            if cur in (None, ""):
-                cur = os.getenv(f.key) or ""
-            # Pre-fill on reconnect, but NEVER echo a secret back to the browser —
-            # send its value only when it's non-secret; a `configured` flag lets the
-            # wizard show "saved — leave blank to keep" for a stored secret instead.
-            d["value"] = "" if f.secret else cur
-            d["configured"] = bool(cur)
-            fields.append(d)
-        out.append({
-            "id": cid, "name": c.name, "auth_kind": c.auth_kind,
-            "fields": fields,
-            "state": st.state, "detail": st.detail,
-            # Browse-only services (Jellyfin) can't be a sync/transfer peer — the
-            # UI filters its source/destination pickers on this.
-            "transferable": is_peer(cid),
-            # Whether this service can replay date-added order into an existing
-            # playlist. Read off the target class (no credentials needed), so a
-            # provider that opts out stays opted out in the UI by construction.
-            "preserves_order": _preserves_order(cid),
-        })
-    return out
+    return [
+        _status_payload(request, profile)
+        for profile in request.app.state.account_profiles.list()
+    ]
 
 
-@router.post("/api/accounts/{cid}/config")
-def save_config(cid: str, request: Request, values: dict = Body(...)):
-    request.app.state.settings.save(values)
+@router.post("/api/accounts")
+def add_account(request: Request, body: dict = Body(...)):
+    try:
+        profile = request.app.state.account_profiles.create(
+            str(body.get("provider") or ""), body.get("label")
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _status_payload(request, profile)
+
+
+@router.patch("/api/accounts/{account_id}")
+def rename_account(account_id: str, request: Request, body: dict = Body(...)):
+    try:
+        profile = request.app.state.account_profiles.rename(account_id, body.get("label"))
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="account profile not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _status_payload(request, profile)
+
+
+@router.post("/api/accounts/{account_id}/config")
+def save_config(account_id: str, request: Request, values: dict = Body(...)):
+    profile = _profile(request, account_id)
+    request.app.state.account_profiles.settings_for(profile.id).save(values)
     return {"ok": True}
 
 
-@router.post("/api/accounts/{cid}/connect")
-async def connect(cid: str, request: Request, body: dict | None = Body(default=None)):
-    c = _conn(request, cid)
-    if c.auth_kind == "oauth_redirect":
-        uri = _redirect_uri(request, cid)
-        return {"kind": "redirect", "url": c.begin_redirect(uri), "redirect_uri": uri}
-    if c.auth_kind == "oauth_device":
-        return {"kind": "device", **asdict(c.begin_device())}
-    st = c.submit(body or {})  # token_paste / api_key
-    return {"kind": c.auth_kind, "state": st.state, "detail": st.detail}
+@router.post("/api/accounts/{account_id}/connect")
+async def connect(account_id: str, request: Request, body: dict | None = Body(default=None)):
+    profile = _profile(request, account_id)
+    profiles = request.app.state.account_profiles
+    connector = _conn(request, profile.id)
+    with profiles.activate(profile.id):
+        if connector.auth_kind == "oauth_redirect":
+            # Deterministic defaults keep the provider callback registered by
+            # existing installations even when the new UI addresses them by
+            # profile id. Additional profiles use isolated callback paths.
+            callback_id = profile.provider if profile.is_default else profile.id
+            uri = _redirect_uri(request, callback_id)
+            return {
+                "kind": "redirect",
+                "url": connector.begin_redirect(uri),
+                "redirect_uri": uri,
+            }
+        if connector.auth_kind == "oauth_device":
+            return {"kind": "device", **asdict(connector.begin_device())}
+        status = connector.submit(body or {})
+    return {"kind": connector.auth_kind, "state": status.state, "detail": status.detail}
 
 
-@router.get("/oauth/{cid}/callback")
-def oauth_callback(cid: str, request: Request):
-    # The provider can bounce back with ?error=... (the user denied, or a
-    # provider-side failure like Spotify's "server_error") instead of a code.
-    # Treat that as a failed connection and, likewise, catch any token-exchange
-    # error — the callback must never 500 and show a raw "Internal Server Error".
-    err = request.query_params.get("error")
-    if err:
-        st = ConnStatus("error", f"{CONNECTORS[cid].name} returned '{err}' — nothing was authorized.")
+@router.get("/oauth/{account_id}/callback")
+def oauth_callback(account_id: str, request: Request):
+    profile = _profile(request, account_id)
+    profiles = request.app.state.account_profiles
+    connector = _conn(request, profile.id)
+    error = request.query_params.get("error")
+    if error:
+        status = ConnStatus(
+            "error", f"{connector.name} returned '{error}' — nothing was authorized."
+        )
     else:
         try:
-            st = _conn(request, cid).complete_redirect({"url": str(request.url)})
-        except Exception as e:
-            st = ConnStatus("error", f"could not finish authorization ({e})")
+            with profiles.activate(profile.id):
+                status = connector.complete_redirect({"url": str(request.url)})
+        except Exception as exc:
+            status = ConnStatus("error", f"could not finish authorization ({exc})")
     return HTMLResponse(
         f"<body style='font-family:system-ui;padding:2rem'>"
-        f"<h2>{html.escape(CONNECTORS[cid].name)}: {html.escape(st.state)}</h2>"
-        f"<p>{html.escape(st.detail or '')}</p>"
+        f"<h2>{html.escape(profiles.display_name(profile.id, connector.name))}: "
+        f"{html.escape(status.state)}</h2>"
+        f"<p>{html.escape(status.detail or '')}</p>"
         f"<p>You can close this tab and return to the app.</p></body>"
     )
 
 
-@router.post("/api/accounts/{cid}/poll")
-async def poll(cid: str, request: Request):
+@router.post("/api/accounts/{account_id}/poll")
+async def poll(account_id: str, request: Request):
+    profile = _profile(request, account_id)
     body = await request.json()
-    dc = DeviceCode("", "", body["device_code"], body.get("interval", 5))
-    st = _conn(request, cid).poll_device(dc)
-    return {"state": st.state, "detail": st.detail}
+    code = DeviceCode("", "", body["device_code"], body.get("interval", 5))
+    with request.app.state.account_profiles.activate(profile.id):
+        status = _conn(request, profile.id).poll_device(code)
+    return {"state": status.state, "detail": status.detail}
 
 
-@router.delete("/api/accounts/{cid}")
-def disconnect(cid: str, request: Request):
-    c = _conn(request, cid)
-    c.disconnect()
+@router.post("/api/accounts/{account_id}/disconnect")
+def disconnect_account(account_id: str, request: Request):
+    profile = _profile(request, account_id)
+    with request.app.state.account_profiles.activate(profile.id):
+        _conn(request, profile.id).disconnect()
     return {"ok": True}
 
 
+@router.delete("/api/accounts/{account_id}")
+def remove_account(account_id: str, request: Request):
+    profiles = request.app.state.account_profiles
+    profile = _profile(request, account_id)
+    with profiles.activate(profile.id):
+        _conn(request, profile.id).disconnect()
+    if profile.is_default:
+        return {"ok": True}
+    profiles.remove(profile.id)
+    return {"ok": True}
+
+
+def _provider_connector(request, account_id, expected):
+    profile = _profile(request, account_id)
+    if profile.provider != expected:
+        raise HTTPException(status_code=422, detail=f"that profile is not a {expected} account")
+    return profile, _conn(request, profile.id)
+
+
+@router.post("/api/accounts/{account_id}/ytmusic/browser")
+async def ytmusic_enable_browser(account_id: str, request: Request, body: dict = Body(...)):
+    profile, connector = _provider_connector(request, account_id, "ytmusic")
+    with request.app.state.account_profiles.activate(profile.id):
+        status = connector.enable_browser(body.get("headers", ""))
+    return {"state": status.state, "detail": status.detail}
+
+
+@router.delete("/api/accounts/{account_id}/ytmusic/browser")
+def ytmusic_disable_browser(account_id: str, request: Request):
+    profile, connector = _provider_connector(request, account_id, "ytmusic")
+    with request.app.state.account_profiles.activate(profile.id):
+        status = connector.disable_browser()
+    return {"state": status.state, "detail": status.detail}
+
+
+@router.post("/api/accounts/{account_id}/spotify/cookie")
+async def spotify_enable_cookie(account_id: str, request: Request, body: dict = Body(...)):
+    profile, connector = _provider_connector(request, account_id, "spotify")
+    with request.app.state.account_profiles.activate(profile.id):
+        status = connector.enable_cookie(body.get("sp_dc", ""))
+    return {"state": status.state, "detail": status.detail}
+
+
+@router.delete("/api/accounts/{account_id}/spotify/cookie")
+def spotify_disable_cookie(account_id: str, request: Request):
+    profile, connector = _provider_connector(request, account_id, "spotify")
+    with request.app.state.account_profiles.activate(profile.id):
+        status = connector.disable_cookie()
+    return {"state": status.state, "detail": status.detail}
+
+
+@router.post("/api/accounts/{account_id}/spotify/isrc-app")
+async def spotify_set_isrc_app(account_id: str, request: Request, body: dict = Body(...)):
+    profile, connector = _provider_connector(request, account_id, "spotify")
+    with request.app.state.account_profiles.activate(profile.id):
+        status = connector.set_isrc_app(
+            body.get("client_id", ""), body.get("client_secret", "")
+        )
+    return {"state": status.state, "detail": status.detail}
+
+
+@router.delete("/api/accounts/{account_id}/spotify/isrc-app")
+def spotify_clear_isrc_app(account_id: str, request: Request):
+    profile, connector = _provider_connector(request, account_id, "spotify")
+    with request.app.state.account_profiles.activate(profile.id):
+        status = connector.clear_isrc_app()
+    return {"state": status.state, "detail": status.detail}
+
+
+# Compatibility routes used by pre-profile frontends. Provider ids resolve to
+# deterministic default profiles inside the shared handlers.
 @router.post("/api/accounts/ytmusic/browser")
-async def ytmusic_enable_browser(request: Request, body: dict = Body(...)):
-    """Turn on YouTube Music's no-quota (browser cookies) backend from pasted
-    music.youtube.com request headers — the fix for large backfills hitting the
-    Data API quota."""
-    st = _conn(request, "ytmusic").enable_browser(body.get("headers", ""))
-    return {"state": st.state, "detail": st.detail}
+async def legacy_ytmusic_enable_browser(request: Request, body: dict = Body(...)):
+    return await ytmusic_enable_browser("ytmusic", request, body)
 
 
 @router.delete("/api/accounts/ytmusic/browser")
-def ytmusic_disable_browser(request: Request):
-    """Revert YouTube Music to the durable OAuth Data API."""
-    st = _conn(request, "ytmusic").disable_browser()
-    return {"state": st.state, "detail": st.detail}
+def legacy_ytmusic_disable_browser(request: Request):
+    return ytmusic_disable_browser("ytmusic", request)
 
 
 @router.post("/api/accounts/spotify/cookie")
-async def spotify_enable_cookie(request: Request, body: dict = Body(...)):
-    """Turn on Spotify's cookie write backend from a pasted sp_dc cookie — the fix
-    for Development-Mode apps that get 403 on playlist create / track edits."""
-    st = _conn(request, "spotify").enable_cookie(body.get("sp_dc", ""))
-    return {"state": st.state, "detail": st.detail}
+async def legacy_spotify_enable_cookie(request: Request, body: dict = Body(...)):
+    return await spotify_enable_cookie("spotify", request, body)
 
 
 @router.delete("/api/accounts/spotify/cookie")
-def spotify_disable_cookie(request: Request):
-    """Revert Spotify writes to the OAuth dev app."""
-    st = _conn(request, "spotify").disable_cookie()
-    return {"state": st.state, "detail": st.detail}
+def legacy_spotify_disable_cookie(request: Request):
+    return spotify_disable_cookie("spotify", request)
 
 
 @router.post("/api/accounts/spotify/isrc-app")
-async def spotify_set_isrc_app(request: Request, body: dict = Body(...)):
-    """Store a batch-capable (extended-quota) app for the ISRC /tracks lookup N-way
-    matching needs — a rate bucket separate from the OAuth user token + cookie token."""
-    st = _conn(request, "spotify").set_isrc_app(body.get("client_id", ""), body.get("client_secret", ""))
-    return {"state": st.state, "detail": st.detail}
+async def legacy_spotify_set_isrc_app(request: Request, body: dict = Body(...)):
+    return await spotify_set_isrc_app("spotify", request, body)
 
 
 @router.delete("/api/accounts/spotify/isrc-app")
-def spotify_clear_isrc_app(request: Request):
-    """Drop the ISRC app (falls back to the OAuth app for /tracks)."""
-    st = _conn(request, "spotify").clear_isrc_app()
-    return {"state": st.state, "detail": st.detail}
+def legacy_spotify_clear_isrc_app(request: Request):
+    return spotify_clear_isrc_app("spotify", request)

--- a/songmirror/web/routers/playlists.py
+++ b/songmirror/web/routers/playlists.py
@@ -16,7 +16,9 @@ router = APIRouter()
 @router.get("/api/playlists")
 def playlists(request: Request, provider: str):
     try:
-        return PlaylistService(request.app.state.settings).browse(provider)
+        return PlaylistService(
+            request.app.state.settings, request.app.state.account_profiles
+        ).browse(provider)
     except PlaylistServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -41,7 +43,9 @@ def export_provider_playlists(
 ):
     """Download every current playlist on one provider as a single backup."""
     try:
-        result = PlaylistService(request.app.state.settings).export(provider, format)
+        result = PlaylistService(
+            request.app.state.settings, request.app.state.account_profiles
+        ).export(provider, format)
         return _export_response(result)
     except PlaylistServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -56,7 +60,9 @@ def export_playlist(
 ):
     """Download one fresh playlist snapshot, optionally as Soundiiz JSON."""
     try:
-        result = PlaylistService(request.app.state.settings).export(
+        result = PlaylistService(
+            request.app.state.settings, request.app.state.account_profiles
+        ).export(
             provider,
             format,
             playlist_id=playlist_id,
@@ -93,7 +99,9 @@ def playlist_detail(
         raise HTTPException(status_code=422, detail="cursor is too long")
     try:
         if page_size is not None:
-            return PlaylistService(request.app.state.settings).detail_page(
+            return PlaylistService(
+                request.app.state.settings, request.app.state.account_profiles
+            ).detail_page(
                 provider,
                 playlist_id,
                 cursor=cursor or None,
@@ -101,7 +109,9 @@ def playlist_detail(
                 refresh=refresh,
                 expected_count=expected_count,
             )
-        return PlaylistService(request.app.state.settings).detail(
+        return PlaylistService(
+            request.app.state.settings, request.app.state.account_profiles
+        ).detail(
             provider,
             playlist_id,
             refresh=refresh,
@@ -148,7 +158,9 @@ async def remove_playlist_track(
                 detail="every selected track needs a non-negative position and track_id",
             ) from exc
 
-        service = PlaylistService(request.app.state.settings)
+        service = PlaylistService(
+            request.app.state.settings, request.app.state.account_profiles
+        )
         try:
             return await request.app.state.sync.run_exclusive(
                 lambda: service.remove_tracks(
@@ -169,7 +181,9 @@ async def remove_playlist_track(
             detail="position and track_id are required",
         ) from exc
 
-    service = PlaylistService(request.app.state.settings)
+    service = PlaylistService(
+        request.app.state.settings, request.app.state.account_profiles
+    )
     try:
         return await request.app.state.sync.run_exclusive(
             lambda: service.remove_track(

--- a/songmirror/web/routers/transfers.py
+++ b/songmirror/web/routers/transfers.py
@@ -16,6 +16,9 @@ def preview_transfer_source(request: Request, body: dict = Body(...)):
     never be shadowed by a job-id pattern (FastAPI matches in declaration order).
     """
     try:
+        account_id = body.get("source_account")
+        if account_id:
+            return request.app.state.transfers.preview(body.get("url", ""), account_id)
         return request.app.state.transfers.preview(body.get("url", ""))
     except TransferPreviewError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -26,9 +29,9 @@ async def start_transfer(request: Request, body: dict = Body(...)):
     # async so submit()'s asyncio.create_task has a running loop (a sync endpoint
     # runs in a threadpool with no loop and would 500).
     job = request.app.state.transfers.submit({
-        "source_provider": body["source_provider"],
+        "source_account": body.get("source_account") or body["source_provider"],
         "source_playlist_id": body["source_playlist_id"],
-        "dest_provider": body["dest_provider"],
+        "dest_account": body.get("dest_account") or body["dest_provider"],
         "dest_playlist_id": body.get("dest_playlist_id"),
         "dest_name": body.get("dest_name", ""),
         # Off unless asked for: the repair costs many extra writes and only

--- a/tests/test_account_profiles.py
+++ b/tests/test_account_profiles.py
@@ -1,0 +1,556 @@
+"""Account profile persistence, compatibility migration, and isolation."""
+
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from songmirror.services.account_profiles import AccountProfileStore
+from songmirror.services.playlists import LinkStore, PlaylistLink
+from songmirror.services.settings import SettingsStore
+from songmirror.services.syncs import SyncJob, SyncStore
+
+
+def test_legacy_provider_settings_migrate_to_a_stable_default_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "before-test")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "before-test-secret")
+    settings = SettingsStore(dir=tmp_path)
+    settings.save({
+        "SPOTIFY_CLIENT_ID": "legacy-client",
+        "SPOTIFY_CLIENT_SECRET": "legacy-secret",
+        "SYNC_INTERVAL": "30m",
+    })
+
+    profiles = AccountProfileStore(settings)
+    default_id = profiles.default_id("spotify")
+
+    assert profiles.canonical_id("spotify") == default_id
+    assert profiles.resolve("spotify").id == default_id
+    assert profiles.settings_for(default_id).get("SPOTIFY_CLIENT_SECRET") == "legacy-secret"
+    assert settings.get("SPOTIFY_CLIENT_SECRET") == "legacy-secret"
+    assert json.loads((tmp_path / "profiles.json").read_text(encoding="utf-8"))[0]["id"].startswith("profile_")
+    assert "legacy-secret" not in (tmp_path / "profiles.json").read_text(encoding="utf-8")
+    assert (tmp_path / "profiles" / default_id / "settings.json").exists()
+
+    settings.save({"SPOTIFY_CLIENT_SECRET": "updated-by-legacy-cli"})
+    assert profiles.settings_for("spotify").get("SPOTIFY_CLIENT_SECRET") == "updated-by-legacy-cli"
+
+    # Re-opening the store is idempotent: deterministic compatibility profiles
+    # are not duplicated and the old provider alias remains valid.
+    reopened = AccountProfileStore(SettingsStore(dir=tmp_path))
+    assert len(reopened.list()) == 8
+    assert reopened.canonical_id("spotify") == default_id
+
+
+def test_custom_profiles_have_disjoint_secrets_sessions_and_cache_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "legacy-secret")
+    monkeypatch.setenv("SPOTIFY_TOKEN_CACHE", "legacy-token-cache")
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    alice = profiles.create("spotify", "Alice")
+    bob = profiles.create("spotify", "Bob")
+    profiles.settings_for(alice.id).save({"SPOTIFY_CLIENT_SECRET": "alice-secret"})
+    profiles.settings_for(bob.id).save({"SPOTIFY_CLIENT_SECRET": "bob-secret"})
+
+    alice_values = profiles.settings_for(alice.id).environment()
+    bob_values = profiles.settings_for(bob.id).environment()
+    assert alice_values["SPOTIFY_TOKEN_CACHE"] != bob_values["SPOTIFY_TOKEN_CACHE"]
+    assert profiles.profile_dir(alice.id) in Path(profiles.settings_for(alice.id).env_path).parents
+    assert profiles.profile_dir(bob.id) in Path(profiles.settings_for(bob.id).env_path).parents
+
+    with profiles.activate(alice.id):
+        assert os.environ["SPOTIFY_CLIENT_SECRET"] == "alice-secret"
+        assert os.environ["SPOTIFY_TOKEN_CACHE"] == alice_values["SPOTIFY_TOKEN_CACHE"]
+    with profiles.activate(bob.id):
+        assert os.environ["SPOTIFY_CLIENT_SECRET"] == "bob-secret"
+        assert os.environ["SPOTIFY_TOKEN_CACHE"] == bob_values["SPOTIFY_TOKEN_CACHE"]
+
+    # The process environment is restored after every connector/target call;
+    # metadata never contains either account's credentials.
+    assert os.environ["SPOTIFY_CLIENT_SECRET"] == "legacy-secret"
+    metadata = (tmp_path / "profiles.json").read_text(encoding="utf-8")
+    assert "alice-secret" not in metadata and "bob-secret" not in metadata
+
+
+def test_root_environment_projection_waits_for_active_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "before-test")
+    settings = SettingsStore(dir=tmp_path)
+    settings.save({"SPOTIFY_WRITE_BACKEND": "cookie"})
+    profiles = AccountProfileStore(settings)
+    custom = profiles.create("spotify", "OAuth account")
+    profiles.settings_for(custom.id).save({"SPOTIFY_WRITE_BACKEND": "oauth"})
+
+    active = threading.Event()
+    release = threading.Event()
+    projector_started = threading.Event()
+    projected = threading.Event()
+    observed = {}
+
+    def use_profile():
+        with profiles.activate(custom.id):
+            observed["active"] = os.environ["SPOTIFY_WRITE_BACKEND"]
+            active.set()
+            release.wait(timeout=2)
+            observed["during"] = os.environ["SPOTIFY_WRITE_BACKEND"]
+
+    def project_root():
+        active.wait(timeout=2)
+        projector_started.set()
+        settings.apply_to_env()
+        observed["after"] = os.environ["SPOTIFY_WRITE_BACKEND"]
+        projected.set()
+
+    profile_thread = threading.Thread(target=use_profile)
+    projection_thread = threading.Thread(target=project_root)
+    profile_thread.start()
+    projection_thread.start()
+    assert active.wait(timeout=2)
+    assert projector_started.wait(timeout=2)
+    assert not projected.wait(timeout=0.1)
+    assert os.environ["SPOTIFY_WRITE_BACKEND"] == "oauth"
+    release.set()
+    profile_thread.join(timeout=2)
+    projection_thread.join(timeout=2)
+
+    assert not profile_thread.is_alive() and not projection_thread.is_alive()
+    assert observed == {"active": "oauth", "during": "oauth", "after": "cookie"}
+
+
+def test_default_profile_reads_fallback_only_after_custom_profile_releases(
+    tmp_path, monkeypatch
+):
+    from songmirror.services.account_profiles import ProfileSettings
+
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "root-secret")
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    custom = profiles.create("spotify", "Custom")
+    profiles.settings_for(custom.id).save({"SPOTIFY_CLIENT_SECRET": "custom-secret"})
+    custom_active = threading.Event()
+    release_custom = threading.Event()
+    default_environment_started = threading.Event()
+    default_finished = threading.Event()
+    observed = {}
+    original_environment = ProfileSettings.environment
+
+    def tracked_environment(profile_settings):
+        if profile_settings.profile.is_default:
+            default_environment_started.set()
+        return original_environment(profile_settings)
+
+    monkeypatch.setattr(ProfileSettings, "environment", tracked_environment)
+
+    def use_custom():
+        with profiles.activate(custom.id):
+            custom_active.set()
+            release_custom.wait(timeout=2)
+
+    def use_default():
+        custom_active.wait(timeout=2)
+        with profiles.activate("spotify"):
+            observed["secret"] = os.environ.get("SPOTIFY_CLIENT_SECRET")
+        default_finished.set()
+
+    custom_thread = threading.Thread(target=use_custom)
+    default_thread = threading.Thread(target=use_default)
+    custom_thread.start()
+    default_thread.start()
+    assert custom_active.wait(timeout=2)
+    # Environment resolution itself is part of the critical section, not only
+    # the later clear/apply/restore sequence.
+    assert not default_environment_started.wait(timeout=0.1)
+    assert not default_finished.is_set()
+    release_custom.set()
+    custom_thread.join(timeout=2)
+    default_thread.join(timeout=2)
+
+    assert not custom_thread.is_alive() and not default_thread.is_alive()
+    assert default_environment_started.is_set() and default_finished.is_set()
+    assert observed == {"secret": "root-secret"}
+
+
+def test_default_profile_direct_get_cannot_read_an_active_custom_profile(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SPOTIFY_TRACKS_CACHE", "root-tracks.json")
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    custom = profiles.create("spotify", "Custom")
+    profiles.settings_for(custom.id).save({
+        "SPOTIFY_TRACKS_CACHE": "custom-tracks.json"
+    })
+    custom_active = threading.Event()
+    release_custom = threading.Event()
+    reader_started = threading.Event()
+    reader_finished = threading.Event()
+    observed = {}
+
+    def use_custom():
+        with profiles.activate(custom.id):
+            custom_active.set()
+            release_custom.wait(timeout=2)
+
+    def read_default():
+        custom_active.wait(timeout=2)
+        reader_started.set()
+        observed["path"] = profiles.settings_for("spotify").get(
+            "SPOTIFY_TRACKS_CACHE"
+        )
+        reader_finished.set()
+
+    custom_thread = threading.Thread(target=use_custom)
+    reader_thread = threading.Thread(target=read_default)
+    custom_thread.start()
+    reader_thread.start()
+    assert custom_active.wait(timeout=2)
+    assert reader_started.wait(timeout=2)
+    assert not reader_finished.wait(timeout=0.1)
+    release_custom.set()
+    custom_thread.join(timeout=2)
+    reader_thread.join(timeout=2)
+
+    assert not custom_thread.is_alive() and not reader_thread.is_alive()
+    assert observed == {"path": "root-tracks.json"}
+
+
+def test_malformed_metadata_row_does_not_erase_valid_custom_profile(tmp_path):
+    settings = SettingsStore(dir=tmp_path)
+    profiles = AccountProfileStore(settings)
+    custom = profiles.create("apple", "Family")
+    rows = json.loads((tmp_path / "profiles.json").read_text(encoding="utf-8"))
+    rows.insert(1, {"id": 42, "provider": "spotify", "unexpected": True})
+    (tmp_path / "profiles.json").write_text(json.dumps(rows), encoding="utf-8")
+
+    reopened = AccountProfileStore(SettingsStore(dir=tmp_path))
+
+    assert reopened.get(custom.id) == custom
+    persisted = json.loads((tmp_path / "profiles.json").read_text(encoding="utf-8"))
+    assert all(row.get("id") != 42 for row in persisted)
+
+
+def test_archive_migration_preserves_all_profile_keyed_state_and_is_idempotent(
+    tmp_path,
+):
+    from songmirror.engine import archive
+
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    aliases = profiles.archive_aliases()
+    db_path = tmp_path / "song_cache.db"
+    conn = archive.connect(str(db_path))
+    old_group = "group:apple,spotify:mix"
+    now = "2025-01-01T00:00:00+00:00"
+    conn.executemany(
+        "INSERT INTO songs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("spotify", "collision", "OLD", "legacy row", "artist", None, 1, '{"id":"collision","name":"legacy row"}', now, now),
+            (aliases["spotify"], "collision", "NEW", "profile row", "artist", None, 2, '{"id":"collision","name":"profile row"}', now, now),
+            ("spotify", "legacy-only", "KEEP", "legacy only", "artist", None, 3, '{"id":"legacy-only","name":"legacy only"}', now, now),
+        ],
+    )
+    conn.execute("INSERT INTO links VALUES (?, ?, ?, ?)", ("sp-id", "apple", "apple-id", now))
+    conn.execute("INSERT INTO sync_state VALUES (?, ?, ?, ?, ?)", ("mix", "tidal", "snap", 4, now))
+    conn.execute("INSERT INTO playlist_state VALUES (?, ?, ?)", (old_group, "spotify", "i:STATE"))
+    conn.execute(
+        "INSERT INTO playlist_state_meta VALUES (?, ?, ?, ?)",
+        (old_group, "apple", now, "apple-playlist"),
+    )
+    conn.execute(
+        "INSERT INTO playlist_pending_removal VALUES (?, ?, ?, ?)",
+        (old_group, "tidal", "i:PENDING", now),
+    )
+    conn.execute(
+        "INSERT INTO track_identity VALUES (?, ?, ?, ?)",
+        ("qobuz", "qobuz-id", "i:IDENTITY", now),
+    )
+    conn.execute(
+        "INSERT INTO track_identity_history VALUES (?, ?, ?, ?)",
+        ("deezer", "deezer-id", "i:HISTORY", now),
+    )
+    conn.execute(
+        "INSERT INTO playlist_order VALUES (?, ?, ?, ?)",
+        (old_group, "amazon", now, '[["amazon-id", "Song", "Artist"]]'),
+    )
+
+    def detail(provider, playlist_id, name, track_ids):
+        return {
+            "provider": provider,
+            "id": playlist_id,
+            "name": name,
+            "description": "",
+            "image": "",
+            "owned": True,
+            "editable": True,
+            "external_url": "",
+            "tracks": [
+                {
+                    "position": position,
+                    "id": track_id,
+                    "name": track_id,
+                    "artist": "Artist",
+                }
+                for position, track_id in enumerate(track_ids)
+            ],
+        }
+
+    archive.set_playlist_detail_cache(
+        conn, detail("ytmusic", "legacy-cache", "Legacy cache", ["yt-1"])
+    )
+    archive.set_playlist_detail_cache(
+        conn, detail("spotify", "collision-cache", "Legacy cache", ["old-1", "old-2"])
+    )
+    archive.set_playlist_detail_cache(
+        conn,
+        detail(
+            aliases["spotify"], "collision-cache", "Profile cache", ["new-1"]
+        ),
+    )
+    conn.close()
+
+    conn = archive.connect(str(db_path), source_aliases=aliases)
+    new_group = (
+        f"group:{aliases['apple']},{aliases['spotify']}:mix"
+    )
+    assert archive.get_snapshots(conn, aliases["spotify"], ["legacy-only"])["legacy-only"]["name"] == "legacy only"
+    collision = conn.execute(
+        "SELECT name, isrc FROM songs WHERE source = ? AND id = 'collision'",
+        (aliases["spotify"],),
+    ).fetchone()
+    assert collision == ("profile row", "NEW")
+    assert archive.get_links(conn, aliases["apple"], ["sp-id"]) == {"sp-id": "apple-id"}
+    assert archive.get_state(conn, "mix", aliases["tidal"]) == ("snap", 4)
+    assert archive.get_playlist_state(conn, new_group, aliases["spotify"]) == {"i:STATE"}
+    assert archive.get_playlist_physical_id(conn, new_group, aliases["apple"]) == "apple-playlist"
+    assert archive.get_pending_removals(conn, new_group, aliases["tidal"]) == {"i:PENDING"}
+    assert archive.get_identities(conn, aliases["qobuz"], ["qobuz-id"]) == {"qobuz-id": "i:IDENTITY"}
+    assert archive.get_identity_history(conn, aliases["deezer"], ["deezer-id"]) == {"deezer-id": {"i:HISTORY"}}
+    assert archive.get_order_history(conn, new_group, aliases["amazon"])[0][1][0][0] == "amazon-id"
+    migrated_cache = archive.get_playlist_detail_cache(
+        conn, aliases["ytmusic"], "legacy-cache"
+    )
+    assert migrated_cache["name"] == "Legacy cache"
+    assert [track["id"] for track in migrated_cache["tracks"]] == ["yt-1"]
+    collision_cache = archive.get_playlist_detail_cache(
+        conn, aliases["spotify"], "collision-cache"
+    )
+    assert collision_cache["name"] == "Profile cache"
+    assert [track["id"] for track in collision_cache["tracks"]] == ["new-1"]
+
+    keyed_columns = [
+        *(archive._PROFILE_ID_COLUMNS),
+        ("playlist_cache", "provider"),
+        ("playlist_track_cache", "provider"),
+    ]
+    legacy_ids = tuple(aliases)
+    marks = ",".join("?" for _ in legacy_ids)
+    for table, column in keyed_columns:
+        assert conn.execute(
+            f'SELECT COUNT(*) FROM "{table}" WHERE "{column}" IN ({marks})',
+            legacy_ids,
+        ).fetchone()[0] == 0
+    counts = {
+        table: conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        for table in {table for table, _column in keyed_columns}
+    }
+    conn.close()
+
+    # Running the migration again changes nothing, while a later legacy CLI
+    # write is picked up by the next profile-aware open.
+    conn = archive.connect(str(db_path), source_aliases=aliases)
+    assert counts == {
+        table: conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        for table in counts
+    }
+    conn.close()
+    legacy = archive.connect(str(db_path))
+    archive.upsert_many(legacy, "tidal", [{"id": "late-cli", "name": "Late CLI"}])
+    legacy.close()
+    conn = archive.connect(str(db_path), source_aliases=aliases)
+    assert archive.get_snapshots(conn, aliases["tidal"], ["late-cli"])["late-cli"]["name"] == "Late CLI"
+    assert conn.execute(
+        "SELECT 1 FROM songs WHERE source = 'tidal' AND id = 'late-cli'"
+    ).fetchone() is None
+    conn.close()
+
+
+def test_bound_spotify_and_tidal_targets_read_the_profile_archive_namespace(
+    tmp_path, monkeypatch
+):
+    from songmirror.engine import archive, spotify_cookie
+    from songmirror.engine.targets import AccountBoundTarget
+    from songmirror.engine.targets.spotify_target import SpotifyTarget
+    from songmirror.engine.targets.tidal import TidalTarget
+
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    spotify_profile = profiles.create("spotify", "Spotify profile")
+    tidal_profile = profiles.create("tidal", "TIDAL profile")
+    profiles.settings_for(spotify_profile.id).save({
+        "SPOTIFY_WRITE_BACKEND": "cookie"
+    })
+    songs = archive.connect(":memory:")
+    archive.upsert_many(songs, spotify_profile.id, [{
+        "id": "spotify-track", "isrc": "US-S1Z-25-00001", "name": "Spotify song"
+    }])
+    archive.upsert_many(songs, tidal_profile.id, [{
+        "id": "tidal-track", "isrc": "US-T1D-25-00001", "name": "TIDAL song"
+    }])
+
+    spotify_target = SpotifyTarget(None, "spotify-cache.json", sync_peer=True, songs=songs)
+    bound_spotify = AccountBoundTarget(spotify_target, spotify_profile, profiles)
+    known = {}
+
+    def spotify_tracks(_playlist_id, *, require_isrc, known_isrc):
+        assert require_isrc is False
+        known.update(known_isrc(["spotify-track"]))
+        return []
+
+    monkeypatch.setattr(spotify_cookie, "playlist_tracks", spotify_tracks)
+    assert bound_spotify.playlist_tracks({"id": "spotify-playlist"}) == []
+    assert known == {"spotify-track": "US-S1Z-25-00001"}
+
+    tidal_target = object.__new__(TidalTarget)
+    tidal_target.cache_file = "tidal-cache.json"
+    tidal_target._songs = songs
+    AccountBoundTarget(tidal_target, tidal_profile, profiles)
+    archived = tidal_target._archived_details(["tidal-track"])
+    assert archived["tidal-track"]["name"] == "TIDAL song"
+    songs.close()
+
+
+def test_reverse_links_recover_isrc_from_any_spotify_profile_namespace(tmp_path):
+    from songmirror.engine import archive
+    from songmirror.engine.targets import AccountBoundTarget
+    from songmirror.engine.targets.base import _entry_cids
+
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    spotify_custom = profiles.create("spotify", "Custom Spotify")
+    apple = profiles.create("apple", "Apple")
+    songs = archive.connect(":memory:")
+    archive.upsert_many(songs, spotify_custom.id, [{
+        "id": "spotify-global-id",
+        "isrc": "US-REV-25-00001",
+        "name": "Recovered song",
+    }])
+    archive.set_links(songs, apple.id, {"spotify-global-id": "apple-track"})
+
+    class AppleTarget:
+        source = "apple"
+        name = "Apple Music"
+        cache_file = "apple-cache.json"
+
+        @staticmethod
+        def track_id(track):
+            return track["id"]
+
+        @staticmethod
+        def native_isrc_map(_cache):
+            return {}
+
+    target = AccountBoundTarget(AppleTarget(), apple, profiles)
+    entries = _entry_cids(
+        target,
+        [{"id": "apple-track", "name": "Recovered song", "artist": "Artist"}],
+        songs,
+        {},
+        {},
+    )
+
+    assert entries[0][0] == "i:USREV2500001"
+    songs.close()
+
+
+def test_target_factory_binds_identity_cache_and_runtime_to_selected_profile(
+    tmp_path, monkeypatch
+):
+    from songmirror.engine.config import parse_args
+    from songmirror.engine import targets
+
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    alice = profiles.create("apple", "Alice")
+    bob = profiles.create("apple", "Bob")
+    for profile, token in ((alice, "alice-token"), (bob, "bob-token")):
+        profiles.settings_for(profile.id).save({
+            "APPLE_BEARER_TOKEN": "shared-app-token",
+            "APPLE_USER_TOKEN": token,
+        })
+
+    class FakeAppleTarget:
+        source = "apple"
+        name = "Apple Music"
+
+        def __init__(self, cache_file):
+            self.cache_file = cache_file
+
+        @staticmethod
+        def current_user_token():
+            return os.getenv("APPLE_USER_TOKEN")
+
+    monkeypatch.setitem(
+        targets._REGISTRY,
+        "apple",
+        lambda opts, _sp, **_kwargs: FakeAppleTarget(opts.cache_file),
+    )
+    opts = parse_args([])
+    opts.account_profiles = profiles
+
+    alice_target = targets.build_one(alice.id, opts)
+    bob_target = targets.build_one(bob.id, opts)
+
+    assert alice_target.source == alice.id
+    assert bob_target.source == bob.id
+    assert alice_target.provider == bob_target.provider == "apple"
+    assert alice_target.cache_file != bob_target.cache_file
+    assert Path(alice_target.cache_file).parent == profiles.profile_dir(alice.id)
+    assert Path(bob_target.cache_file).parent == profiles.profile_dir(bob.id)
+    assert alice_target.current_user_token() == "alice-token"
+    assert bob_target.current_user_token() == "bob-token"
+
+
+def test_removing_a_custom_profile_deletes_only_its_private_directory(tmp_path):
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+    custom = profiles.create("apple", "Family")
+    profiles.settings_for(custom.id).save({"APPLE_USER_TOKEN": "private-token"})
+    custom_dir = profiles.profile_dir(custom.id)
+
+    profiles.remove(custom.id)
+
+    assert profiles.get(custom.id) is None
+    assert not custom_dir.exists()
+    assert profiles.resolve("apple").is_default is True
+    with pytest.raises(ValueError, match="cannot be removed"):
+        profiles.remove("apple")
+
+
+def test_sync_jobs_and_playlist_links_migrate_provider_ids_to_profiles(tmp_path):
+    legacy_syncs = SyncStore(dir=tmp_path)
+    job = legacy_syncs.upsert(SyncJob(
+        name="Legacy household sync",
+        source="spotify",
+        providers="spotify,apple",
+        liked_tracks=True,
+        liked_routes={"apple": {"kind": "native"}},
+    ))
+    legacy_links = LinkStore(dir=tmp_path)
+    link = legacy_links.upsert(PlaylistLink(
+        name="Shared",
+        source="spotify",
+        members={"spotify": "source-list", "apple": "dest-list"},
+    ))
+    profiles = AccountProfileStore(SettingsStore(dir=tmp_path))
+
+    migrated_job = SyncStore(dir=tmp_path, profiles=profiles).get(job.id)
+    migrated_link = next(
+        item for item in LinkStore(dir=tmp_path, profiles=profiles).list()
+        if item.id == link.id
+    )
+
+    spotify = profiles.default_id("spotify")
+    apple = profiles.default_id("apple")
+    assert migrated_job.source == spotify
+    assert migrated_job.providers == f"{spotify},{apple}"
+    assert migrated_job.liked_routes == {apple: {"kind": "native"}}
+    assert migrated_link.source == spotify
+    assert migrated_link.members == {spotify: "source-list", apple: "dest-list"}
+
+    persisted_sync = (tmp_path / "syncs.json").read_text(encoding="utf-8")
+    persisted_links = (tmp_path / "links.json").read_text(encoding="utf-8")
+    assert '"source": "spotify"' not in persisted_sync
+    assert '"source": "spotify"' not in persisted_links

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from songmirror.services.events import EventBus
+from songmirror.services.account_profiles import AccountProfileStore
 from songmirror.services.settings import SettingsStore
 from songmirror.services.sync_service import SyncService
 from songmirror.services.transfers import (
@@ -234,6 +235,62 @@ def test_transfer_same_provider_copies_by_id_without_resolving():
     assert res["added"] == 2
     assert added == ["t1", "t2"]   # copied by their own ids, oldest-first
     assert resolved == []          # resolver never invoked
+
+
+def test_transfer_service_builds_both_selected_profiles_for_cross_account_copy(
+    monkeypatch, tmp_path
+):
+    """Two accounts of one provider stay distinct all the way to construction.
+
+    The copy path must still recognize the underlying provider as identical so
+    Spotify track ids can be written directly into the other account.
+    """
+    built, added, resolved = [], [], []
+    settings = SettingsStore(dir=tmp_path)
+    profiles = AccountProfileStore(settings)
+    source_profile = profiles.create("spotify", "Alice")
+    dest_profile = profiles.create("spotify", "Bob")
+
+    src = _Prov(
+        str(tmp_path / "alice-cache.json"),
+        [{"id": "spotify-track", "name": "Song", "artists": ["Artist"],
+          "duration_ms": 1, "isrc": "I", "added_at": "1"}],
+        source="spotify",
+    )
+    dst = _Prov(str(tmp_path / "bob-cache.json"), [], source="spotify")
+    src.track_id = lambda raw: raw["id"]
+    dst.resolve = lambda norm, cache: resolved.append(norm["name"])
+    dst.add = lambda playlist, ids: added.extend(ids)
+
+    def build(_self, account_id, _opts):
+        built.append(account_id)
+        return src if account_id == source_profile.id else dst
+
+    monkeypatch.setattr(TransferService, "_build", build)
+
+    async def scenario():
+        bus = EventBus()
+        bus.bind_loop(asyncio.get_running_loop())
+        sync = SyncService(settings, bus, profiles=profiles)
+        service = TransferService(settings, bus, sync, profiles=profiles)
+        job = service.submit({
+            "source_account": source_profile.id,
+            "source_playlist_id": "p1",
+            "dest_account": dest_profile.id,
+            "dest_playlist_id": "p1",
+        })
+        return service.public(await _await_job(service, job["id"]))
+
+    job = asyncio.run(scenario())
+
+    assert built == [source_profile.id, dest_profile.id]
+    assert job["source"]["account"] == source_profile.id
+    assert job["source"]["provider"] == "spotify"
+    assert job["dest"]["account"] == dest_profile.id
+    assert job["dest"]["provider"] == "spotify"
+    assert job["status"] == "done"
+    assert added == ["spotify-track"]
+    assert resolved == []
 
 
 def test_transfer_orders_mixed_timestamp_formats_chronologically():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -77,19 +77,74 @@ def test_playlist_export_routes_reject_unknown_formats(tmp_path):
     assert response.status_code == 422
 
 
-def test_accounts_list_all_unconfigured(tmp_path):
+def test_accounts_list_all_unconfigured(tmp_path, monkeypatch):
+    # Default profiles deliberately honor legacy env-based installations. Make
+    # this clean-install assertion independent of credentials another test may
+    # have projected into the process environment.
+    from songmirror.services.account_profiles import PROVIDER_KEYS
+
+    for keys in PROVIDER_KEYS.values():
+        for key in keys:
+            monkeypatch.delenv(key, raising=False)
     with TestClient(_app(tmp_path)) as client:
         accounts = client.get("/api/accounts").json()
-        assert {a["id"] for a in accounts} == {
+        assert {a["provider"] for a in accounts} == {
             "spotify", "tidal", "qobuz", "deezer", "amazon", "apple", "ytmusic", "jellyfin"
         }
+        assert all(a["id"].startswith("profile_default_") for a in accounts)
+        assert all(a["id"] != a["provider"] for a in accounts)
+        assert all(a["is_default"] is True and a["removable"] is False for a in accounts)
         assert all(a["state"] == "unconfigured" for a in accounts)
         # The transfer form greys out its "preserve order" switch on a service
         # whose writes can't replay date-added order.
-        by_id = {a["id"]: a for a in accounts}
-        assert by_id["apple"]["preserves_order"] is True
-        assert by_id["deezer"]["preserves_order"] is False
-        assert by_id["jellyfin"]["preserves_order"] is False   # browse-only, no target
+        by_provider = {a["provider"]: a for a in accounts}
+        assert by_provider["apple"]["preserves_order"] is True
+        assert by_provider["deezer"]["preserves_order"] is False
+        assert by_provider["jellyfin"]["preserves_order"] is False   # browse-only, no target
+
+
+def test_account_profile_api_adds_labels_isolates_secrets_and_removes(tmp_path):
+    store = SettingsStore(dir=tmp_path)
+    with TestClient(create_app(settings=store)) as client:
+        created = client.post(
+            "/api/accounts", json={"provider": "spotify", "label": "Alex"}
+        )
+        assert created.status_code == 200
+        profile = created.json()
+        assert profile["id"].startswith("profile_")
+        assert profile["id"] != "spotify"
+        assert profile["provider"] == "spotify"
+        assert profile["label"] == "Alex"
+        assert profile["name"] == "Spotify · Alex"
+        assert profile["is_default"] is False and profile["removable"] is True
+
+        assert client.post(
+            f"/api/accounts/{profile['id']}/config",
+            json={"SPOTIFY_SP_DC": "profile-secret"},
+        ).json() == {"ok": True}
+        listed = next(
+            account for account in client.get("/api/accounts").json()
+            if account["id"] == profile["id"]
+        )
+        secret = next(
+            field for field in listed["fields"]
+            if field["key"] == "SPOTIFY_SP_DC"
+        )
+        assert secret["configured"] is True
+        assert secret["value"] == ""
+        assert store.get("SPOTIFY_SP_DC") is None
+        assert "profile-secret" not in (tmp_path / "profiles.json").read_text(encoding="utf-8")
+
+        renamed = client.patch(
+            f"/api/accounts/{profile['id']}", json={"label": "Household"}
+        ).json()
+        assert renamed["label"] == "Household"
+        profile_dir = tmp_path / "profiles" / profile["id"]
+        assert "profile-secret" in (profile_dir / "settings.json").read_text(encoding="utf-8")
+
+        assert client.delete(f"/api/accounts/{profile['id']}").json() == {"ok": True}
+        assert not profile_dir.exists()
+        assert profile["id"] not in {a["id"] for a in client.get("/api/accounts").json()}
 
 
 def test_settings_roundtrip_masks_secrets(tmp_path):
@@ -236,13 +291,54 @@ def test_oauth_redirect_uses_configured_public_url(tmp_path, monkeypatch):
     assert result["redirect_uri"] == expected
 
 
+def test_oauth_redirect_keeps_default_callback_and_scopes_custom_profile(
+    tmp_path, monkeypatch
+):
+    from songmirror.services.accounts.spotify import SpotifyConnector
+
+    seen = []
+    monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
+    monkeypatch.setattr(
+        SpotifyConnector,
+        "begin_redirect",
+        lambda _self, uri: (seen.append(uri), "https://accounts.spotify.test/authorize")[1],
+    )
+
+    with TestClient(_app(tmp_path)) as client:
+        default = next(
+            account for account in client.get("/api/accounts").json()
+            if account["provider"] == "spotify" and account["is_default"]
+        )
+        default_result = client.post(
+            f"/api/accounts/{default['id']}/connect",
+            headers={"host": "localhost:8888"},
+        ).json()
+        custom = client.post(
+            "/api/accounts", json={"provider": "spotify", "label": "Family"}
+        ).json()
+        client.post(
+            f"/api/accounts/{custom['id']}/config",
+            json={"SPOTIFY_AUTH_MODE": "oauth"},
+        )
+        custom_result = client.post(
+            f"/api/accounts/{custom['id']}/connect",
+            headers={"host": "localhost:8888"},
+        ).json()
+
+    legacy = "http://127.0.0.1:8888/oauth/spotify/callback"
+    scoped = f"http://127.0.0.1:8888/oauth/{custom['id']}/callback"
+    assert default_result["redirect_uri"] == legacy
+    assert custom_result["redirect_uri"] == scoped
+    assert seen == [legacy, scoped]
+
+
 def test_spotify_oauth_mode_exposes_masked_env_credentials(tmp_path, monkeypatch):
     monkeypatch.setenv("SPOTIFY_AUTH_MODE", "oauth")
     monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env-client")
     monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "env-secret")
 
     with TestClient(_app(tmp_path)) as client:
-        spotify = next(a for a in client.get("/api/accounts").json() if a["id"] == "spotify")
+        spotify = next(a for a in client.get("/api/accounts").json() if a["provider"] == "spotify")
 
     assert spotify["auth_kind"] == "oauth_redirect"
     fields = {field["key"]: field for field in spotify["fields"]}


### PR DESCRIPTION
## Summary
- add labeled, independently authenticated profiles with isolated credentials, session state, and caches
- make accounts, playlist browsing, links, syncs, transfers, and background target construction profile-aware
- support same-provider cross-profile transfers while keeping provider branding separate from account identity

## Compatibility and migration
Legacy provider IDs remain aliases for deterministic default profiles, so existing jobs, links, settings, and API callers continue to work. Default OAuth profiles retain the registered `/oauth/<provider>/callback` URLs; custom profiles use scoped callback URLs.

Profile metadata contains no secrets. Each profile stores private settings and session state beneath the data directory, and provider environment projection is guarded by a shared process-wide lock.

Profile-aware archive opens transactionally and idempotently migrate legacy provider namespaces across snapshots, links, sync baselines, pending removals, identity history, order state, and playlist caches. Existing profile-era rows win collisions, and later writes from older CLI versions are migrated on the next profile-aware open.

## Verification
- `uv run pytest -q` — 544 passed, 1 skipped
- `pnpm -C frontend lint` — passed
- `pnpm -C frontend build` — passed
- `$env:CI='1'; pnpm -C frontend test:e2e:ci` — 132 checks, 0 horizontal-overflow failures
- `docker compose config --quiet` — passed
- `git diff --check origin/main...HEAD` — passed

Closes #43