### PR TITLE
fix: unblock valid sync additions and improve storage settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,14 +299,22 @@ Some of these integrations use the providers' first-party web interfaces and can
 
 Backups do not require a second provider or a sync job:
 
-- On **Settings → Playlist archive**, add any connected playlist account, choose JSON or XML, set its interval and how many snapshots to retain, then leave SongMirror running. Set retention to `0` to keep every snapshot.
-- Scheduled files are written under `data/playlist_backups/<account-profile-id>/` (or `/data/playlist_backups/<account-profile-id>/` in Docker), alongside the rest of SongMirror's persistent data. Each account keeps its own schedule, including multiple accounts on the same service. Removing a schedule never deletes snapshots already on disk.
+- On **Settings → Playlist backups**, use **Add backup** at the top to add a connected account. Choose JSON or XML, then select a frequency such as daily or weekly. Custom intervals use a number and a unit. **Keep backups** offers retention presets, a custom count, or **All backups**.
+- Backups default to `data/playlist_backups/<account-profile-id>/` (or `/data/playlist_backups/<account-profile-id>/` in Docker). Click **Backup folder** for the built-in folder picker, or choose **Enter path manually**. A custom folder still gets a separate subfolder for each account. **Use default backup folder** restores the default. Changing locations affects future backups; old files stay where they are. Retention and **Download latest** apply to the selected location. Removing a schedule never deletes saved files.
+- **Settings → Downloads & Jellyfin → Download folder** uses the same built-in picker and manual entry. Choose a folder accessible to your Jellyfin library. Downloads follow each opted-in sync's schedule on the Sync tab. The picker displays configured host paths (for example, `F:\Torrent\Music`) while retaining their Docker mapping (`/music`) internally. Existing download mounts are unchanged. Additional host folders must first be shared as Docker bind mounts; choosing an unmounted folder shows an error and leaves the current setting unchanged.
+
 - The same Settings card shows the next run, stored snapshot count, last successful file and counts, and the most recent failure. **Back up now** queues a safe on-demand run; **Download latest** retrieves the newest persisted snapshot.
 - On the **Playlists** page, use **Export** on a service card to download every playlist from that service in one versioned JSON or XML file.
 - Open a playlist to export only that playlist. Its **Soundiiz** option follows [Soundiiz's documented JSON import shape](https://soundiiz.com/data/fileExamples/playlistExport.json), so the downloaded track list can be uploaded through Soundiiz's **Import Playlist → From File** flow.
 - SongMirror JSON/XML preserves playlist order and names plus provider track/occurrence IDs, available ISRCs, artists, albums, album track positions, durations, added dates, artwork links, and unavailable-entry markers. ID-less catalog ghosts remain in the backup instead of disappearing. Files contain no cookies, tokens, request headers, previews, or streaming-file URLs.
 
 Manual exports are downloaded by the browser to the device running the UI. Scheduled exports use the existing application-data volume, so no second host path or container mount is required. Backup reads queue behind syncs and transfers instead of accessing provider clients concurrently. The `schema_version` field lets future releases evolve the lossless format without making old snapshots ambiguous.
+
+### Built-in folder picker
+
+Click a folder field or **Browse…** to open the built-in picker. Use **Locations**, clickable breadcrumbs, **Back**, **Forward**, and **Up one folder** to navigate. Click a folder to select it; double-click, press Enter, or use its arrow to open it. Search filters the current folder. **Enter a folder path** accepts a full address. **Select folder** updates the draft; save the settings or schedule to apply it. Cancel leaves the draft unchanged. No desktop helper or additional process is required.
+
+**New folder** creates a named subfolder in the currently open location, then opens it. Existing items are never overwritten. Cancelling name entry creates nothing; cancelling the picker after creation leaves the new folder on disk. Your saved backup or download location changes only after selecting and saving. In Docker, the picker explains which paths are shared and shows both the container path and its configured computer path when available.
 
 <div align="right">
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,14 @@ services:
       SPOTIFY_OAUTH_OPEN_BROWSER: "0"
       # Container-internal download path (the host music dir is bind-mounted to
       # it below). SONGMIRROR_DOWNLOAD_DIR is authoritative over any UI-saved
-      # DOWNLOAD_DIR — that value can be a host path (e.g. F:\Torrent\Music) the
+      # legacy DOWNLOAD_DIR — that value can be a host path (e.g. F:\Torrent\Music) the
       # container's Linux filesystem doesn't have, which would send spotDL into
       # the ephemeral container instead of the mount. Set the HOST location via
-      # DOWNLOAD_DIR in .env (it drives the mount below), not the in-app field.
+      # DOWNLOAD_DIR in .env (it drives the mount below). New folder choices in
+      # the UI are validated inside the container and can select another mount.
       SONGMIRROR_DOWNLOAD_DIR: /music
+      # Display the host music path in the built-in folder picker.
+      SONGMIRROR_HOST_DOWNLOAD_DIR: "${DOWNLOAD_DIR:-}"
     volumes:
       - ./data:/data
       - "${DOWNLOAD_DIR:-./downloads}:/music"

--- a/frontend/e2e/backup-folder-edit.cjs
+++ b/frontend/e2e/backup-folder-edit.cjs
@@ -1,0 +1,127 @@
+// Focused regression: editing a folder is safe while a backup is running;
+// applying that change must wait, and polling must preserve the draft.
+const assert = require('node:assert/strict')
+const http = require('node:http')
+const fs = require('node:fs')
+const path = require('node:path')
+const { chromium } = require('playwright')
+
+async function main() {
+  const dist = path.resolve(__dirname, '../dist')
+  const server = http.createServer((req, res) => {
+    const pathname = new URL(req.url, 'http://localhost').pathname
+    const asset = path.resolve(dist, '.' + pathname)
+    const file = asset.startsWith(dist + path.sep) && fs.existsSync(asset) && fs.statSync(asset).isFile()
+      ? asset : path.join(dist, 'index.html')
+    const mime = { '.js': 'text/javascript', '.css': 'text/css', '.html': 'text/html', '.woff2': 'font/woff2' }
+    res.setHeader('Content-Type', mime[path.extname(file)] || 'application/octet-stream')
+    fs.createReadStream(file).pipe(res)
+  })
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    const job = { account_id: 'spotify', provider: 'spotify', provider_name: 'Spotify', account_name: 'Spotify',
+      enabled: true, interval: '24h', format: 'json', retention: 5, storage_dir: '',
+      default_storage_dir: '/data/playlist_backups', storage_path: '/data/playlist_backups/spotify',
+      running: true, next_run_at: null, snapshot_count: 1, last_success: null, last_failure: null }
+    let saved = null
+    let nativeRequests = 0
+    const createdFolders = []
+    await page.route('**/api/**', async route => {
+      const req = route.request()
+      const url = new URL(req.url())
+      let body = []
+      if (url.pathname === '/api/accounts') body = [{ id: 'spotify', provider: 'spotify', label: '', name: 'Spotify', state: 'connected', fields: [], transferable: true }]
+      if (url.pathname === '/api/settings') body = { DISPLAY_NAME: '', DOWNLOAD_DIR: '/music', LOCAL_MIRROR_FORMAT: '' }
+      if (url.pathname === '/api/sync/status') body = { running: false, jobs: [], last: null }
+      if (url.pathname === '/api/playlist-backups') body = [job]
+      if (url.pathname === '/api/playlist-backups/spotify' && req.method() === 'PUT') {
+        saved = req.postDataJSON()
+        Object.assign(job, saved)
+        body = job
+      }
+      if (url.pathname === '/api/folders/config') body = { scope: 'container', mounts: [{ host: 'F:\\Torrent\\Music', server: '/music' }], locations: [{ name: 'App data', path: '/data' }] }
+      if (url.pathname === '/api/folders' && req.method() === 'POST') {
+        const values = req.postDataJSON()
+        if (values.name === 'existing') return route.fulfill({ status: 422, contentType: 'application/json', body: JSON.stringify({ detail: 'A file or folder with that name already exists. Choose another name.' }) })
+        createdFolders.push(values)
+        body = { path: values.parent + '/' + values.name }
+      }
+      if (url.pathname === '/api/folders' && req.method() === 'GET') {
+        const folder = url.searchParams.get('path') || '/data'
+        body = { path: folder, parent: '/data', writable: true, directories: [], breadcrumbs: [{ name: 'App data', path: '/data' }] }
+      }
+      if (url.pathname.startsWith('/api/folders/pick')) nativeRequests++
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(body) })
+    })
+    await page.route('**/events*', route => route.fulfill({ contentType: 'text/event-stream', body: '' }))
+    await page.goto(`http://127.0.0.1:${server.address().port}/settings?section=backups`)
+    const folder = page.getByLabel('Backup folder', { exact: true })
+    await folder.waitFor()
+    assert.equal(await folder.isEnabled(), true, 'A running backup must not disable folder browsing')
+    assert.equal(await page.getByRole('switch', { name: 'Use default backup folder' }).isEnabled(), true)
+    await folder.click()
+    await page.getByRole('dialog', { name: 'Choose backup folder' }).waitFor()
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click()
+    await page.getByRole('button', { name: 'Enter path manually', exact: true }).click()
+    await folder.fill('/data/custom-backups')
+    const save = page.getByRole('button', { name: 'Save Spotify backup schedule' })
+    assert.equal(await save.isDisabled(), true, 'Changing the active destination must wait for completion')
+    await page.getByText('You can choose a folder now. Save the new location after this backup finishes.').waitFor()
+    job.running = false
+    await page.waitForFunction(() => !document.querySelector('[aria-label="Save Spotify backup schedule"]').disabled, null, { timeout: 8000 })
+    assert.equal(await folder.inputValue(), '/data/custom-backups', 'Polling must preserve the selected draft')
+    await Promise.all([page.waitForResponse(response => response.url().endsWith('/api/playlist-backups/spotify') && response.request().method() === 'PUT'), save.click()])
+    assert.equal(saved.storage_dir, '/data/custom-backups')
+    await page.getByRole('link', { name: 'Downloads & Jellyfin', exact: true }).click()
+    await page.getByLabel('Download folder', { exact: true }).click()
+    await page.getByRole('dialog', { name: 'Choose download folder' }).waitFor()
+    const dialog = page.getByRole('dialog', { name: 'Choose download folder' })
+    await dialog.getByText('Docker storage, not your whole computer').waitFor()
+    await dialog.getByText('Container path:', { exact: false }).waitFor()
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 })
+      await dialog.getByRole('button', { name: 'New folder', exact: true }).click()
+      const name = dialog.getByLabel('Folder name', { exact: true })
+      await name.fill('unused')
+      await dialog.getByRole('button', { name: 'Cancel creation', exact: true }).click()
+      assert.equal(createdFolders.length, width === 1280 ? 0 : 1, 'Cancel creation must not write a folder')
+      await dialog.getByRole('button', { name: 'New folder', exact: true }).click()
+      await name.fill('existing')
+      await name.press('Enter')
+      await dialog.getByRole('alert').filter({ hasText: 'already exists' }).waitFor()
+      assert.equal(await name.inputValue(), 'existing', 'An error must preserve the entered name')
+      await name.fill('My backups ' + width)
+      fs.mkdirSync(path.join(__dirname, 'screenshots'), { recursive: true })
+      await page.screenshot({ path: path.join(__dirname, `screenshots/new-folder-${width}.png`) })
+      await name.press('Enter')
+      await dialog.getByRole('status').filter({ hasText: 'Created My backups ' + width }).waitFor()
+      assert.ok((await dialog.innerText()).includes('Cancelling the picker will not delete it.'))
+      const size = await dialog.evaluate(el => ({ scroll: el.scrollWidth, client: el.clientWidth }))
+      assert.ok(size.scroll <= size.client, 'Folder controls must fit at ' + width)
+    }
+    assert.equal(createdFolders[0].parent, '/music')
+    assert.equal(createdFolders[1].parent, '/music/My backups 1280')
+    await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
+    assert.equal((await page.getByLabel('Download folder', { exact: true }).innerText()).trim(), 'F:\\Torrent\\Music', 'Creating a folder must not change the saved location')
+    assert.equal(nativeRequests, 0, 'Neither picker may request a desktop helper')
+    await page.goto(`http://127.0.0.1:${server.address().port}/accounts`)
+    for (const width of [1280, 375]) {
+      await page.setViewportSize({ width, height: 900 })
+      const controls = [page.getByLabel('Provider', { exact: true }), page.getByLabel('New profile label', { exact: true }), page.getByRole('button', { name: 'Add profile', exact: true })]
+      const boxes = await Promise.all(controls.map(control => control.boundingBox()))
+      if (width === 1280) {
+        assert.ok(Math.max(...boxes.map(box => box.y)) - Math.min(...boxes.map(box => box.y)) <= 1, 'Profile fields and button must align at the top')
+        assert.ok(Math.max(...boxes.map(box => box.y + box.height)) - Math.min(...boxes.map(box => box.y + box.height)) <= 1, 'Profile fields and button must align at the bottom')
+      } else assert.ok(boxes[0].y < boxes[1].y && boxes[1].y < boxes[2].y, 'Profile controls stack on mobile')
+      await page.screenshot({ path: path.join(__dirname, `screenshots/account-profile-alignment-${width}.png`) })
+    }
+    console.log('PASS: running-backup editing, draft preservation, no helper, Docker path guidance, folder creation/cancellation/errors on desktop and mobile')
+    console.log('PASS: account profile row aligns on desktop and stacks on mobile')
+  } finally {
+    await browser.close()
+    await new Promise(resolve => server.close(resolve))
+  }
+}
+main().catch(error => { console.error(error); process.exitCode = 1 })

--- a/frontend/e2e/verify.cjs
+++ b/frontend/e2e/verify.cjs
@@ -159,6 +159,8 @@ function initialPlaylistBackups() {
     next_run_at: Math.floor(now / 1000) + 6 * 3600,
     snapshot_count: 3,
     storage_path: '/data/playlist_backups/spotify',
+    storage_dir: '',
+    default_storage_dir: '/data/playlist_backups',
     last_success: {
       at: new Date(now - 24 * 3600 * 1000).toISOString(),
       filename: 'songmirror-spotify-all-playlists-20260903T120000Z.json',
@@ -509,7 +511,7 @@ async function installMocks(page, opts = {}) {
   // one test never leak into another.
   let syncsData = opts.syncs ?? initialSyncs()
   let accountsData = [...(opts.accounts ?? ACCOUNTS)]
-  const settingsData = opts.settings ?? SETTINGS
+  const settingsData = { ...(opts.settings ?? SETTINGS) }
   const playlistsData = opts.playlists ?? PLAYLISTS
   const delays = opts.delays ?? {}
   let playlistBackupsData = opts.playlistBackups ?? initialPlaylistBackups()
@@ -582,7 +584,23 @@ async function installMocks(page, opts = {}) {
       await delay('settings')
       return json(settingsData)
     }
-    if (p === '/api/settings' && method === 'PUT') return json({ ok: true })
+    if (p === '/api/settings' && method === 'PUT') {
+      Object.assign(settingsData, req.postDataJSON())
+      return json({ ok: true })
+    }
+
+    if (p === '/api/folders/config') {
+      return json({ scope: 'container', locations: [{ name: 'App data', path: '/data' }, { name: 'Music downloads', path: '/music/playlists' }], mounts: [{ host: 'F:\\Torrent\\Music', server: '/music' }] })
+    }
+    if (p === '/api/folders' && method === 'GET') {
+      const folderPath = url.searchParams.get('path') || '/data'
+      if (folderPath === '/missing') return json({ detail: 'Folder not found. Choose another path.' }, 422)
+      const directories = folderPath === '/data' ? [{ name: 'Backups', path: '/data/Backups' }, { name: 'playlist_backups', path: '/data/playlist_backups' }]
+        : folderPath === '/music/playlists' ? [{ name: 'Jellyfin', path: '/music/playlists/Jellyfin' }, { name: 'Aurora', path: '/music/playlists/Aurora' }] : []
+      const parts = folderPath.split('/').filter(Boolean)
+      return json({ path: folderPath, parent: folderPath === '/' ? null : folderPath.slice(0, folderPath.lastIndexOf('/')) || '/',
+        breadcrumbs: [{ name: '/', path: '/' }, ...parts.map((name, i) => ({ name, path: '/' + parts.slice(0, i + 1).join('/') }))], directories, writable: true })
+    }
 
     if (p === '/api/playlist-backups' && method === 'GET') return json(playlistBackupsData)
     if (/^\/api\/playlist-backups\/[^/]+$/.test(p) && method === 'PUT') {
@@ -603,11 +621,14 @@ async function installMocks(page, opts = {}) {
         next_run_at: Math.floor(Date.now() / 1000) + 24 * 3600,
         snapshot_count: 0,
         storage_path: `/data/playlist_backups/${accountId}`,
+        storage_dir: '',
+        default_storage_dir: '/data/playlist_backups',
         last_success: null,
         last_failure: null,
         ...existing,
         ...body,
       }
+      updated.storage_path = `${updated.storage_dir || updated.default_storage_dir}/${accountId}`
       playlistBackupsData = [
         ...playlistBackupsData.filter((item) => item.account_id !== accountId),
         updated,
@@ -2399,23 +2420,25 @@ async function main() {
       const settingsShapeOk =
         settingsBodyText.includes('PROFILE') &&
         settingsBodyText.includes('APPEARANCE') &&
-        settingsBodyText.includes('DOWNLOAD MIRROR') &&
-        settingsBodyText.includes('PLAYLIST ARCHIVE') &&
-        settingsBodyText.includes('/data/playlist_backups/spotify') &&
-        settingsBodyText.includes('Last success') &&
-        settingsBodyText.includes('Last failure') &&
+        !settingsBodyText.includes('DOWNLOAD MIRROR') &&
+        !settingsBodyText.includes('PLAYLIST ARCHIVE') &&
         !settingsBodyText.includes('SYNC BEHAVIOR') &&
         !settingsBodyText.includes('SAFETY CAPS')
-      console.log(`${settingsShapeOk ? 'ok        ' : 'FAIL      '} Settings shows Profile + Appearance + Download mirror + persistent playlist archive`)
+      console.log(`${settingsShapeOk ? 'ok        ' : 'FAIL      '} General settings stays focused on Profile and Appearance`)
       if (!settingsShapeOk) results.push({ label: 'settings shape', overflow: true })
-      const downloadDirValue = await page.getByLabel('Download folder', { exact: true }).inputValue()
-      console.log(`${downloadDirValue === '/music/playlists' ? 'ok        ' : 'FAIL      '} Settings' Download folder is pre-filled from SETTINGS (got "${downloadDirValue}")`)
-      if (downloadDirValue !== '/music/playlists') results.push({ label: 'settings download dir prefill', overflow: true })
       const syncPointer = page.getByRole('link', { name: 'Manage your syncs on the Sync tab', exact: true })
       const syncPointerHref = await syncPointer.getAttribute('href')
       console.log(`${syncPointerHref === '/sync' ? 'ok        ' : 'FAIL      '} Settings has a pointer link to the Sync tab (href="${syncPointerHref}")`)
       if (syncPointerHref !== '/sync') results.push({ label: 'settings sync pointer', overflow: true })
 
+      await page.getByRole('link', { name: 'Playlist backups', exact: true }).click()
+      const addBox = await page.getByRole('button', { name: 'Add backup', exact: true }).boundingBox()
+      const cardBox = await page.getByRole('heading', { name: 'Spotify', exact: true }).boundingBox()
+      const addFirst = addBox.y < cardBox.y
+      console.log(`${addFirst ? 'ok        ' : 'FAIL      '} Add backup appears above existing schedules`)
+      if (!addFirst) results.push({ label: 'backup add first', overflow: true })
+      await checkOverflow(page, `Backup settings @ ${width}`, results)
+      await shot(page, `settings-backups-${width}`)
       await page.getByRole('button', { name: 'Back up Spotify now', exact: true }).click()
       await page.waitForTimeout(100)
       const manualBackupRecorded = (await page.locator('body').innerText()).includes('4 stored snapshots')
@@ -2423,11 +2446,76 @@ async function main() {
       if (!manualBackupRecorded) results.push({ label: 'playlist backup run now', overflow: true })
 
       await page.getByLabel('Add a connected account', { exact: true }).selectOption('apple')
-      await page.getByRole('button', { name: 'Add daily backup', exact: true }).click()
+      await page.getByRole('button', { name: 'Add backup', exact: true }).click()
       await page.waitForSelector('h3:has-text("Apple Music")')
       const appleScheduleAdded = (await page.locator('body').innerText()).includes('/data/playlist_backups/apple')
       console.log(`${appleScheduleAdded ? 'ok        ' : 'FAIL      '} a connected account gets its own persisted backup schedule`)
       if (!appleScheduleAdded) results.push({ label: 'playlist backup schedule create', overflow: true })
+
+      // Frequency presets, custom units, retention, folder browsing, and manual
+      // paths must all persist through the existing Save schedule flow.
+      const spotifyBackup = page.locator('div.rounded-control').filter({ has: page.getByRole('heading', { name: 'Spotify', exact: true }) }).first()
+      await spotifyBackup.getByLabel('Backup frequency', { exact: true }).selectOption('168h')
+      await page.getByRole('button', { name: 'Save Spotify backup schedule' }).click()
+      await page.waitForResponse((response) => response.url().endsWith('/api/playlist-backups') && response.request().method() === 'GET')
+      await spotifyBackup.getByLabel('Backup frequency', { exact: true }).selectOption('custom')
+      await spotifyBackup.getByLabel('Backup frequency: unit', { exact: true }).selectOption('d')
+      await spotifyBackup.getByLabel('Backup frequency: every', { exact: true }).fill('2')
+      await spotifyBackup.getByLabel('Keep backups', { exact: true }).selectOption('0')
+      await spotifyBackup.getByLabel('Backup folder', { exact: true }).click()
+      let folderDialog = page.getByRole('dialog', { name: 'Choose backup folder' })
+      await folderDialog.getByRole('button', { name: 'App data', exact: true }).click()
+      await folderDialog.getByRole('button', { name: 'Backups', exact: true }).click()
+      await folderDialog.getByRole('button', { name: 'Select folder', exact: true }).click()
+      await spotifyBackup.getByLabel('Backup folder', { exact: true }).filter({ hasText: '/data/Backups' }).waitFor()
+      const saveBackupRequest = page.waitForRequest((request) => request.url().endsWith('/api/playlist-backups/spotify') && request.method() === 'PUT')
+      await page.getByRole('button', { name: 'Save Spotify backup schedule' }).click()
+      const savedBackup = (await saveBackupRequest).postDataJSON()
+      const friendlyBackupOk = savedBackup.interval === '172800s' && savedBackup.retention === 0 && savedBackup.storage_dir === '/data/Backups'
+      console.log(`${friendlyBackupOk ? 'ok        ' : 'FAIL      '} friendly backup frequency, retention, and selected folder persist`)
+      if (!friendlyBackupOk) results.push({ label: 'backup frequency and location', overflow: true })
+
+      await page.getByRole('link', { name: 'Downloads & Jellyfin', exact: true }).click()
+      const downloadDirValue = (await page.getByLabel('Download folder', { exact: true }).innerText()).trim()
+      const hostPathShown = downloadDirValue === 'F:\\Torrent\\Music\\playlists'
+      console.log(`${hostPathShown ? 'ok        ' : 'FAIL      '} Download folder displays the original Windows host path (${downloadDirValue})`)
+      if (!hostPathShown) results.push({ label: 'settings host download path', overflow: true })
+      await page.getByLabel('Download folder', { exact: true }).click()
+      folderDialog = page.getByRole('dialog', { name: 'Choose download folder' })
+      await folderDialog.getByRole('button', { name: 'Open Jellyfin', exact: true }).click()
+      await folderDialog.getByText('No subfolders. You can select this folder.').waitFor()
+      await folderDialog.getByRole('button', { name: 'Back', exact: true }).click()
+      await folderDialog.getByRole('button', { name: 'Jellyfin', exact: true }).waitFor()
+      await folderDialog.getByRole('button', { name: 'Forward', exact: true }).click()
+      await folderDialog.getByText('No subfolders. You can select this folder.').waitFor()
+      await folderDialog.getByRole('button', { name: 'Up one folder', exact: true }).click()
+      await folderDialog.getByRole('button', { name: 'Aurora', exact: true }).waitFor()
+      await folderDialog.getByLabel('Search folders').fill('jelly')
+      await folderDialog.getByRole('button', { name: 'Aurora', exact: true }).waitFor({ state: 'hidden' })
+      await folderDialog.getByRole('button', { name: 'Jellyfin', exact: true }).click()
+      await checkOverflow(page, `Explorer folder picker @ ${width}`, results)
+      await shot(page, `folder-picker-${width}`)
+      await folderDialog.getByRole('button', { name: 'Cancel', exact: true }).click()
+      if ((await page.getByLabel('Download folder', { exact: true }).innerText()).trim() !== downloadDirValue) results.push({ label: 'picker cancel preserves path', overflow: true })
+      await page.getByLabel('Download folder', { exact: true }).click()
+      await folderDialog.getByRole('button', { name: 'Enter a folder path', exact: true }).click()
+      await folderDialog.getByLabel('Folder address').fill('/missing')
+      await folderDialog.getByLabel('Folder address').press('Enter')
+      await folderDialog.getByRole('alert').filter({ hasText: 'Folder not found' }).waitFor()
+      if (await folderDialog.getByRole('button', { name: 'Select folder', exact: true }).isEnabled()) results.push({ label: 'invalid path prevents selection', overflow: true })
+      await folderDialog.getByRole('button', { name: 'Music downloads', exact: true }).click()
+      await folderDialog.getByRole('button', { name: 'Jellyfin', exact: true }).dblclick()
+      await folderDialog.getByText('No subfolders. You can select this folder.').waitFor()
+      await folderDialog.getByRole('button', { name: 'Select folder', exact: true }).click()
+      await page.getByLabel('Download folder', { exact: true }).filter({ hasText: 'Jellyfin' }).waitFor()
+      const downloadGroup = page.locator('div').filter({ has: page.getByLabel('Download folder', { exact: true }) }).filter({ has: page.getByRole('button', { name: 'Enter path manually', exact: true }) }).last()
+      await downloadGroup.getByRole('button', { name: 'Enter path manually', exact: true }).click()
+      await page.getByLabel('Download folder', { exact: true }).fill('/music/custom')
+      const settingsRequest = page.waitForRequest((request) => request.url().endsWith('/api/settings') && request.method() === 'PUT')
+      await page.getByRole('button', { name: 'Save changes', exact: true }).click()
+      const folderSaved = (await settingsRequest).postDataJSON().DOWNLOAD_DIR === '/music/custom'
+      console.log(`${folderSaved ? 'ok        ' : 'FAIL      '} download folder supports browsing and manual input`)
+      if (!folderSaved) results.push({ label: 'download folder picker and manual input', overflow: true })
       await checkOverflow(page, `Settings shape @ ${width}`, results)
       await shot(page, `settings-${width}`)
 
@@ -2603,7 +2691,7 @@ async function main() {
       const summaryOk =
         summaryText.includes('Bidirectional (N-way)') &&
         summaryText.includes('Spotify ⇄ Apple Music') &&
-        summaryText.includes('30m')
+        summaryText.includes('30 minutes')
       console.log(`${summaryOk ? 'ok        ' : 'FAIL      '} Wizard review reflects Direction + Services + Schedule choices (got "${summaryText.replace(/\n/g, ' ')}")`)
       if (!summaryOk) results.push({ label: 'wizard review summary', overflow: true })
       await checkOverflow(page, `Wizard step 5 Limits + review @ ${width}`, results)
@@ -2614,7 +2702,7 @@ async function main() {
       await page.getByRole('button', { name: 'Save changes', exact: true }).click()
       await page.waitForSelector('text=Edit "Default"', { state: 'hidden' })
       const listAfterSaveText = await page.locator('body').innerText()
-      const saveRoundTripOk = listAfterSaveText.includes('Spotify ⇄ Apple Music') && listAfterSaveText.includes('every 30m')
+      const saveRoundTripOk = listAfterSaveText.includes('Spotify ⇄ Apple Music') && listAfterSaveText.includes('every 30 minutes')
       console.log(`${saveRoundTripOk ? 'ok        ' : 'FAIL      '} Saving the wizard updates the list card (PUT round trip)`)
       if (!saveRoundTripOk) results.push({ label: 'wizard save round trip', overflow: true })
       await checkOverflow(page, `Sync list after save @ ${width}`, results)
@@ -2923,7 +3011,7 @@ async function main() {
       // wizard involved.
       const workoutCard = page.locator('h3', { hasText: 'Workout' }).locator('xpath=ancestor::div[contains(@class,"rounded-card")][1]')
       await workoutCard.getByRole('switch', { name: /Resume "Workout"/, exact: false }).click()
-      await page.waitForSelector('text=every 1h') // "manual only" -> "every 1h" once enabled
+      await page.waitForSelector('text=every 1 hour') // "manual only" -> scheduled once enabled
       const workoutPausedGone = (await workoutCard.getByText('paused', { exact: true }).count()) === 0
       console.log(`${workoutPausedGone ? 'ok        ' : 'FAIL      '} Toggling a job's switch flips it live (paused badge clears)`)
       if (!workoutPausedGone) results.push({ label: 'sync card toggle', overflow: true })
@@ -4114,7 +4202,7 @@ async function main() {
       })
 
       await page.setViewportSize({ width: 1280, height: 900 })
-      await page.goto(BASE_URL + '/settings', { waitUntil: 'networkidle' })
+      await page.goto(BASE_URL + '/settings?section=backups', { waitUntil: 'networkidle' })
       const accountSelect = page.getByLabel('Add a connected account', { exact: true })
       const availableAccountIds = await accountSelect.locator('option').evaluateAll(
         (options) => options.map((option) => option.value),
@@ -4123,7 +4211,7 @@ async function main() {
         availableAccountIds.includes(alexSpotify.id)
         && !availableAccountIds.includes(defaultSpotify.id)
       await accountSelect.selectOption(alexSpotify.id)
-      await page.getByRole('button', { name: 'Add daily backup', exact: true }).click()
+      await page.getByRole('button', { name: 'Add backup', exact: true }).click()
       await page.getByRole('heading', { name: 'Spotify · Alex', exact: true }).waitFor()
       const body = await page.locator('body').innerText()
       const profilesStaySeparate =

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "oxlint",
     "preview": "vite preview",
-    "test:e2e": "node e2e/verify.cjs",
-    "test:e2e:ci": "vite build && node e2e/verify.cjs"
+    "test:e2e": "node e2e/verify.cjs && node e2e/backup-folder-edit.cjs",
+    "test:e2e:ci": "vite build && node e2e/verify.cjs && node e2e/backup-folder-edit.cjs"
   },
   "dependencies": {
     "@fontsource-variable/archivo": "^5.2.8",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,8 @@
 // production (FastAPI serves the built SPA); proxied through Vite in dev
 // (see vite.config.ts). No client-side base URL needed either way.
 import type {
+  FolderPickerConfig,
+  FolderListing,
   Account,
   ClearUnmatchedResponse,
   ConnectResponse,
@@ -147,6 +149,9 @@ export const api = {
 
   // Settings
   getSettings: () => request<Settings>('/api/settings'),
+  folderPickerConfig: () => request<FolderPickerConfig>('/api/folders/config'),
+  browseFolders: (path = '') => request<FolderListing>(`/api/folders?path=${encodeURIComponent(path)}`),
+  createFolder: (parent: string, name: string) => request<{ path: string }>('/api/folders', { method: 'POST', body: JSON.stringify({ parent, name }) }),
   saveSettings: (values: Settings) => request<OkResponse>('/api/settings', { method: 'PUT', body: JSON.stringify(values) }),
 
   // Persistent scheduled playlist-metadata backups

--- a/frontend/src/components/settings/ScheduledPlaylistBackups.tsx
+++ b/frontend/src/components/settings/ScheduledPlaylistBackups.tsx
@@ -6,7 +6,7 @@ import { useAccounts } from '@/hooks/useAccounts'
 import { useNow } from '@/hooks/useNow'
 import { usePlaylistBackups } from '@/hooks/usePlaylistBackups'
 import { capabilitiesOf } from '@/lib/accountCapabilities'
-import { formatClockTime, formatCountdown, isValidIntervalText } from '@/lib/format'
+import { formatCountdown, intervalSeconds } from '@/lib/format'
 import type {
   Account,
   PlaylistBackupFormat,
@@ -16,13 +16,15 @@ import type {
 
 import { Button } from '../ui/Button'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { FolderField } from '../ui/FolderField'
+import { IntervalField } from '../ui/IntervalField'
 import { SelectField } from '../ui/SelectField'
 import { ServiceLogo } from '../ui/ServiceLogo'
 import { TextField } from '../ui/TextField'
 import { Toggle } from '../ui/Toggle'
 
 const FORMAT_OPTIONS = [
-  { value: 'json', label: 'JSON' },
+  { value: 'json', label: 'JSON (recommended)' },
   { value: 'xml', label: 'XML' },
 ]
 
@@ -31,6 +33,7 @@ const DEFAULT_UPDATE: Required<PlaylistBackupUpdate> = {
   interval: '24h',
   format: 'json',
   retention: 30,
+  storage_dir: '',
 }
 
 interface Draft {
@@ -38,6 +41,7 @@ interface Draft {
   interval: string
   format: PlaylistBackupFormat
   retention: string
+  storage_dir: string
 }
 
 function draftFrom(job: PlaylistBackupJob): Draft {
@@ -46,18 +50,11 @@ function draftFrom(job: PlaylistBackupJob): Draft {
     interval: job.interval,
     format: job.format,
     retention: String(job.retention),
+    storage_dir: job.storage_dir ?? '',
   }
 }
 
-function intervalSeconds(value: string): number | null {
-  const match = value.trim().toLocaleLowerCase().match(/^(\d+)\s*([smh]?)$/)
-  if (!match) return null
-  const multiplier = match[2] === 'h' ? 3600 : match[2] === 'm' ? 60 : 1
-  return Number(match[1]) * multiplier
-}
-
 function validInterval(value: string): boolean {
-  if (!isValidIntervalText(value)) return false
   const seconds = intervalSeconds(value)
   return seconds !== null && seconds >= 60 && seconds <= 365 * 24 * 60 * 60
 }
@@ -92,23 +89,26 @@ function BackupScheduleCard({
   const [busy, setBusy] = useState<'save' | 'run' | 'download' | 'delete' | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [customRetention, setCustomRetention] = useState(false)
   const now = useNow()
-  const { enabled, format, interval, retention } = job
+  const { enabled, format, interval, retention, storage_dir = '' } = job
 
   useEffect(() => {
-    setDraft({ enabled, format, interval, retention: String(retention) })
-  }, [enabled, format, interval, retention])
+    setDraft({ enabled, format, interval, retention: String(retention), storage_dir })
+  }, [enabled, format, interval, retention, storage_dir])
 
   const dirty = draft.enabled !== job.enabled
     || draft.interval !== job.interval
     || draft.format !== job.format
     || draft.retention !== String(job.retention)
+    || draft.storage_dir !== storage_dir
   const intervalOk = validInterval(draft.interval)
   const retentionOk = validRetention(draft.retention)
   const latestFailed = resultIsFailure(job)
+  const folderSaveBlocked = job.running && draft.storage_dir !== storage_dir
 
   async function save() {
-    if (!intervalOk || !retentionOk) return
+    if (!intervalOk || !retentionOk || folderSaveBlocked) return
     setBusy('save')
     setActionError(null)
     try {
@@ -117,6 +117,7 @@ function BackupScheduleCard({
         interval: draft.interval.trim(),
         format: draft.format,
         retention: Number(draft.retention),
+        storage_dir: draft.storage_dir,
       })
       await refresh()
     } catch (err) {
@@ -208,16 +209,16 @@ function BackupScheduleCard({
       </div>
 
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <TextField
-          label="Run every"
-          help="1m–8760h; for example 6h, 24h, or 168h."
+        <IntervalField
+          label="Backup frequency"
+          help="Choose how often to save a fresh backup."
           value={draft.interval}
-          error={intervalOk ? undefined : 'Use an interval from 1m through 8760h.'}
-          onChange={(event) => setDraft((current) => ({ ...current, interval: event.target.value }))}
+          error={intervalOk ? undefined : 'Choose an interval from 1 minute to 365 days.'}
+          onChange={(interval) => setDraft((current) => ({ ...current, interval }))}
         />
         <SelectField
-          label="Snapshot format"
-          help="JSON is easiest to inspect or process."
+          label="Backup format"
+          help="Playlist names and track details; audio is not included."
           options={FORMAT_OPTIONS}
           value={draft.format}
           onChange={(event) => setDraft((current) => ({
@@ -225,17 +226,44 @@ function BackupScheduleCard({
             format: event.target.value as PlaylistBackupFormat,
           }))}
         />
-        <TextField
-          label="Snapshots to keep"
-          help="Set 0 to keep every snapshot."
-          type="number"
-          min={0}
-          max={10_000}
-          step={1}
-          value={draft.retention}
-          error={retentionOk ? undefined : 'Enter a whole number from 0 through 10000.'}
-          onChange={(event) => setDraft((current) => ({ ...current, retention: event.target.value }))}
-        />
+        <div className="flex min-w-0 flex-col gap-3">
+          <SelectField label="Keep backups"
+            help="Older backups are removed after a successful save."
+            value={customRetention || !['7', '30', '90', '0'].includes(draft.retention) ? 'custom' : draft.retention}
+            options={[{ value: '7', label: 'Latest 7 backups' }, { value: '30', label: 'Latest 30 backups' },
+              { value: '90', label: 'Latest 90 backups' }, { value: '0', label: 'All backups' }, { value: 'custom', label: 'Custom amount…' }]}
+            onChange={(event) => {
+              setCustomRetention(event.target.value === 'custom')
+              if (event.target.value !== 'custom') setDraft((current) => ({ ...current, retention: event.target.value }))
+            }} />
+          {(customRetention || !['7', '30', '90', '0'].includes(draft.retention)) && (
+            <TextField
+              label="Keep latest backups"
+              type="number"
+              min={1}
+              max={10_000}
+              step={1}
+              value={draft.retention}
+              error={retentionOk ? undefined : 'Enter a whole number from 1 through 10,000.'}
+              onChange={(event) => setDraft((current) => ({ ...current, retention: event.target.value }))}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-control border border-border bg-surface p-3">
+        <FolderField label="Backup folder" value={draft.storage_dir}
+          defaultPath={job.default_storage_dir}
+          disabled={busy !== null}
+          help="Each account gets its own subfolder. Choose a folder or enter an existing path."
+          onChange={(storage_dir) => setDraft((current) => ({ ...current, storage_dir }))} />
+        <div className="mt-3">
+          <Toggle label="Use default backup folder" checked={!draft.storage_dir}
+            disabled={busy !== null}
+            onChange={(useDefault) => setDraft((current) => ({ ...current, storage_dir: useDefault ? '' : job.default_storage_dir }))} />
+        </div>
+        {draft.storage_dir !== storage_dir && <p className="mt-2 text-xs text-text-3">The new location applies to future backups. Existing files stay in their current folder.</p>}
+        {job.running && <p className="mt-2 text-xs text-text-3">You can choose a folder now. Save the new location after this backup finishes.</p>}
       </div>
 
       <div aria-live="polite" className="mt-4 rounded-control border border-border/80 bg-surface px-3 py-2.5 text-xs leading-relaxed text-text-2">
@@ -243,7 +271,7 @@ function BackupScheduleCard({
           <p>Reading every playlist now. Syncs and transfers will run before or after this backup, never at the same time.</p>
         ) : job.enabled && job.next_run_at ? (
           <p>
-            Next run at <span className="font-semibold text-text">{formatClockTime(job.next_run_at)}</span>
+            Next backup <span className="font-semibold text-text">{dateTime(new Date(job.next_run_at * 1000).toISOString())}</span>
             {' '}· {formatCountdown(job.next_run_at, now)}
           </p>
         ) : (
@@ -273,7 +301,7 @@ function BackupScheduleCard({
           size="sm"
           icon={<LuSave className="size-3.5" aria-hidden="true" />}
           loading={busy === 'save'}
-          disabled={!dirty || !intervalOk || !retentionOk || busy !== null}
+          disabled={!dirty || !intervalOk || !retentionOk || busy !== null || folderSaveBlocked}
           aria-label={`Save ${job.account_name} backup schedule`}
           onClick={() => void save()}
         >
@@ -383,39 +411,32 @@ export function ScheduledPlaylistBackups() {
         <div>
           <p className="text-sm font-medium text-text">Scheduled playlist archive</p>
           <p className="mt-0.5 text-xs leading-relaxed text-text-3">
-            Save fresh metadata for every playlist on a connected account alongside SongMirror's persistent app data.
-            Snapshots contain no credentials and stay available when their schedule is removed.
+            Save playlist names and track details automatically. Backups use SongMirror's app data folder by default,
+            or a folder you choose. Removing a schedule keeps its saved files.
           </p>
         </div>
       </div>
 
-      {error ? <p role="alert" className="rounded-control bg-danger-soft px-3 py-2 text-xs text-danger">Could not load backup schedules: {error}</p> : null}
-      {loading ? <p className="text-xs text-text-3">Loading backup schedules…</p> : null}
-      {(backups ?? []).map((job) => (
-        <BackupScheduleCard key={job.account_id} job={job} refresh={refresh} />
-      ))}
-
       {backups !== null ? (
         <div className="rounded-control border border-dashed border-border-strong p-3.5 sm:p-4">
           {available.length > 0 ? (
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div className="grid grid-cols-1 items-end gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
               <div className="min-w-0 flex-1">
                 <SelectField
                   label="Add a connected account"
-                  help="Each account gets its own schedule, storage, and run history."
                   options={available.map((account) => ({ value: account.id, label: account.name }))}
                   value={selectedAccount}
                   onChange={(event) => setAccountId(event.target.value)}
                 />
               </div>
               <Button
-                className="sm:mb-[1.625rem]"
-                size="sm"
+                className="h-11 md:h-[42px]"
                 loading={adding}
                 onClick={() => void addSchedule()}
               >
-                Add daily backup
+                Add backup
               </Button>
+              <p className="text-xs text-text-3 sm:col-span-2">Each account gets its own schedule and folder. New schedules start with daily backups.</p>
             </div>
           ) : (
             <p className="text-xs leading-relaxed text-text-3">
@@ -429,6 +450,11 @@ export function ScheduledPlaylistBackups() {
           {addError ? <p role="alert" className="mt-2 text-xs text-danger">{addError}</p> : null}
         </div>
       ) : null}
+      {error ? <p role="alert" className="rounded-control bg-danger-soft px-3 py-2 text-xs text-danger">Could not load backup schedules: {error}</p> : null}
+      {loading ? <p className="text-xs text-text-3">Loading backup schedules…</p> : null}
+      {(backups ?? []).map((job) => (
+        <BackupScheduleCard key={job.account_id} job={job} refresh={refresh} />
+      ))}
     </div>
   )
 }

--- a/frontend/src/components/sync/SyncJobCard.tsx
+++ b/frontend/src/components/sync/SyncJobCard.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { Spinner } from '@/components/ui/Spinner'
 import { Toggle } from '@/components/ui/Toggle'
 import { cn } from '@/lib/cn'
+import { describeInterval } from '@/lib/format'
 import { buildSyncSummaryRows } from '@/lib/syncSummary'
 import type { Account, SyncJob } from '@/types'
 
@@ -109,7 +110,7 @@ export function SyncJobCard({ job, peers, running, queued, paused, pending, onEd
           </div>
           <p className="mt-1 text-[13px] leading-relaxed text-text-2">{summary}</p>
           <p className="mt-1.5 font-mono text-[10.5px] tracking-wide text-text-3">
-            {job.enabled ? `every ${job.interval}` : 'manual only'}
+            {job.enabled ? `every ${describeInterval(job.interval)}` : 'manual only'}
           </p>
         </div>
         <Toggle

--- a/frontend/src/components/sync/SyncWizard.tsx
+++ b/frontend/src/components/sync/SyncWizard.tsx
@@ -3,9 +3,9 @@ import { LuArrowLeft, LuArrowRight, LuCheck, LuInfo } from 'react-icons/lu'
 
 import { api, errorMessage } from '@/api'
 import { Button } from '@/components/ui/Button'
+import { IntervalField } from '@/components/ui/IntervalField'
 import { Modal } from '@/components/ui/Modal'
 import { RadioCard } from '@/components/ui/RadioCard'
-import { SelectField } from '@/components/ui/SelectField'
 import { ServiceLogo } from '@/components/ui/ServiceLogo'
 import { SettingsGroup } from '@/components/ui/SettingsGroup'
 import { TextField } from '@/components/ui/TextField'
@@ -15,7 +15,7 @@ import { useSettings } from '@/hooks/useSettings'
 import { canSyncAccount } from '@/lib/accountCapabilities'
 import { cn } from '@/lib/cn'
 import { serviceLogoId, tagDot, tagText } from '@/lib/constants'
-import { isValidIntervalText, isValidPositiveInt } from '@/lib/format'
+import { intervalSeconds, isValidIntervalText, isValidPositiveInt } from '@/lib/format'
 import { nativeLikedTracksName, providerLikedTracksLabel } from '@/lib/likedTracks'
 import {
   authorityProvidersOf,
@@ -132,17 +132,6 @@ function normalizedLikedRoutes(
   }
   return normalized
 }
-
-const INTERVAL_PRESETS: Array<{ value: string; label: string }> = [
-  { value: '15m', label: 'Every 15 minutes' },
-  { value: '30m', label: 'Every 30 minutes' },
-  { value: '1h', label: 'Every hour' },
-  { value: '2h', label: 'Every 2 hours' },
-  { value: '3h', label: 'Every 3 hours' },
-  { value: '6h', label: 'Every 6 hours' },
-  { value: '12h', label: 'Every 12 hours' },
-  { value: '24h', label: 'Once a day' },
-]
 
 // The wizard's five steps, in order. `intro` is the one friendly sentence
 // shown above each step's fields; `label` is what the stepper shows.
@@ -552,7 +541,7 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
   }
 
   const nameValid = form.name.trim().length > 0
-  const intervalValid = isValidIntervalText(form.interval)
+  const intervalValid = isValidIntervalText(form.interval) && (intervalSeconds(form.interval) ?? 0) > 0
   const maxAddsValid = isValidPositiveInt(form.max_adds)
   const maxRemovalsValid = !form.mirror_removals || isValidPositiveInt(form.max_removals)
   const groupValid =
@@ -985,16 +974,12 @@ export function SyncWizard({ open, onClose, job, accounts, onSaved }: Props) {
                     : 'Paused, skipped by its schedule and by "Run all enabled". You can still sync it manually.'
                 }
               />
-              <SelectField
+              <IntervalField
                 label="Interval"
                 help="How often this sync runs automatically."
                 value={form.interval}
-                onChange={(e) => setField('interval', e.target.value)}
-                options={
-                  INTERVAL_PRESETS.some((o) => o.value === form.interval)
-                    ? INTERVAL_PRESETS
-                    : [{ value: form.interval, label: form.interval || '(unset)' }, ...INTERVAL_PRESETS]
-                }
+                onChange={(value) => setField('interval', value)}
+                error={intervalValid ? undefined : 'Enter a positive whole-number interval.'}
               />
             </>
           )}

--- a/frontend/src/components/ui/FolderField.tsx
+++ b/frontend/src/components/ui/FolderField.tsx
@@ -1,0 +1,68 @@
+import { useId, useRef, useState } from 'react'
+import { LuFolderOpen } from 'react-icons/lu'
+import useSWR from 'swr'
+
+import { api } from '@/api'
+import { FolderPicker } from './FolderPicker'
+import { displayFolderPath } from '@/lib/folderPaths'
+
+import { TextField } from './TextField'
+import { FIELD_INPUT_CLASSES } from './fieldStyles'
+
+export function FolderField({ label, value, onChange, defaultPath = '', help, disabled = false }: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  defaultPath?: string
+  help?: string
+  disabled?: boolean
+}) {
+  const id = useId()
+  const [editing, setEditing] = useState(false)
+  const [open, setOpen] = useState(false)
+  const trigger = useRef<HTMLElement | null>(null)
+  const { data: config } = useSWR('/api/folders/config', api.folderPickerConfig)
+
+  function displayPath(path: string) {
+    return displayFolderPath(path, config)
+  }
+
+  function choose() {
+    trigger.current = document.activeElement as HTMLElement
+    setOpen(true)
+  }
+
+  function close() {
+    setOpen(false)
+    trigger.current?.focus()
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1.5">
+      {editing ? (
+        <TextField label={label} value={displayPath(value)} disabled={disabled}
+          placeholder={displayPath(defaultPath) || 'Full folder path'} help={help}
+          onChange={(event) => onChange(event.target.value)} />
+      ) : (
+        <>
+          <label htmlFor={id} className="text-[12.5px] font-semibold text-text-2">{label}</label>
+          <button id={id} type="button" disabled={disabled} aria-describedby={`${id}-help`}
+            className={`${FIELD_INPUT_CLASSES} flex items-center gap-2 text-left`} onClick={() => void choose()}>
+            <LuFolderOpen className="size-4 shrink-0 text-accent" aria-hidden="true" />
+            <span className="min-w-0 flex-1 truncate">{displayPath(value || defaultPath) || 'Choose a folder…'}</span>
+          </button>
+          <p id={`${id}-help`} className="text-xs text-text-3">{help}</p>
+        </>
+      )}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs font-semibold text-accent">
+        <button type="button" className="min-h-8" onClick={choose} disabled={disabled}>Browse…</button>
+        <button type="button" className="min-h-8" onClick={() => setEditing(!editing)} disabled={disabled}>
+          {editing ? 'Use folder picker' : 'Enter path manually'}
+        </button>
+      </div>
+      {config?.scope === 'container' && <p className="text-xs text-text-3">Docker storage: use a shared folder's path. Other folders on your computer must be shared with SongMirror first.</p>}
+      {open && <FolderPicker title={`Choose ${label.toLowerCase()}`} initialPath={value || defaultPath}
+        onClose={close} onSelect={(path) => { onChange(path); close() }} />}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/FolderPicker.tsx
+++ b/frontend/src/components/ui/FolderPicker.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react'
+import { LuArrowLeft, LuArrowRight, LuArrowUp, LuChevronRight, LuFolder, LuFolderPlus, LuHardDrive, LuSearch } from 'react-icons/lu'
+import useSWR from 'swr'
+
+import { api, errorMessage } from '@/api'
+import { cn } from '@/lib/cn'
+import type { FolderListing } from '@/types'
+import { displayFolderPath } from '@/lib/folderPaths'
+import { Button } from './Button'
+import { Modal } from './Modal'
+import { FIELD_INPUT_CLASSES } from './fieldStyles'
+
+export function FolderPicker({ initialPath, title, onClose, onSelect }: {
+  initialPath: string; title: string; onClose: () => void; onSelect: (path: string) => void
+}) {
+  const { data: config } = useSWR('/api/folders/config', api.folderPickerConfig)
+  const [listing, setListing] = useState<FolderListing | null>(null)
+  const [address, setAddress] = useState(initialPath)
+  const [editingAddress, setEditingAddress] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [selected, setSelected] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [notice, setNotice] = useState('')
+  const [history, setHistory] = useState<string[]>([])
+  const [index, setIndex] = useState(-1)
+  const sequence = useRef<object>({})
+  const addressRef = useRef<HTMLInputElement>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
+
+  async function navigate(path: string, historyIndex?: number) {
+    if (busy) return
+    const request = {}
+    sequence.current = request
+    setBusy(true)
+    setError(null)
+    setSelected('')
+    setCreating(false)
+    setCreateError(null)
+    setNotice('')
+    try {
+      const next = await api.browseFolders(path)
+      if (request !== sequence.current) return
+      setListing(next)
+      setAddress(next.path)
+      setEditingAddress(false)
+      setFilter('')
+      if (historyIndex !== undefined) setIndex(historyIndex)
+      else {
+        setHistory((previous) => [...previous.slice(0, index + 1), next.path])
+        setIndex(index + 1)
+      }
+    } catch (err) {
+      if (request === sequence.current) setError(errorMessage(err))
+    } finally {
+      if (request === sequence.current) setBusy(false)
+    }
+  }
+
+  useEffect(() => {
+    void navigate(initialPath)
+    return () => { sequence.current = {} }
+    // Each opening mounts a new picker; navigation is deliberately user-driven.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => { if (editingAddress) addressRef.current?.focus() }, [editingAddress])
+  useEffect(() => { if (creating) nameRef.current?.focus() }, [creating])
+
+  const folders = listing?.directories.filter((item) => item.name.toLocaleLowerCase().includes(filter.toLocaleLowerCase())) ?? []
+  const destination = selected || listing?.path || ''
+  const show = (path: string) => displayFolderPath(path, config)
+  const container = config?.scope === 'container'
+
+  async function createFolder() {
+    if (!listing || !newName.trim() || busy) return
+    const request = sequence.current
+    setBusy(true)
+    setCreateError(null)
+    try {
+      const created = await api.createFolder(listing.path, newName)
+      if (request !== sequence.current) return
+      setCreating(false)
+      setNotice(`Created ${newName}. Select this folder to use it. Cancelling the picker will not delete it.`)
+      setNewName('')
+      setSelected('')
+      setFilter('')
+      setError(null)
+      try {
+        const next = await api.browseFolders(created.path)
+        if (request !== sequence.current) return
+        setListing(next)
+        setAddress(next.path)
+        setEditingAddress(false)
+        setHistory((previous) => [...previous.slice(0, index + 1), next.path])
+        setIndex(index + 1)
+      } catch (err) {
+        if (request === sequence.current) setError(`Folder created, but could not open it. ${errorMessage(err)}`)
+      }
+    } catch (err) { if (request === sequence.current) setCreateError(errorMessage(err)) }
+    finally { if (request === sequence.current) setBusy(false) }
+  }
+
+  async function confirm() {
+    if (!destination || busy || error) return
+    const request = sequence.current
+    setBusy(true)
+    try {
+      const verified = await api.browseFolders(destination)
+      if (request !== sequence.current) return
+      if (!verified.writable) throw new Error('SongMirror cannot save here. Choose a writable folder.')
+      onSelect(verified.path)
+    } catch (err) { if (request === sequence.current) setError(errorMessage(err)) }
+    finally { if (request === sequence.current) setBusy(false) }
+  }
+
+  return (
+    <Modal open onClose={onClose} title={title} widthClassName="max-w-3xl"
+      description="Choose where SongMirror saves files. Your current setting stays unchanged until you save."
+      footer={<>
+        <div className="min-w-0 flex-1 self-center text-xs text-text-3">{destination ? <span className="break-all">Selected: <span className="font-semibold text-text">{show(destination)}</span></span> : 'Choose a folder to continue.'}</div>
+        <Button variant="secondary" onClick={onClose}>Cancel</Button>
+        <Button onClick={() => void confirm()} disabled={busy || creating || !listing || !!error || (!selected && !listing.writable)}>Select folder</Button>
+      </>}>
+      <div onKeyDown={(event) => {
+        if (event.altKey && event.key === 'ArrowUp' && listing?.parent) { event.preventDefault(); void navigate(listing.parent) }
+        if ((event.ctrlKey || event.metaKey) && event.key === 'l') { event.preventDefault(); setEditingAddress(true) }
+      }}>
+        {container && <div role="note" className="mb-3 rounded-control border border-border bg-surface-2 px-3 py-2.5 text-xs leading-relaxed text-text-2">
+          <p className="font-semibold text-text">Docker storage, not your whole computer</p>
+          <p>Only folders shared with SongMirror are available here. Paste a container path such as /data, or a mapped computer path shown in this picker. Other Windows or macOS paths must be shared with the container first.</p>
+        </div>}
+        {config?.scope === 'computer' && <p className="mb-3 text-xs text-text-3">Folders are on the computer running SongMirror, which may be different from the device using this browser.</p>}
+        <div className="flex items-center gap-1.5 border-y border-border py-3">
+          {[
+            { label: 'Back', icon: LuArrowLeft, enabled: index > 0, action: () => navigate(history[index - 1], index - 1) },
+            { label: 'Forward', icon: LuArrowRight, enabled: index < history.length - 1, action: () => navigate(history[index + 1], index + 1) },
+            { label: 'Up one folder', icon: LuArrowUp, enabled: !!listing?.parent, action: () => navigate(listing!.parent!) },
+          ].map(({ label, icon: Icon, enabled, action }) => <button key={label} type="button" aria-label={label} title={label}
+            disabled={!enabled || busy} onClick={() => void action()} className="flex size-11 shrink-0 items-center justify-center rounded-control text-text-2 hover:bg-surface-2 disabled:opacity-30">
+            <Icon className="size-4" aria-hidden="true" />
+          </button>)}
+          <div className="min-w-0 flex-1">
+            {editingAddress || !listing ? <div className="flex gap-1">
+              <input ref={addressRef} aria-label="Folder address" value={show(address)} className={FIELD_INPUT_CLASSES}
+                placeholder={container ? 'Container path or mapped computer path' : 'Full path on the SongMirror computer'}
+                onChange={(event) => setAddress(event.target.value)} onKeyDown={(event) => {
+                  if (event.key === 'Enter') { event.preventDefault(); void navigate(address) }
+                  if (event.key === 'Escape' && listing) { event.preventDefault(); setAddress(listing.path); setEditingAddress(false) }
+                }} />
+              <Button variant="secondary" disabled={busy} onClick={() => void navigate(address)}>Go</Button>
+            </div> : <nav aria-label="Folder breadcrumbs" className="flex h-11 items-center overflow-x-auto rounded-control border border-border-strong bg-field px-1">
+              {listing.breadcrumbs.map((item, i) => <span className="flex shrink-0 items-center" key={item.path}>
+                {i > 0 && <LuChevronRight className="size-3 text-text-3" aria-hidden="true" />}
+                <button type="button" disabled={busy} onClick={() => void navigate(item.path)} title={show(item.path)}
+                  className="rounded-control px-2 py-2 text-sm text-text-2 hover:bg-surface-2">{config?.mounts.some((mount) => mount.server === item.path) ? show(item.path) : item.name}</button>
+              </span>)}
+            </nav>}
+          </div>
+        </div>
+        {container && listing && <p className="mt-2 break-all text-xs text-text-3">Container path: <span className="font-mono">{listing.path}</span>{show(listing.path) !== listing.path ? ` · Computer path: ${show(listing.path)}` : ''}</p>}
+        <div className="my-2 flex flex-wrap items-center justify-between gap-2">
+          <Button size="sm" variant="secondary" icon={<LuFolderPlus className="size-4" aria-hidden="true" />}
+            disabled={busy || !listing?.writable || !!error || creating} onClick={() => { setCreating(true); setNewName(''); setCreateError(null) }}>New folder</Button>
+          <button type="button" disabled={busy} className="min-h-8 text-xs font-semibold text-accent" onClick={() => setEditingAddress(!editingAddress)}>{editingAddress ? 'Show breadcrumbs' : 'Enter a folder path'}</button>
+        </div>
+        {creating && <div className="mb-3 rounded-control border border-border bg-surface-2 p-3">
+          <label htmlFor="new-folder-name" className="text-xs font-semibold text-text">Folder name</label>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <input id="new-folder-name" ref={nameRef} value={newName} maxLength={255} disabled={busy} placeholder="e.g. Playlist backups"
+              className={cn(FIELD_INPUT_CLASSES, 'min-w-0 flex-1 basis-40')} aria-describedby="new-folder-help"
+              onChange={(event) => { setNewName(event.target.value); setCreateError(null) }} onKeyDown={(event) => {
+                if (event.key === 'Enter') { event.preventDefault(); void createFolder() }
+                if (event.key === 'Escape') { event.preventDefault(); if (!busy) setCreating(false) }
+              }} />
+            <Button disabled={busy || !newName.trim()} onClick={() => void createFolder()}>Create folder</Button>
+            <Button variant="secondary" disabled={busy} onClick={() => setCreating(false)}>Cancel creation</Button>
+          </div>
+          <p id="new-folder-help" className="mt-2 break-all text-xs text-text-3">Create inside {show(listing?.path || '')}. Enter a name, not a full path.</p>
+          {createError && <p role="alert" className="mt-2 text-xs text-danger">{createError}</p>}
+        </div>}
+        {notice && <p role="status" className="mb-3 text-xs text-success">{notice}</p>}
+        <div className="grid min-h-64 grid-cols-1 overflow-hidden rounded-control border border-border sm:grid-cols-[160px_minmax(0,1fr)]">
+          <aside aria-label="Folder locations" className="border-b border-border bg-surface-2 p-2 sm:border-b-0 sm:border-r">
+            <p className="px-2 py-2 font-mono text-[10px] font-semibold uppercase tracking-wide text-text-3">Locations</p>
+            <div className="flex flex-wrap gap-1 sm:flex-col">
+              {config?.locations.map((item) => <button key={item.path} type="button" disabled={busy} title={show(item.path)}
+                onClick={() => void navigate(item.path)} className={cn('flex min-h-11 items-center gap-2 rounded-control px-2 text-left text-xs', listing?.path === item.path ? 'bg-accent-soft font-semibold text-accent' : 'text-text-2 hover:bg-surface')}>
+                <LuHardDrive className="size-4 shrink-0" aria-hidden="true" />{item.name}
+              </button>)}
+            </div>
+          </aside>
+          <div className="min-w-0 bg-field">
+            <div className="relative m-3">
+              <LuSearch className="pointer-events-none absolute left-3 top-3.5 size-4 text-text-3" aria-hidden="true" />
+              <input aria-label="Search folders" placeholder="Search this folder" value={filter} disabled={busy} onChange={(event) => { setFilter(event.target.value); setSelected('') }} className={cn(FIELD_INPUT_CLASSES, 'pl-9')} />
+            </div>
+            <div className="flex justify-between border-y border-border px-4 py-2 text-xs text-text-3"><span>Name</span><span>Folder</span></div>
+            <div aria-label="Folders" aria-busy={busy} className="h-60 overflow-y-auto p-1">
+              {busy ? <p role="status" className="p-4 text-sm text-text-3">Opening folder…</p> : error ? <p role="alert" className="p-4 text-sm text-danger">{error}</p> : folders.length ? folders.map((item) => (
+                <div key={item.path} className={cn('flex items-center rounded-control', selected === item.path ? 'bg-accent-soft' : 'hover:bg-surface-2')}>
+                  <button type="button" aria-pressed={selected === item.path} className="flex min-h-11 min-w-0 flex-1 items-center gap-3 px-3 text-left text-sm text-text"
+                    onClick={() => setSelected(item.path)} onDoubleClick={() => void navigate(item.path)} onKeyDown={(event) => {
+                      if (event.key === 'Enter') { event.preventDefault(); void navigate(item.path) }
+                    }}>
+                    <LuFolder className="size-5 shrink-0 text-accent" aria-hidden="true" /><span className="truncate">{item.name}</span>
+                  </button>
+                  <button type="button" aria-label={`Open ${item.name}`} title={`Open ${item.name}`} onClick={() => void navigate(item.path)} className="flex size-11 shrink-0 items-center justify-center text-text-3 hover:text-accent"><LuChevronRight className="size-4" aria-hidden="true" /></button>
+                </div>
+              )) : <p className="p-4 text-sm text-text-3">{filter ? 'No matching folders. Try another name.' : 'No subfolders. You can select this folder.'}</p>}
+            </div>
+            <p className="border-t border-border px-4 py-2 text-xs text-text-3">{!busy && !error ? `${folders.length} folders · ` : ''}Double-click or use the arrow to open.</p>
+          </div>
+        </div>
+        <p className="mt-3 text-xs text-text-3">Only folders accessible to SongMirror are shown. In Docker, other computer folders must be shared with the container first.</p>
+        {listing && !listing.writable && !error && <p role="status" className="mt-2 text-xs text-warning">This folder is read-only. Open or select a writable subfolder.</p>}
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/ui/IntervalField.tsx
+++ b/frontend/src/components/ui/IntervalField.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { intervalSeconds } from '@/lib/format'
+
+import { SelectField } from './SelectField'
+import { TextField } from './TextField'
+
+const PRESETS = [
+  { value: '15m', label: 'Every 15 minutes' },
+  { value: '30m', label: 'Every 30 minutes' },
+  { value: '1h', label: 'Every hour' },
+  { value: '2h', label: 'Every 2 hours' },
+  { value: '3h', label: 'Every 3 hours' },
+  { value: '6h', label: 'Every 6 hours' },
+  { value: '12h', label: 'Every 12 hours' },
+  { value: '24h', label: 'Daily' },
+  { value: '168h', label: 'Weekly' },
+  { value: '336h', label: 'Every 2 weeks' },
+  { value: '720h', label: 'Every 30 days' },
+  { value: 'custom', label: 'Custom interval…' },
+]
+const UNITS = [
+  { value: 'm', label: 'Minutes', seconds: 60 },
+  { value: 'h', label: 'Hours', seconds: 3600 },
+  { value: 'd', label: 'Days', seconds: 86400 },
+  { value: 'w', label: 'Weeks', seconds: 604800 },
+  { value: 's', label: 'Seconds', seconds: 1 },
+]
+
+function unitFor(value: string): string {
+  const seconds = intervalSeconds(value) ?? 0
+  return [...UNITS].sort((a, b) => b.seconds - a.seconds).find((item) => seconds > 0 && seconds % item.seconds === 0)?.value ?? 'h'
+}
+
+/** Keeps the engine's interval representation while showing numbers and units. */
+export function IntervalField({ label = 'Interval', value, onChange, error, help }: {
+  label?: string
+  value: string
+  onChange: (value: string) => void
+  error?: string
+  help?: string
+}) {
+  const [custom, setCustom] = useState(false)
+  const [unit, setUnit] = useState(() => unitFor(value))
+  const isCustom = custom || !PRESETS.some((option) => option.value === value)
+  const multiplier = UNITS.find((item) => item.value === unit)!.seconds
+  const seconds = intervalSeconds(value)
+  const amount = seconds === null ? '' : seconds / multiplier
+
+  function changeAmount(next: string, nextUnit = unit) {
+    const factor = UNITS.find((item) => item.value === nextUnit)!.seconds
+    onChange(/^\d+$/.test(next) ? `${Number(next) * factor}s` : '')
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <SelectField label={label} help={help} error={!isCustom ? error : undefined}
+        options={PRESETS} value={isCustom ? 'custom' : value}
+        onChange={(event) => {
+          setCustom(event.target.value === 'custom')
+          if (event.target.value !== 'custom') {
+            setUnit(unitFor(event.target.value))
+            onChange(event.target.value)
+          }
+        }} />
+      {isCustom && (
+        <div className="grid grid-cols-2 gap-2">
+          <TextField label={`${label}: every`} type="number" min={1} step={1}
+            value={amount} error={error} onChange={(event) => changeAmount(event.target.value)} />
+          <SelectField label={`${label}: unit`} value={unit} options={UNITS}
+            onChange={(event) => {
+              setUnit(event.target.value)
+              changeAmount(String(amount), event.target.value)
+            }} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/folderPaths.ts
+++ b/frontend/src/lib/folderPaths.ts
@@ -1,0 +1,9 @@
+import type { FolderPickerConfig } from '@/types'
+
+export function displayFolderPath(path: string, config?: FolderPickerConfig) {
+  const mount = [...(config?.mounts ?? [])].sort((a, b) => b.server.length - a.server.length)
+    .find((item) => path === item.server || path.startsWith(`${item.server}/`))
+  if (!mount) return path
+  const suffix = path.slice(mount.server.length)
+  return mount.host.replace(/[\\/]$/, '') + (mount.host.includes('\\') ? suffix.replaceAll('/', '\\') : suffix)
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -74,6 +74,25 @@ export function isValidIntervalText(value: string): boolean {
   return /^\d+\s*[smh]?$/i.test(value.trim())
 }
 
+export function intervalSeconds(value: string): number | null {
+  const match = value.trim().match(/^(\d+)\s*([smh]?)$/i)
+  if (!match) return null
+  const seconds = Number(match[1]) * (match[2].toLowerCase() === 'h' ? 3600 : match[2].toLowerCase() === 'm' ? 60 : 1)
+  return Number.isSafeInteger(seconds) ? seconds : null
+}
+
+export function describeInterval(value: string): string {
+  const seconds = intervalSeconds(value)
+  if (!seconds) return value
+  for (const [unit, size] of [['week', 604800], ['day', 86400], ['hour', 3600], ['minute', 60], ['second', 1]] as const) {
+    if (seconds % size === 0) {
+      const amount = seconds / size
+      return `${amount} ${unit}${amount === 1 ? '' : 's'}`
+    }
+  }
+  return value
+}
+
 /** Matches the backend's `--max-adds` validation (config.py: must be >= 1). */
 export function isValidPositiveInt(value: string): boolean {
   return /^\d+$/.test(value.trim()) && Number(value) >= 1

--- a/frontend/src/lib/syncSummary.ts
+++ b/frontend/src/lib/syncSummary.ts
@@ -1,4 +1,5 @@
 import { providerLikedTracksLabel } from '@/lib/likedTracks'
+import { describeInterval } from '@/lib/format'
 import type { Account, SyncJob } from '@/types'
 
 export function parseCsv(value: string | null | undefined): string[] {
@@ -61,7 +62,7 @@ export interface SyncSummaryRow {
 export function buildSyncSummaryRows(job: SyncJob, peers: Account[], downloadDir?: string): SyncSummaryRow[] {
   const rows: SyncSummaryRow[] = []
 
-  rows.push({ label: 'Schedule', value: job.enabled ? `Every ${job.interval || '?'}` : 'Manual' })
+  rows.push({ label: 'Schedule', value: job.enabled ? `Every ${describeInterval(job.interval || '?')}` : 'Manual' })
 
   if (job.mode === 'merge') {
     const providerName = (id: string) => peers.find((peer) => peer.id === id)?.name ?? id

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -46,7 +46,7 @@ export default function Accounts() {
         </p>
       </div>
 
-      <Card className="flex flex-col gap-3 p-4 sm:flex-row sm:items-end">
+      <Card className="grid grid-cols-1 items-end gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto]">
         <SelectField
           label="Provider"
           value={provider}
@@ -55,14 +55,15 @@ export default function Accounts() {
         />
         <TextField
           label="New profile label"
-          help="Use a household member or purpose, such as Alex or Work."
+          aria-describedby="profile-label-help"
           placeholder="e.g. Alex"
           value={label}
           onChange={(event) => setLabel(event.target.value)}
         />
-        <Button loading={adding} onClick={() => void addProfile()}>
+        <Button className="h-11 md:h-[42px]" loading={adding} onClick={() => void addProfile()}>
           Add profile
         </Button>
+        <p id="profile-label-help" className="text-xs text-text-3 sm:col-span-3">Use a household member or purpose, such as Alex or Work.</p>
       </Card>
       {addError && <p className="rounded-control bg-danger-soft px-3 py-2 text-sm text-danger">Could not add profile: {addError}</p>}
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { LuArrowRight } from 'react-icons/lu'
 
 import { api, errorMessage } from '@/api'
 import { ThemeToggle } from '@/components/layout/ThemeToggle'
 import { ScheduledPlaylistBackups } from '@/components/settings/ScheduledPlaylistBackups'
 import { Button } from '@/components/ui/Button'
+import { FolderField } from '@/components/ui/FolderField'
 import { SelectField } from '@/components/ui/SelectField'
 import { LoadingStatus, Skeleton } from '@/components/ui/Skeleton'
 import { SettingsGroup } from '@/components/ui/SettingsGroup'
@@ -33,10 +34,12 @@ function sameSettings(left: SettingsMap, right: SettingsMap): boolean {
 }
 
 function settingsForm(settings: SettingsMap): SettingsMap {
-  return { ...DEFAULTS, ...settings }
+  return Object.fromEntries(Object.entries(DEFAULTS).map(([key, fallback]) => [key, settings[key] ?? fallback]))
 }
 
 export default function Settings() {
+  const [params] = useSearchParams()
+  const section = ['backups', 'downloads'].includes(params.get('section') ?? '') ? params.get('section')! : 'general'
   const { settings, loading, error, refresh } = useSettings()
   const initialServerForm = settings ? settingsForm(settings) : null
   const [form, setForm] = useState<SettingsMap | null>(() => initialServerForm)
@@ -66,18 +69,26 @@ export default function Settings() {
   }
 
   function discard() {
-    if (settings) setForm({ ...DEFAULTS, ...settings })
+    if (settings) setForm((current) => current && {
+      ...current, ...Object.fromEntries(sectionKeys.map((key) => [key, settingsForm(settings)[key]])),
+    })
     setSaveError(null)
   }
 
-  const dirty = Boolean(form && settings && !sameSettings(settingsForm(settings), form))
+  const sectionKeys = section === 'downloads' ? ['DOWNLOAD_DIR', 'LOCAL_MIRROR_FORMAT'] : ['DISPLAY_NAME']
+  const dirty = Boolean(form && settings && sectionKeys.some((key) => form[key] !== settingsForm(settings)[key]))
 
   async function save() {
     if (!form) return
     setSaving(true)
     setSaveError(null)
     try {
-      await api.saveSettings(form)
+      await api.saveSettings(Object.fromEntries(sectionKeys.map((key) => [key, form[key]])))
+      const saved = settingsForm(await api.getSettings())
+      setForm((current) => current && {
+        ...current,
+        ...Object.fromEntries(sectionKeys.filter((key) => current[key] === form[key]).map((key) => [key, saved[key]])),
+      })
       setJustSaved(true)
       await refresh()
     } catch (err) {
@@ -105,18 +116,33 @@ export default function Settings() {
 
       {error && <p className="rounded-control bg-danger-soft px-3 py-2 text-sm text-danger">Could not load settings: {error}</p>}
 
+      <nav aria-label="Settings sections" className="flex flex-wrap gap-1 rounded-card border border-border bg-surface p-1.5">
+        {[['general', 'General'], ['backups', 'Playlist backups'], ['downloads', 'Downloads & Jellyfin']].map(([key, title]) => (
+          <Link key={key} to={key === 'general' ? '/settings' : `/settings?section=${key}`}
+            aria-current={section === key ? 'page' : undefined}
+            className={cn('flex min-h-11 items-center rounded-control px-4 text-sm font-semibold',
+              section === key ? 'bg-accent-soft text-accent' : 'text-text-3 hover:bg-surface-2 hover:text-text')}>
+            {title}
+          </Link>
+        ))}
+      </nav>
+
+      {section === 'general' && (
       <SettingsGroup label="APPEARANCE">
         <ThemeToggle />
         <p className="text-xs leading-relaxed text-text-3">
           Applies instantly and is remembered on this device, separate from your account settings.
         </p>
       </SettingsGroup>
+      )}
 
+      {section === 'backups' && (
       <SettingsGroup label="PLAYLIST ARCHIVE">
         <ScheduledPlaylistBackups />
       </SettingsGroup>
+      )}
 
-      {loading && !form ? (
+      {section !== 'backups' && (loading && !form ? (
         <LoadingStatus label="Loading settings…">
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Skeleton className="h-32 w-full rounded-card" />
@@ -131,7 +157,8 @@ export default function Settings() {
             void save()
           }}
         >
-          <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
+          <div className="grid grid-cols-1 items-start gap-4">
+            {section === 'general' && (
             <SettingsGroup label="PROFILE">
               <TextField
                 label="Display name"
@@ -141,19 +168,20 @@ export default function Settings() {
                 onChange={(e) => setField('DISPLAY_NAME', e.target.value)}
               />
             </SettingsGroup>
+            )}
 
+            {section === 'downloads' && (
             <SettingsGroup label="DOWNLOAD MIRROR">
               <p className="text-xs leading-relaxed text-text-3">
                 Optional: where offline audio copies land for any sync that opts in ("Download this sync's
                 playlists", on the Sync tab).
               </p>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <TextField
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+                <FolderField
                   label="Download folder"
-                  help="Leave empty to disable local downloads for every sync."
-                  placeholder="e.g. /music or D:\Music"
+                  help="Use a folder your Jellyfin music library can access. Enter an empty path to disable downloads."
                   value={form.DOWNLOAD_DIR ?? ''}
-                  onChange={(e) => setField('DOWNLOAD_DIR', e.target.value)}
+                  onChange={(value) => setField('DOWNLOAD_DIR', value)}
                 />
                 <SelectField
                   label="Audio format"
@@ -163,10 +191,12 @@ export default function Settings() {
                   onChange={(e) => setField('LOCAL_MIRROR_FORMAT', e.target.value)}
                 />
               </div>
+              <p className="text-xs text-text-3">Downloads follow each sync's schedule. Choose its frequency on the Sync tab.</p>
             </SettingsGroup>
+            )}
           </div>
 
-          <div className="sticky bottom-0 z-10 flex flex-wrap items-center gap-3 rounded-card border border-border bg-surface p-3.5 shadow-lg sm:p-4">
+          <div className="flex flex-wrap items-center gap-3 rounded-card border border-border bg-surface p-3.5 sm:p-4">
             <span
               className={cn('size-2 shrink-0 rounded-full', dirty ? 'bg-warning' : 'bg-success')}
               aria-hidden="true"
@@ -185,7 +215,7 @@ export default function Settings() {
             </div>
           </div>
         </form>
-      ) : null}
+      ) : null)}
     </div>
   )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -438,6 +438,8 @@ export interface PlaylistBackupJob {
   next_run_at: number | null
   snapshot_count: number
   storage_path: string
+  storage_dir: string
+  default_storage_dir: string
   last_success: PlaylistBackupSuccess | null
   last_failure: PlaylistBackupFailure | null
 }
@@ -447,6 +449,21 @@ export interface PlaylistBackupUpdate {
   interval?: string
   format?: PlaylistBackupFormat
   retention?: number
+  storage_dir?: string
+}
+
+export interface FolderPickerConfig {
+  scope?: 'container' | 'computer'
+  locations: Array<{ name: string; path: string }>
+  mounts: Array<{ host: string; server: string }>
+}
+
+export interface FolderListing {
+  path: string
+  parent: string | null
+  breadcrumbs: Array<{ name: string; path: string }>
+  directories: Array<{ name: string; path: string }>
+  writable: boolean
 }
 
 export interface QueueResponse {

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -1678,6 +1678,12 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 if not equivalent:
                     add_blockers.add("a resolved addition collided with a different current track")
                     chronology_collision = True
+                    deferred += 1
+                    log_warn(
+                        f"{p.name}/{name}: deferring {norm['name']} - {norm['artist']}: "
+                        "its catalog match belongs to a different current track",
+                        tag=p.tag,
+                    )
                 else:
                     current_candidates_by_cid[cid] = [
                         (
@@ -1743,6 +1749,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 claimed_positions.add(candidate[1][0])
             else:
                 chronology_collision = True
+                deferred += 1
                 add_blockers.add("one current occurrence matched multiple desired tracks")
         favorite_check = getattr(p, "is_favorite_tracks_resource", None)
         resource = playlists[p.source]
@@ -1753,33 +1760,29 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         can_replay = callable(getattr(p, "replay_chronology", None)) and not is_favorite_resource
         replay_write_cost = getattr(p, "chronology_replay_write_cost", len)
         if chronology_collision and additions:
-            # A provider returned an id belonging to a demonstrably different
-            # current row. Its place in the desired chronology is ambiguous, so
-            # appending around it would recreate the ordering bug this repair is
-            # designed to prevent. Hold the batch for manual/cache correction.
-            cap_deferred = len(additions)
-            deferred += cap_deferred
-            full_write_cost = len(additions)
-            additions, chronology_replay = [], []
+            # Only the ambiguous entries are blocked. Replaying existing rows
+            # would rely on their disputed identities, but independently resolved
+            # additions can safely append in source order. A later pass can
+            # recover older gaps once the conflicting matches are corrected.
             log_warn(
-                f"{p.name}/{name}: deferring {cap_deferred} addition(s) because a resolved "
-                "catalog id collides with a different current track",
+                f"{p.name}/{name}: appending valid additions without reordering existing "
+                "tracks while conflicting matches are held",
                 tag=p.tag,
             )
-        else:
-            additions, chronology_replay, cap_deferred, full_write_cost = _fit_chronology_writes(
-                ordered_desired,
-                current_by_cid,
-                additions,
-                lambda item: item[0],
-                max_adds,
-                addition_target_id=lambda item: item[1],
-                replay_write_cost=replay_write_cost,
-                can_replay=can_replay,
-            )
+        can_replay = can_replay and not chronology_collision
+        additions, chronology_replay, cap_deferred, full_write_cost = _fit_chronology_writes(
+            ordered_desired,
+            current_by_cid,
+            additions,
+            lambda item: item[0],
+            max_adds,
+            addition_target_id=lambda item: item[1],
+            replay_write_cost=replay_write_cost,
+            can_replay=can_replay,
+        )
         chronology_replayed = sum(1 for _target_id, original in chronology_replay
                                   if original is not None)
-        if cap_deferred and not chronology_collision:
+        if cap_deferred:
             deferred += cap_deferred
             if full_write_cost > max_adds and can_replay:
                 log_warn(

--- a/songmirror/services/folders.py
+++ b/songmirror/services/folders.py
@@ -1,0 +1,116 @@
+"""Directory selection for files written by the SongMirror server."""
+
+import os
+import re
+from pathlib import Path, PurePosixPath, PureWindowsPath
+import string
+
+
+def writable_directory(value):
+    if not isinstance(value, str) or not value.strip() or "\0" in value:
+        raise ValueError("Enter a folder path on the computer running SongMirror.")
+    path = Path(value.strip()).expanduser()
+    if not path.is_absolute():
+        raise ValueError("Use a full folder path on the computer running SongMirror.")
+    if not path.is_dir():
+        raise ValueError("Folder not found. Choose an existing folder accessible to SongMirror.")
+    if not os.access(path, os.W_OK | os.X_OK):
+        raise ValueError("SongMirror cannot write to this folder. Choose another folder or update its permissions.")
+    return path.resolve()
+
+
+def download_directory(settings):
+    configured = settings.get("DOWNLOAD_DIR", "") or ""
+    mounted = os.getenv("SONGMIRROR_DOWNLOAD_DIR", "")
+    # Explicit choices made through the folder UI take precedence, including
+    # disabling downloads. Older configs may contain a host-only Windows path.
+    if settings.get("DOWNLOAD_DIR_CONFIRMED") == "1":
+        return configured
+    if mounted:
+        return mounted
+    return configured or os.getenv("DOWNLOAD_DIR", "")
+
+
+class FolderBrowser:
+    """Browse directories available to the server, without reading file contents."""
+
+    def __init__(self, settings):
+        self.settings = settings
+
+    def config(self):
+        container = Path('/.dockerenv').is_file()
+        host = os.getenv("SONGMIRROR_HOST_DOWNLOAD_DIR", "")
+        server = os.getenv("SONGMIRROR_DOWNLOAD_DIR", "")
+        mounts = []
+        if host and server and (PureWindowsPath(host).is_absolute() or PurePosixPath(host).is_absolute()):
+            mounts.append({"host": host, "server": server})
+        locations = [{"name": "App data", "path": str(Path(self.settings.data_dir).resolve())}]
+        music = download_directory(self.settings)
+        if music and Path(music).is_dir():
+            locations.insert(0, {"name": "Music downloads", "path": str(Path(music).resolve())})
+        if os.name == "nt":
+            locations.extend({"name": f"{drive}: drive", "path": f"{drive}:\\"}
+                             for drive in string.ascii_uppercase if Path(f"{drive}:\\").is_dir())
+        else:
+            locations.append({"name": "Container filesystem" if container else "Server filesystem", "path": "/"})
+        return {"mounts": mounts, "locations": locations,
+                "scope": "container" if container else "computer"}
+
+    def server_path(self, value):
+        if not isinstance(value, str):
+            return value
+        for mount in self.config()["mounts"]:
+            path_type = PureWindowsPath if PureWindowsPath(mount["host"]).drive else PurePosixPath
+            try:
+                relative = path_type(value).relative_to(mount["host"])
+            except ValueError:
+                continue
+            if ".." in relative.parts:
+                raise ValueError("Folder must stay within its shared location.")
+            return str(PurePosixPath(mount["server"]).joinpath(*relative.parts))
+        if os.name != 'nt' and PureWindowsPath(value).is_absolute():
+            raise ValueError('This Windows folder is not shared with SongMirror. Choose a listed location, or share the folder with the Docker container first.')
+        return value
+
+    def browse(self, value=""):
+        value = self.server_path(value or str(self.settings.data_dir))
+        if not isinstance(value, str) or "\0" in value or len(value) > 4096:
+            raise ValueError("Enter a valid folder path.")
+        path = Path(value).expanduser()
+        if not path.is_absolute():
+            raise ValueError("Enter a full folder path.")
+        path = path.resolve()
+        if not path.is_dir():
+            raise ValueError("Folder not found. Choose a location or enter another path.")
+        directories = []
+        try:
+            for child in path.iterdir():
+                try:
+                    if child.is_dir() and not child.name.startswith('.'):
+                        directories.append({"name": child.name, "path": str(child)})
+                except OSError:
+                    continue
+        except PermissionError as exc:
+            raise ValueError("SongMirror cannot open this folder. Choose another location or update its permissions.") from exc
+        directories.sort(key=lambda child: (child["name"].casefold(), child["name"]))
+        ancestors = list(reversed(path.parents)) + [path]
+        return {"path": str(path), "parent": str(path.parent) if path.parent != path else None,
+                "breadcrumbs": [{"name": item.name or str(item), "path": str(item)} for item in ancestors],
+                "directories": directories, "writable": os.access(path, os.W_OK | os.X_OK)}
+
+    def create(self, parent, name):
+        # Accept one portable folder name, never a path or a Windows device.
+        if (not isinstance(name, str) or not name or len(name) > 255
+                or name != name.strip() or name.endswith('.') or name in ('.', '..')
+                or any(ord(char) < 32 or char in '<>:"/\\|?*' for char in name)
+                or re.match(r'^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.|$)', name, re.I)):
+            raise ValueError('Enter a folder name without path separators, reserved characters, or trailing dots or spaces.')
+        directory = writable_directory(self.server_path(parent))
+        child = directory / name
+        try:
+            child.mkdir()
+        except FileExistsError as exc:
+            raise ValueError('A file or folder with that name already exists. Choose another name.') from exc
+        except OSError as exc:
+            raise ValueError('SongMirror could not create this folder. Check permissions or choose another name or location.') from exc
+        return {"path": str(child)}

--- a/songmirror/services/playlist_backups.py
+++ b/songmirror/services/playlist_backups.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from ..engine import logs
 from ..engine.config import parse_interval
+from .folders import writable_directory
 from .playlists import PlaylistService, provider_label
 
 
@@ -92,6 +93,7 @@ class PlaylistBackupJob:
     interval: str = DEFAULT_BACKUP_INTERVAL
     format: str = DEFAULT_BACKUP_FORMAT
     retention: int = DEFAULT_BACKUP_RETENTION
+    storage_dir: str = ""
 
 
 def validate_backup_job(job):
@@ -99,6 +101,11 @@ def validate_backup_job(job):
     job.account_id = str(job.account_id or "").strip().casefold()
     job.interval = str(job.interval or "").strip().casefold()
     job.format = str(job.format or "").strip().casefold()
+    if not isinstance(job.storage_dir, str):
+        raise ValueError("backup folder must be a path")
+    job.storage_dir = job.storage_dir.strip()
+    if job.storage_dir and ("\0" in job.storage_dir or not Path(job.storage_dir).expanduser().is_absolute()):
+        raise ValueError("Use a full backup folder path on the computer running SongMirror.")
     if not re.fullmatch(r"[a-z0-9_-]+", job.account_id):
         raise ValueError("account is required")
     if type(job.enabled) is not bool:
@@ -146,8 +153,17 @@ class PlaylistBackupStore:
     def snapshots_dir(self):
         return self._snapshots_dir
 
-    def account_dir(self, account_id):
-        return self._snapshots_dir / self._account(account_id)
+    def storage_root(self, account_id, storage_dir=None):
+        if storage_dir is None:
+            job = self.get(account_id)
+            storage_dir = job.storage_dir if job else ""
+        return Path(storage_dir).expanduser() if storage_dir else self._snapshots_dir
+
+    def account_dir(self, account_id, storage_dir=None):
+        account_id = self._account(account_id)
+        if not re.fullmatch(r"[a-z0-9_-]+", account_id):
+            raise ValueError("invalid backup account")
+        return self.storage_root(account_id, storage_dir) / account_id
 
     @staticmethod
     def _read_json(path, default):
@@ -277,9 +293,11 @@ class PlaylistBackupStore:
     def record_failure(self, account_id, value):
         self._record(account_id, "last_failure", value)
 
-    def snapshots(self, account_id):
+    def snapshots(self, account_id, storage_dir=None):
         account_id = self._account(account_id)
-        directory = self.account_dir(account_id)
+        directory = self.account_dir(account_id, storage_dir)
+        if directory.is_symlink():
+            return []
         try:
             candidates = [
                 path for path in directory.iterdir()
@@ -299,16 +317,21 @@ class PlaylistBackupStore:
 
         return sorted(candidates, key=sort_key, reverse=True)
 
-    def write_snapshot(self, account_id, export, retention):
+    def write_snapshot(self, account_id, export, retention, storage_dir=None):
         account_id = self._account(account_id)
-        directory = self.account_dir(account_id)
+        root = self.storage_root(account_id, storage_dir)
+        if root != self._snapshots_dir:
+            writable_directory(str(root))
+        directory = self.account_dir(account_id, storage_dir)
         directory.mkdir(parents=True, exist_ok=True)
         if (
             directory.is_symlink()
-            or directory.resolve().parent != self._snapshots_dir.resolve()
+            or directory.resolve().parent != root.resolve()
         ):
-            raise ValueError("playlist backup directory escapes application data")
-        for private_directory in (self._snapshots_dir, directory):
+            raise ValueError("playlist backup directory escapes the selected folder")
+        # Never change permissions on a user-selected parent folder.
+        private_directories = (root, directory) if root == self._snapshots_dir else (directory,)
+        for private_directory in private_directories:
             try:
                 os.chmod(private_directory, 0o700)
             except OSError:
@@ -359,7 +382,7 @@ class PlaylistBackupStore:
 
         removed = 0
         if retention > 0:
-            for stale in self.snapshots(account_id)[retention:]:
+            for stale in self.snapshots(account_id, storage_dir)[retention:]:
                 stale.unlink()
                 removed += 1
         return destination, removed
@@ -523,6 +546,7 @@ class PlaylistBackupService:
                 account_id,
                 export,
                 job.retention,
+                job.storage_dir,
             )
             success = {
                 "at": _utc_timestamp(),
@@ -569,6 +593,7 @@ class PlaylistBackupService:
             "next_run_at": self._next_run.get(account_id) if job.enabled else None,
             "snapshot_count": len(self.store.snapshots(account_id)),
             "storage_path": str(self.store.account_dir(account_id).resolve()),
+            "default_storage_dir": str(self.store.snapshots_dir.resolve()),
             "last_success": history.get("last_success"),
             "last_failure": history.get("last_failure"),
         }

--- a/songmirror/services/sync_service.py
+++ b/songmirror/services/sync_service.py
@@ -23,6 +23,7 @@ from ..engine import logs
 from ..engine.config import DEFAULT_INTERVAL, parse_args, parse_interval
 from ..engine.runner import run_pass
 from .syncs import SyncStore
+from .folders import download_directory
 
 
 async def _run_pass_async(opts, should_continue=None):
@@ -76,13 +77,9 @@ class SyncService:
         opts.max_adds = job.max_adds
         opts.max_removals = job.max_removals
         opts.apply_large_removals = job.apply_large_removals
-        # SONGMIRROR_DOWNLOAD_DIR (a container-internal bind-mount path set by
-        # docker-compose) wins over the UI-saved DOWNLOAD_DIR: inside the
-        # container that UI value can be a host path (e.g. a Windows F:\ path)
-        # that doesn't exist on the container's filesystem, so spotDL would write
-        # into the ephemeral container instead of the mounted volume. Unset
-        # outside Docker, so the UI value is used there.
-        opts.download_dir = (os.getenv("SONGMIRROR_DOWNLOAD_DIR") or self._settings.get("DOWNLOAD_DIR", "") or "") if job.download else ""
+        # Explicit UI folder choices are validated on the server. Legacy host
+        # paths still fall back to Docker's configured mount.
+        opts.download_dir = download_directory(self._settings) if job.download else ""
         return opts
 
     async def run_job(self, job_id, execute=False):

--- a/songmirror/web/__init__.py
+++ b/songmirror/web/__init__.py
@@ -26,7 +26,7 @@ from ..services.syncs import SyncStore
 from ..services.transfers import TransferService
 from .access_log import install_oauth_access_log_filter
 from .routers import (
-    accounts, events, playlist_backups as playlist_backups_router, playlists,
+    accounts, events, folders, playlist_backups as playlist_backups_router, playlists,
     resolve_cache as resolve_cache_router, settings as settings_router, sync,
     syncs as syncs_router,
     transfers as transfers_router,
@@ -90,6 +90,7 @@ def create_app(settings=None, bus=None, sync_service=None, links=None, transfers
 
     app.include_router(accounts.router)
     app.include_router(settings_router.router)
+    app.include_router(folders.router)
     app.include_router(sync.router)
     app.include_router(syncs_router.router)
     app.include_router(events.router)

--- a/songmirror/web/routers/folders.py
+++ b/songmirror/web/routers/folders.py
@@ -1,0 +1,31 @@
+"""Directory-only browsing for backup and download locations."""
+
+from fastapi import APIRouter, Body, HTTPException, Query, Request
+
+from ...services.folders import FolderBrowser
+
+router = APIRouter()
+
+
+@router.post("/api/folders", status_code=201)
+def create_folder(request: Request, values: dict = Body(...)):
+    try:
+        parent = values.get("parent")
+        if not isinstance(parent, str) or len(parent) > 4096:
+            raise ValueError("Choose a parent folder first.")
+        return FolderBrowser(request.app.state.settings).create(parent, values.get("name"))
+    except (ValueError, OSError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/api/folders/config")
+def folder_config(request: Request):
+    return FolderBrowser(request.app.state.settings).config()
+
+
+@router.get("/api/folders")
+def browse_folders(request: Request, path: str = Query(default="", max_length=4096)):
+    try:
+        return FolderBrowser(request.app.state.settings).browse(path)
+    except (ValueError, OSError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/songmirror/web/routers/playlist_backups.py
+++ b/songmirror/web/routers/playlist_backups.py
@@ -7,11 +7,13 @@ from fastapi.responses import FileResponse, JSONResponse
 
 from ...engine.targets import is_peer
 from ...services.accounts import CONNECTORS
+from ...services.folders import writable_directory
+from ...services.folders import FolderBrowser
 from ...services.playlist_backups import PlaylistBackupJob, validate_backup_job
 
 
 router = APIRouter()
-_FIELDS = {"enabled", "interval", "format", "retention"}
+_FIELDS = {"enabled", "interval", "format", "retention", "storage_dir"}
 
 
 def _known_account(account_id, profiles=None):
@@ -70,14 +72,26 @@ async def put_playlist_backup(
     service = request.app.state.playlist_backups
     profiles = request.app.state.account_profiles
     account_id = _known_account(account_id, profiles)
-    job = service.store.upsert(
-        _job_from(
-            account_id,
-            values,
-            existing=service.store.get(account_id),
-            profiles=profiles,
-        )
+    existing = service.store.get(account_id)
+    if "storage_dir" in values:
+        try:
+            values["storage_dir"] = FolderBrowser(request.app.state.settings).server_path(values["storage_dir"])
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+    job = _job_from(
+        account_id,
+        values,
+        existing=existing,
+        profiles=profiles,
     )
+    if existing and job.storage_dir != existing.storage_dir and service.job_status(existing)["running"]:
+        raise HTTPException(status_code=409, detail="Wait for the current backup to finish before changing its folder.")
+    if job.storage_dir:
+        try:
+            job.storage_dir = str(writable_directory(job.storage_dir))
+        except (ValueError, OSError) as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+    job = service.store.upsert(job)
     await service.reconcile()
     return service.job_status(job)
 

--- a/songmirror/web/routers/settings.py
+++ b/songmirror/web/routers/settings.py
@@ -2,9 +2,11 @@
 
 import os
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 
 from ...services.accounts import CONNECTORS
+from ...services.folders import download_directory, writable_directory
+from ...services.folders import FolderBrowser
 
 router = APIRouter()
 
@@ -41,10 +43,22 @@ def get_settings(request: Request):
     for key in CONFIG_KEYS:
         if key not in out and os.getenv(key):
             out[key] = os.getenv(key)
+    out["DOWNLOAD_DIR"] = download_directory(request.app.state.settings)
+    out.pop("DOWNLOAD_DIR_CONFIRMED", None)
     return out
 
 
 @router.put("/api/settings")
 def put_settings(request: Request, values: dict = Body(...)):
+    values.pop("DOWNLOAD_DIR_CONFIRMED", None)
+    if "DOWNLOAD_DIR" in values:
+        try:
+            value = FolderBrowser(request.app.state.settings).server_path(values["DOWNLOAD_DIR"])
+            if not isinstance(value, str):
+                raise ValueError("Download folder must be a path.")
+            values["DOWNLOAD_DIR"] = str(writable_directory(value)) if value.strip() else ""
+            values["DOWNLOAD_DIR_CONFIRMED"] = "1"
+        except (ValueError, OSError) as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     request.app.state.settings.save(values)
     return {"ok": True}

--- a/tests/test_folders.py
+++ b/tests/test_folders.py
@@ -1,0 +1,131 @@
+from fastapi.testclient import TestClient
+import os
+import pytest
+
+from songmirror.services.folders import FolderBrowser, download_directory
+from songmirror.services.settings import SettingsStore
+from songmirror.services.syncs import SyncJob
+from songmirror.web import create_app
+
+
+def test_browser_lists_sorted_directories_breadcrumbs_and_locations(tmp_path):
+    settings = SettingsStore(dir=tmp_path / "data", project_env=False)
+    for name in ("Zulu", "alpha", ".hidden"):
+        (tmp_path / name).mkdir()
+    (tmp_path / "private.txt").write_text("not a directory")
+    client = TestClient(create_app(settings=settings))
+    result = client.get('/api/folders', params={'path': str(tmp_path)}).json()
+    assert [item['name'] for item in result['directories']] == ['alpha', 'data', 'Zulu']
+    assert result['path'] == str(tmp_path)
+    assert result['parent'] == str(tmp_path.parent)
+    assert result['breadcrumbs'][-1]['path'] == str(tmp_path)
+    assert result['writable'] is True
+    assert client.get('/api/folders/config').json()['locations']
+    assert client.post('/api/folders/pick', json={}).status_code == 405
+
+
+@pytest.mark.parametrize('path', ['relative/folder', '/missing-songmirror-folder', '\0'])
+def test_browser_rejects_invalid_addresses(tmp_path, path):
+    settings = SettingsStore(dir=tmp_path / 'data', project_env=False)
+    client = TestClient(create_app(settings=settings))
+    assert client.get('/api/folders', params={'path': path}).status_code == 422
+
+
+def test_empty_and_read_only_folder(tmp_path, monkeypatch):
+    settings = SettingsStore(dir=tmp_path / 'data', project_env=False)
+    empty = tmp_path / 'empty'
+    empty.mkdir()
+    monkeypatch.setattr('songmirror.services.folders.os.access', lambda *args: False)
+    result = FolderBrowser(settings).browse(str(empty))
+    assert result['directories'] == []
+    assert result['writable'] is False
+
+
+def test_original_host_download_path_mapping_needs_no_helper(tmp_path, monkeypatch):
+    monkeypatch.setenv('SONGMIRROR_HOST_DOWNLOAD_DIR', 'F:\\Torrent\\Music')
+    monkeypatch.setenv('SONGMIRROR_DOWNLOAD_DIR', '/music')
+    picker = FolderBrowser(SettingsStore(dir=tmp_path / 'data', project_env=False))
+    assert picker.config()['mounts'] == [{'host': 'F:\\Torrent\\Music', 'server': '/music'}]
+    assert picker.server_path('F:\\Torrent\\Music') == '/music'
+    assert picker.server_path('F:\\Torrent\\Music\\Aurora') == '/music/Aurora'
+    if os.name == 'nt':
+        assert picker.server_path('F:\\Torrent\\Music elsewhere') == 'F:\\Torrent\\Music elsewhere'
+    else:
+        with pytest.raises(ValueError, match='not shared'):
+            picker.server_path('F:\\Torrent\\Music elsewhere')
+    with pytest.raises(ValueError, match='shared location'):
+        picker.server_path('F:\\Torrent\\Music\\..\\other')
+
+
+def test_general_settings_save_preserves_original_download_location(tmp_path, monkeypatch):
+    monkeypatch.setenv('SONGMIRROR_DOWNLOAD_DIR', '/music')
+    settings = SettingsStore(dir=tmp_path / 'data', project_env=False)
+    settings.save({'DOWNLOAD_DIR': 'F:\\Torrent\\Music'})
+    client = TestClient(create_app(settings=settings))
+    assert client.put('/api/settings', json={'DISPLAY_NAME': 'Maya'}).status_code == 200
+    assert settings.get('DOWNLOAD_DIR') == 'F:\\Torrent\\Music'
+    assert settings.get('DOWNLOAD_DIR_CONFIRMED') is None
+    assert download_directory(settings) == '/music'
+
+
+def test_download_folder_choice_overrides_mount_and_can_be_disabled(tmp_path, monkeypatch):
+    settings = SettingsStore(dir=tmp_path / "data", project_env=False)
+    settings.save({"DOWNLOAD_DIR": "F:\\old-host-only-path"})
+    monkeypatch.setenv("SONGMIRROR_DOWNLOAD_DIR", "/music")
+    app = create_app(settings=settings)
+    client = TestClient(app)
+    assert client.get("/api/settings").json()["DOWNLOAD_DIR"] == "/music"
+    choice = tmp_path / "Jellyfin Music"
+    choice.mkdir()
+    assert client.put("/api/settings", json={"DOWNLOAD_DIR": str(choice)}).status_code == 200
+    assert client.get("/api/settings").json()["DOWNLOAD_DIR"] == str(choice.resolve())
+    assert "DOWNLOAD_DIR_CONFIRMED" not in client.get("/api/settings").json()
+    reloaded = SettingsStore(dir=settings.data_dir, project_env=False)
+    assert download_directory(reloaded) == str(choice.resolve())
+    assert app.state.sync._opts_for(SyncJob(download=True), execute=True).download_dir == str(choice.resolve())
+    assert client.put("/api/settings", json={"DOWNLOAD_DIR": ""}).status_code == 200
+    assert download_directory(settings) == ""
+
+
+def test_invalid_download_folder_does_not_save_other_changes(tmp_path):
+    settings = SettingsStore(dir=tmp_path / "data", project_env=False)
+    client = TestClient(create_app(settings=settings))
+    response = client.put("/api/settings", json={"DOWNLOAD_DIR": str(tmp_path / "missing"), "DISPLAY_NAME": "Changed"})
+    assert response.status_code == 422
+    assert settings.get("DISPLAY_NAME") is None
+
+
+def test_create_folder_and_reject_existing_items(tmp_path):
+    settings = SettingsStore(dir=tmp_path / 'data', project_env=False)
+    client = TestClient(create_app(settings=settings))
+    values = {'parent': str(tmp_path), 'name': 'Music & playlist backups'}
+    response = client.post('/api/folders', json=values)
+    assert response.status_code == 201
+    child = tmp_path / values['name']
+    assert response.json()['path'] == str(child)
+    assert child.is_dir()
+    assert not list(child.iterdir())
+    assert client.post('/api/folders', json=values).status_code == 422
+    existing = tmp_path / 'existing.txt'
+    existing.write_text('keep this')
+    response = client.post('/api/folders', json={**values, 'name': existing.name})
+    assert response.status_code == 422
+    assert 'already exists' in response.json()['detail']
+    assert existing.read_text() == 'keep this'
+    assert settings.get('DOWNLOAD_DIR') is None
+
+
+@pytest.mark.parametrize('name', ['', '.', '..', '../outside', 'one/two', 'one\\two', 'C:\\outside',
+                                  'bad\0name', 'bad:name', 'trail.', 'trail ', 'CON', 'LPT1.txt', None, 42])
+def test_create_rejects_invalid_names(tmp_path, name):
+    client = TestClient(create_app(settings=SettingsStore(dir=tmp_path / 'data', project_env=False)))
+    assert client.post('/api/folders', json={'parent': str(tmp_path), 'name': name}).status_code == 422
+    assert sorted(item.name for item in tmp_path.iterdir()) == ['data']
+
+
+def test_create_rejects_missing_and_readonly_parents(tmp_path, monkeypatch):
+    client = TestClient(create_app(settings=SettingsStore(dir=tmp_path / 'data', project_env=False)))
+    assert client.post('/api/folders', json={'parent': str(tmp_path / 'missing'), 'name': 'child'}).status_code == 422
+    monkeypatch.setattr('songmirror.services.folders.os.access', lambda *args: False)
+    assert client.post('/api/folders', json={'parent': str(tmp_path), 'name': 'child'}).status_code == 422
+    assert not (tmp_path / 'child').exists()

--- a/tests/test_playlist_backups.py
+++ b/tests/test_playlist_backups.py
@@ -60,6 +60,52 @@ def test_backup_job_validation_rejects_unsafe_schedules(changes, message):
         validate_backup_job(job)
 
 
+def test_custom_folder_is_persisted_scoped_and_does_not_prune_old_location(tmp_path):
+    data = tmp_path / "data"
+    custom = tmp_path / "My backups"
+    custom.mkdir()
+    store = PlaylistBackupStore(data)
+    store.upsert(PlaylistBackupJob(account_id="spotify", retention=1))
+    original, _ = store.write_snapshot("spotify", _export(1), 1)
+    store.upsert(PlaylistBackupJob(account_id="spotify", retention=1, storage_dir=str(custom)))
+    # Another account and unrelated files in the chosen root must be untouched.
+    store.upsert(PlaylistBackupJob(account_id="apple", storage_dir=str(custom)))
+    other, _ = store.write_snapshot("apple", _export(1), 1)
+    unrelated = custom / "keep.txt"
+    unrelated.write_text("keep", encoding="utf-8")
+    reloaded = PlaylistBackupStore(data)
+    first, _ = reloaded.write_snapshot("spotify", _export(2), 1)
+    latest, removed = reloaded.write_snapshot("spotify", _export(3), 1)
+    assert latest.parent == custom / "spotify"
+    assert removed == 1 and not first.exists()
+    assert reloaded.latest_snapshot("spotify") == latest
+    assert latest.read_bytes() == _export(3).content
+    assert original.exists() and other.exists() and unrelated.exists()
+    reloaded.upsert(PlaylistBackupJob(account_id="spotify", storage_dir=""))
+    assert reloaded.latest_snapshot("spotify") == original
+    assert latest.exists()
+
+
+def test_backup_api_custom_folder_validation_and_latest(tmp_path):
+    settings = SettingsStore(dir=tmp_path / "data", project_env=False)
+    app = create_app(settings=settings)
+    client = TestClient(app)
+    custom = tmp_path / "Backups"
+    custom.mkdir()
+    url = "/api/playlist-backups/spotify"
+    response = client.put(url, json={"storage_dir": str(custom), "enabled": False})
+    assert response.status_code == 200
+    job = response.json()
+    assert job["storage_dir"] == str(custom.resolve())
+    assert job["default_storage_dir"] == str((settings.data_dir / "playlist_backups").resolve())
+    assert Path(job["storage_path"]) == custom / job["account_id"]
+    app.state.playlist_backups.store.write_snapshot(job["account_id"], _export(1), 30)
+    assert client.get(url + "/latest").content == _export(1).content
+    for invalid in ("relative/path", str(tmp_path / "missing"), 123, None):
+        assert client.put(url, json={"storage_dir": invalid}).status_code == 422
+    assert app.state.playlist_backups.store.get("spotify").storage_dir == str(custom.resolve())
+
+
 def test_backup_run_persists_status_and_prunes_only_managed_snapshots(
     tmp_path,
     monkeypatch,

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1366,6 +1366,41 @@ def test_two_additions_resolving_to_one_new_track_hold_all_removals(tmp_path):
     conn.close()
 
 
+@pytest.mark.parametrize("max_adds, expected", [(200, ["reverse", "self"]), (1, ["reverse"])])
+def test_unrelated_catalog_collision_does_not_block_valid_new_songs(max_adds, expected):
+    def track(tid, name, isrc, date, artist="Temper City"):
+        return dict(id=tid, name=name, isrc=isrc, artist=artist, artists=[artist],
+                    duration_ms=180000, added_at=date)
+
+    old = track("old", "Existing unrelated track", "OLD", "2020", "Other artist")
+    conflict = track("conflict", "Another recording", "CONFLICT", "2021", "Different artist")
+    new = [track("reverse", "Reverse Psychology", "NEW1", "2026-09-04T13:09:42Z"),
+           track("self", "Self Aware", "NEW2", "2026-09-04T13:09:49Z")]
+
+    class Mirror(_ManyPeer):
+        def replay_chronology(self, playlist, ordered_entries):
+            pytest.fail("A collision must not rewrite existing playlist entries")
+
+    conn = archive.connect(":memory:")
+    spotify = _ManyPeer("spotify", [old, conflict, *new], lambda norm: norm["_raw"]["id"])
+    destinations = [Mirror(source, [old], lambda norm:
+                           "old" if norm["isrc"] == "CONFLICT" else norm["_raw"]["id"])
+                    for source in ("apple", "ytmusic", "tidal", "deezer", "amazon", "qobuz")]
+    peers = [spotify, *destinations]
+
+    stats = reconcile(peers, "Aurora", {p.source: {"id": p.source} for p in peers},
+                      _caches(*(p.source for p in peers)), conn, execute=True,
+                      max_removals=200, max_adds=max_adds,
+                      authority_sources={"spotify", "apple"})
+
+    assert all(peer.added == expected for peer in destinations)
+    assert all(peer.removed == [] for peer in peers)
+    assert stats["added"] == len(expected) * 6
+    assert stats["deferred"] == (3 - len(expected)) * 6
+    assert stats["clean"] is False
+    conn.close()
+
+
 def test_same_key_queued_additions_stay_distinct_when_audio_differs(tmp_path):
     conn = archive.connect(str(tmp_path / "queued-key-collision.db"))
     for src in ("spotify", "tidal"):


### PR DESCRIPTION
## Summary

- Defer only ambiguous catalog matches so unrelated valid additions continue syncing, with source ordering, write caps, and removal protections preserved.
- Split Settings into focused sections and add friendly backup frequency and retention options, default/custom backup locations, and aligned account and backup forms.
- Add a shared Explorer-style folder picker with navigation, search, manual paths, and subfolder creation. Explain Docker-visible paths and mapped host locations without requiring a desktop helper.

## Storage safeguards

Existing download paths and mounts remain unchanged unless explicitly saved. Backup retention stays within each account's selected folder; moving the destination leaves previous snapshots intact. Custom parent-directory permissions are not altered. Folder drafts remain editable during a backup, while destination changes wait for completion.

## Verification

- Python suite: 635 passed, 1 skipped.
- Reconcile suite: 78 passed, including collision isolation across six destination providers.
- Frontend production build and lint passed.
- Browser suite: 138 checks passed with zero horizontal overflow, plus focused desktop/mobile folder, draft-preservation, and account-alignment regressions.
- Docker Compose validation and deployed UI smoke checks passed.

The frontend build retains its existing large-bundle warning. Docker folder browsing remains limited to mounted storage; the picker explains this boundary and rejects unshared host paths with actionable guidance.