### PR TITLE
fix(matching): preserve recording variants and enrich YouTube metadata

### DIFF
--- a/songmirror/engine/dedupe.py
+++ b/songmirror/engine/dedupe.py
@@ -18,14 +18,12 @@ CLI (report by default; inside the container prefix with `docker exec`):
 """
 
 from . import archive
-from .matching import fuzzy_in, loose_name, romanized, spotify_track_keys, track_key
+from .matching import creative_version_markers, fuzzy_in, loose_name, romanized, spotify_track_keys, track_key
 from .targets.base import _entry_cids, _unify_aliases
 
-# Words that mark a DIFFERENT RECORDING of the same song. Alias unification is
-# deliberately version-blind (folding "Song (Live)" into "Song" keeps the sync
-# from re-propagating provider-local variants), but a DELETION across such a
-# boundary would destroy a real recording — e.g. a studio track flagged as a
-# "copy" of a live video that happened to fold into it.
+# Duplicate deletion is stricter than alias matching: even a release-format
+# difference or remaster stays for review. Include the shared creative markers
+# so localized labels receive the same protection as English ones.
 VERSION_MARKERS = frozenset((
     "live", "instrumental", "acoustic", "unplugged", "remix", "mix", "karaoke",
     "demo", "cover", "sped", "slowed", "nightcore", "reverb", "orchestral",
@@ -34,7 +32,7 @@ VERSION_MARKERS = frozenset((
 
 
 def _markers(name):
-    return VERSION_MARKERS.intersection(loose_name(name).split())
+    return VERSION_MARKERS.intersection(loose_name(name).split()) | creative_version_markers(name)
 
 
 def _order_rows(peer, raw):

--- a/songmirror/engine/matching.py
+++ b/songmirror/engine/matching.py
@@ -23,7 +23,10 @@ DURATION_TOLERANCE_MS = 2500
 CATALOG_DURATION_TOLERANCE_MS = 5000
 
 PAREN_FEAT_RE = re.compile(r"[\(\[]\s*(feat|featuring|ft|with)\b.*?[\)\]]", re.IGNORECASE)
-TRAILING_FEAT_RE = re.compile(r"\s+(feat|featuring|ft)\s+.*$")
+TRAILING_FEAT_RE = re.compile(
+    r"\s+(?:feat|featuring|ft)\.?\s+.*?(?=\s*[\(\[\{]|\s+[-–—]\s+|$)",
+    re.IGNORECASE,
+)
 CATALOG_TAG = r"(?:(?:\d{4}\s+)?re-?master(?:ed)?(?:\s+\d{4})?|clean|explicit)"
 BRACKETED_CATALOG_TAG_RE = re.compile(rf"[\(\[]\s*(?:{CATALOG_TAG})\s*[\)\]]", re.IGNORECASE)
 TRAILING_CATALOG_TAG_RE = re.compile(rf"\s*[-–—]\s*(?:{CATALOG_TAG})\s*$", re.IGNORECASE)
@@ -32,9 +35,13 @@ FROM_RELEASE_RE = re.compile(
     re.IGNORECASE,
 )
 CREATIVE_VERSION_PATTERNS = (
-    ("live", re.compile(r"\blive\b", re.IGNORECASE)),
-    ("acoustic", re.compile(r"\b(?:acoustic|unplugged)\b", re.IGNORECASE)),
-    ("remix", re.compile(r"\b(?:remix|rework|extended mix|radio edit)\b", re.IGNORECASE)),
+    ("live", re.compile(r"\b(?:live|canli|ao vivo|en vivo)\b", re.IGNORECASE)),
+    ("acoustic", re.compile(r"\b(?:acoustic|akustik|acustic[oa]|acoustique|unplugged|stripped)\b", re.IGNORECASE)),
+    ("remix", re.compile(r"\b(?:remix|rework|mashup)\b", re.IGNORECASE)),
+    ("dub", re.compile(r"\b(?:dub|dubbed)\b", re.IGNORECASE)),
+    ("mix", re.compile(r"\bmix\b", re.IGNORECASE)),
+    ("edit", re.compile(r"\bedit\b", re.IGNORECASE)),
+    ("vip", re.compile(r"\bvip\b", re.IGNORECASE)),
     ("instrumental", re.compile(r"\binstrumental\b", re.IGNORECASE)),
     ("karaoke", re.compile(r"\bkaraoke\b", re.IGNORECASE)),
     ("piano", re.compile(r"\bpiano\b", re.IGNORECASE)),
@@ -43,6 +50,13 @@ CREATIVE_VERSION_PATTERNS = (
     ("alternate-speed", re.compile(r"\b(?:sped up|slowed(?: down)?|nightcore)\b", re.IGNORECASE)),
     ("mix-format", re.compile(r"\b(?:mono|stereo)\b", re.IGNORECASE)),
     ("cover", re.compile(r"\bcover\b", re.IGNORECASE)),
+    ("a-cappella", re.compile(r"\ba ?ca?pp?ella\b", re.IGNORECASE)),
+    ("orchestral", re.compile(r"\b(?:orchestral|orchestra|symphonic)\b", re.IGNORECASE)),
+    ("re-recording", re.compile(r"\bre ?record(?:ed|ing)\b", re.IGNORECASE)),
+    ("reverb", re.compile(r"\breverb\b", re.IGNORECASE)),
+    ("spatial", re.compile(r"\b(?:8d|binaural)\b", re.IGNORECASE)),
+    ("solo", re.compile(r"\bsolo\b", re.IGNORECASE)),
+    ("alternate", re.compile(r"\b(?:alternate|alternative)\b", re.IGNORECASE)),
 )
 
 
@@ -141,12 +155,16 @@ def normalize_canonical_id(value):
     return f"i:{isrc}" if isrc else canonical
 
 
+def _without_feature_credits(name):
+    return TRAILING_FEAT_RE.sub("", PAREN_FEAT_RE.sub(" ", str(name or "")))
+
+
 def loose_name(name):
     """Title with feat-clauses stripped — '(feat. X)' is the classic drift for
     the SAME song. Version qualifiers like (Live)/(Acoustic) are kept: those
     are different recordings — but the abbreviation 'ver' expands to 'version'
     so 'Twin Ver.' and 'Twin Version' agree token-for-token."""
-    cleaned = TRAILING_FEAT_RE.sub("", normalize_text(PAREN_FEAT_RE.sub(" ", name or ""))).strip()
+    cleaned = normalize_text(_without_feature_credits(name))
     cleaned = re.sub(r"\bver\b", "version", cleaned)
     return cleaned or normalize_text(name)
 
@@ -180,7 +198,7 @@ def creative_version_markers(name):
     is used only when no more specific qualifier explains it, so "Piano
     Version" and "Piano" still describe the same creative variant.
     """
-    normalized = normalize_text(name)
+    normalized = romanized(loose_name(name))
     markers = {
         marker
         for marker, pattern in CREATIVE_VERSION_PATTERNS
@@ -198,8 +216,65 @@ def romanized(text):
     return normalize_text(anyascii(str(text or "")))
 
 
+def featured_artists(name):
+    """Explicit guest credits, independent of title-vs-artist API formatting."""
+    credits = []
+    for pattern in (PAREN_FEAT_RE, TRAILING_FEAT_RE):
+        for match in pattern.finditer(str(name or "")):
+            credit = re.sub(r"^[\s(\[]*(?:feat|featuring|ft|with)\b\.?\s*", "", match[0], flags=re.IGNORECASE)
+            credit = credit.rstrip(")] ")
+            credits.extend(part.strip() for part in re.split(r"\s*(?:,|&|\band\b)\s*", credit) if part.strip())
+    return credits
+
+
+def _has_credit(credit, artists):
+    return f" {romanized(credit)} " in f" {romanized(artists)} "
+
+
+def recording_version_signature(name):
+    """Recording family plus named mix, venue, or version-number qualifiers.
+
+    Token-set title similarity cannot distinguish two DJs' remixes or two
+    concerts. Compare explicit qualifiers before fuzzy scoring, while allowing
+    label spelling differences such as Acoustic Version / Akustik.
+    """
+    markers = frozenset(creative_version_markers(name))
+    details = set()
+    for part in re.split(r"\s+[-–—]\s+|[()\[\]{}]", _without_feature_credits(name))[1:]:
+        if not creative_version_markers(part):
+            continue
+        normalized = romanized(loose_name(part))
+        for marker, pattern in CREATIVE_VERSION_PATTERNS:
+            normalized = pattern.sub(marker, normalized)
+        if markers != {"alternate-version"}:
+            normalized = re.sub(r"\bversion\b", "", normalized)
+        detail = " ".join(sorted(normalized.split()))
+        if detail != " ".join(sorted(markers)):
+            details.add(detail)
+    return markers, frozenset(details)
+
+
+def recording_versions_compatible(name, artists, cand_name, cand_artists):
+    if recording_version_signature(name) != recording_version_signature(cand_name):
+        return False
+    features, cand_features = featured_artists(name), featured_artists(cand_name)
+    if isinstance(artists, str):
+        artists = [artists]
+    if isinstance(cand_artists, str):
+        cand_artists = [cand_artists]
+    credits = " ".join([*(artists or []), *features])
+    cand_credits = " ".join([*(cand_artists or []), *cand_features])
+    return all(_has_credit(guest, cand_credits) for guest in features) and all(
+        _has_credit(guest, credits) for guest in cand_features
+    )
+
+
 def track_key(name, artist):
-    return f"{loose_name(name)}|{normalize_text(artist)}"
+    credits = str(artist or "")
+    for guest in featured_artists(name):
+        if not _has_credit(guest, credits):
+            credits += " " + guest
+    return f"{loose_name(name)}|{normalize_text(credits)}"
 
 
 def _sim_strict(a, b):
@@ -262,7 +337,7 @@ def fuzzy_in(key, keys, threshold=FUZZY_THRESHOLD):
 def score_candidate(name, artists, duration_ms, cand_name, cand_artist, cand_duration_ms):
     """(score in 0..1, acceptable) for a search-result candidate vs the wanted
     track — the fuzzy fallback when no ISRC/link resolves it."""
-    if creative_version_markers(name) != creative_version_markers(cand_name):
+    if not recording_versions_compatible(name, artists, cand_name, cand_artist):
         return 0.0, False
     if isinstance(artists, str):
         artists = [artists]
@@ -303,6 +378,11 @@ def same_catalog_recording(track, candidate):
     it) near-identical duration. It catches alternate catalog releases without
     treating an acoustic/live/remix/version as the ordinary track.
     """
+    if not recording_versions_compatible(
+        track.get("name"), track.get("artists") or track.get("artist"),
+        candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
+    ):
+        return False
     wanted = catalog_name(track.get("name"))
     existing = catalog_name(candidate.get("name"))
     if not wanted or wanted != existing:
@@ -328,8 +408,9 @@ def same_unresolved_recording(source_track, existing_track, threshold=0.8):
     performer (for example, two unrelated songs named "Bad Blood"). Duration,
     when both providers expose it, must also agree closely.
     """
-    if creative_version_markers(source_track.get("name")) != creative_version_markers(
-        existing_track.get("name")
+    if not recording_versions_compatible(
+        source_track.get("name"), source_track.get("artists") or source_track.get("artist"),
+        existing_track.get("name"), existing_track.get("artists") or existing_track.get("artist"),
     ):
         return False
 
@@ -363,23 +444,34 @@ def compute_diff(sp_tracks, target_tracks, expected_by_sp, target_id_of, thresho
     or fuzzy Spotify match (fuzzy applies only to this destructive side, as the
     guard against a metadata mismatch deleting a real track).
     """
-    target_ids = {target_id_of(t) for t in target_tracks if target_id_of(t)}
-    target_keys = {track_key(t["name"], t["artist"]) for t in target_tracks}
+    target_by_id, target_by_key = {}, {}
+    for track in target_tracks:
+        if target_id_of(track):
+            target_by_id.setdefault(target_id_of(track), []).append(track)
+        target_by_key.setdefault(track_key(track["name"], track["artist"]), []).append(track)
+
+    def compatible(source, target):
+        return recording_versions_compatible(
+            source.get("name"), source.get("artists") or source.get("artist"),
+            target.get("name"), target.get("artists") or target.get("artist"),
+        )
 
     expected_all = set()
-    sp_keys = set()
-    sp_keys_by_version = {}
+    sp_by_version = {}
     to_add = []
     for tr in sp_tracks:
         expected = expected_by_sp.get(tr.get("id")) or set()
+        expected = {
+            tid for tid in expected
+            if any(compatible(tr, target) for target in target_by_id.get(tid, []))
+        }
         expected_all |= expected
         keys = spotify_track_keys(tr)
-        sp_keys |= keys
-        version = frozenset(creative_version_markers(tr.get("name")))
-        sp_keys_by_version.setdefault(version, set()).update(keys)
-        if expected & target_ids:
+        version = recording_version_signature(tr.get("name"))
+        sp_by_version.setdefault(version, []).append((keys, tr))
+        if expected:
             continue
-        if keys & target_keys:
+        if any(compatible(tr, target) for key in keys for target in target_by_key.get(key, [])):
             continue
         to_add.append(tr)
     to_add = tracks_oldest_first(to_add)
@@ -390,10 +482,11 @@ def compute_diff(sp_tracks, target_tracks, expected_by_sp, target_id_of, thresho
         if tid and tid in expected_all:
             continue
         key = track_key(t["name"], t["artist"])
-        compatible_keys = sp_keys_by_version.get(
-            frozenset(creative_version_markers(t.get("name"))), set()
+        sources = sp_by_version.get(
+            recording_version_signature(t.get("name")), []
         )
-        if key in sp_keys or fuzzy_in(key, compatible_keys, threshold):
+        if any((key in keys or fuzzy_in(key, keys, threshold)) and compatible(source, t)
+               for keys, source in sources):
             continue
         to_remove.append(t)
     return to_add, to_remove

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -55,25 +55,32 @@ def _save_json(path, data):
         json.dump(data, f)
 
 
+MATCHING_CACHE_VERSION = 1
+
+
 def load_cache(cache_file):
     """The provider's resolution cache: ISRC candidates, search results, and
     which search keys were set by hand.
 
-    `manual` is a set of `search` keys a person chose in the conflict editor
-    rather than the matcher finding. A cache written before that existed loads
-    with an empty set, and a cache written with it stays readable by anything
-    that only knows the other two keys.
+    `manual` is a set of `search` keys a person chose in the conflict editor.
+    Old automatic results must be searched again when matching rules change:
+    they contain only ids, so recording-version conflicts cannot be checked
+    offline. Manual choices survive migration. ISRC candidates are refetched
+    as older normalizers could discard the provider's separate version field.
     """
     try:
         with open(cache_file) as f:
             data = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
         data = {}
+    manual = set(data.get("manual") or [])
+    migrate = bool(data) and data.get("matching_version") != MATCHING_CACHE_VERSION
+    search = data.get("search", {})
     return {
-        "isrc": data.get("isrc", {}),
-        "search": data.get("search", {}),
-        "manual": set(data.get("manual") or []),
-        "dirty": False,
+        "isrc": {} if migrate else data.get("isrc", {}),
+        "search": {key: value for key, value in search.items() if key in manual} if migrate else search,
+        "manual": manual,
+        "dirty": migrate,
     }
 
 
@@ -82,6 +89,7 @@ def save_cache(cache_file, cache):
         return
     with open(cache_file, "w") as f:
         json.dump({
+            "matching_version": MATCHING_CACHE_VERSION,
             "isrc": cache["isrc"],
             "search": cache["search"],
             "manual": sorted(cache.get("manual") or ()),

--- a/songmirror/engine/targets/amazon_music.py
+++ b/songmirror/engine/targets/amazon_music.py
@@ -21,7 +21,7 @@ from ...oauth import merge_refresh, read_token, token_is_live, token_path, write
 from ..config import REQUEST_TIMEOUT, polite_sleep, required_env
 from ..matching import normalize_isrc, normalize_text, romanized, track_key
 from .base import MirrorTarget, TargetAuthError
-from .provider_utils import best_candidate, chunks, source_playlist_details
+from .provider_utils import best_candidate, chunks, compatible_isrc_candidates, source_playlist_details
 
 API = "https://api.music.amazon.dev/v1"
 TOKEN_URL = "https://api.amazon.com/auth/o2/token"
@@ -675,7 +675,7 @@ class AmazonMusicTarget(MirrorTarget):
     def expected_ids(self, source_tracks, links, cache):
         out = {}
         for track in source_tracks:
-            ids = {str(c["id"]) for c in cache["isrc"].get(track.get("isrc") or "", []) if c.get("id")}
+            ids = {str(c["id"]) for c in compatible_isrc_candidates(track, cache)}
             if links.get(track.get("id")):
                 ids.add(str(links[track["id"]]))
             if ids:
@@ -683,7 +683,7 @@ class AmazonMusicTarget(MirrorTarget):
         return out
 
     def resolve(self, track, cache):
-        candidates = cache["isrc"].get(track.get("isrc") or "", [])
+        candidates = compatible_isrc_candidates(track, cache)
         if candidates:
             return best_candidate(track, candidates) or str(candidates[0]["id"]), "isrc"
         key = track_key(track.get("name", ""), " ".join(track.get("artists") or []))

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -13,14 +13,14 @@ from ..config import (
     AMP, DEFAULT_CACHE_FILE, REQUEST_TIMEOUT, polite_sleep, required_env,
 )
 from ..logs import log, log_warn
-from ..matching import normalize_text, romanized, score_candidate
+from ..matching import normalize_text, recording_versions_compatible, romanized, score_candidate
 from .base import (
     MirrorTarget,
     TargetAuthError,
     TargetCapabilityError,
     TargetTransientError,
 )
-from .provider_utils import source_playlist_details
+from .provider_utils import compatible_isrc_candidates, source_playlist_details
 
 # playlist_id -> (lastModifiedDate, track_count): in-process cache so the browse
 # doesn't re-issue a meta.total call for an unchanged Apple playlist (library
@@ -434,10 +434,7 @@ class AppleMusicTarget(MirrorTarget):
         out = {}
         for t in sp_tracks:
             ids = set()
-            candidates = [
-                c for c in cache["isrc"].get(t.get("isrc") or "", [])
-                if c.get("id")
-            ]
+            candidates = compatible_isrc_candidates(t, cache)
             for c in candidates:
                 if c.get("id"):
                     ids.add(c["id"])
@@ -451,7 +448,7 @@ class AppleMusicTarget(MirrorTarget):
         return out
 
     def resolve(self, track, cache):
-        candidates = [c for c in cache["isrc"].get(track["isrc"] or "", []) if c.get("id")]
+        candidates = compatible_isrc_candidates(track, cache)
         if candidates and track["duration_ms"] is not None:
             candidates.sort(key=lambda c: abs((c.get("duration_ms") or 0) - track["duration_ms"]))
         if candidates:
@@ -481,7 +478,7 @@ class AppleMusicTarget(MirrorTarget):
         isrc = track.get("isrc") or ""
         if isrc not in cache["isrc"]:
             return target_id, "link"
-        candidates = [candidate for candidate in cache["isrc"][isrc] if candidate.get("id")]
+        candidates = compatible_isrc_candidates(track, cache)
         if candidates and track.get("duration_ms") is not None:
             candidates.sort(
                 key=lambda candidate: abs(
@@ -503,9 +500,16 @@ class AppleMusicTarget(MirrorTarget):
                 f"{AMP}/catalog/{self.storefront}/songs/{target_id}",
                 ok404=True,
             )
-            validated[target_id] = response is not None
+            rows = response.json().get("data", []) if response is not None else []
+            validated[target_id] = next(
+                (row.get("attributes") or {} for row in rows if str(row.get("id")) == str(target_id)),
+                None,
+            )
             self._validated_catalog_ids = validated
-        if validated[target_id]:
+        attrs = validated[target_id]
+        if attrs is not None and recording_versions_compatible(
+            track.get("name"), track.get("artists"), attrs.get("name"), attrs.get("artistName"),
+        ):
             self._remember_resolution(track, target_id, cache)
             return target_id, "link"
         return None, None

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -21,6 +21,7 @@ from ..matching import (
     catalog_name, compute_diff, fuzzy_in, match_unresolved_removals,
     protect_removals, romanized,
     normalize_canonical_id, normalize_isrc, same_catalog_recording,
+    recording_version_signature, recording_versions_compatible,
     spotify_track_keys, track_addition_order_key, track_key, tracks_oldest_first,
 )
 
@@ -557,7 +558,8 @@ def _recover_archived_links(songs, source_key, target, source_tracks, known):
     A destination playlist can be deleted while the catalog entries SongMirror
     previously proved remain valid. Reusing those mappings avoids unnecessary
     provider search traffic (and is especially important while a catalog search
-    route is throttled). Direct links supplied by the caller remain authoritative.
+    route is throttled). Explicit recording conflicts in saved metadata reject
+    a historical link, including one produced by an older matcher.
     """
     source_ids = [track.get("id") for track in source_tracks if track.get("id")]
     recovered = archive.get_identity_crosswalk(
@@ -565,10 +567,11 @@ def _recover_archived_links(songs, source_key, target, source_tracks, known):
     recovered = {source_id: target_id for source_id, target_id in recovered.items()
                  if source_id not in known and target_id}
 
-    by_name = {}
+    by_name, by_id = {}, {}
     for candidate in archive.get_song_history(songs, target.source):
         target_id = target.track_id(candidate) or candidate.get("_archive_id")
         if target_id:
+            by_id.setdefault(str(target_id), candidate)
             by_name.setdefault(catalog_name(candidate.get("name", "")), []).append(
                 (target_id, candidate))
 
@@ -587,7 +590,15 @@ def _recover_archived_links(songs, source_key, target, source_tracks, known):
             # Fresh, conservative metadata evidence also repairs a stale direct
             # link or hard-identity candidate left by a deleted playlist.
             recovered[track["id"]] = matches[0][0]
-    return recovered
+    links = {**known, **recovered}
+    for track in source_tracks:
+        candidate = by_id.get(str(links.get(track.get("id"))))
+        if candidate and not recording_versions_compatible(
+            track.get("name"), track.get("artists") or track.get("artist"),
+            candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
+        ):
+            links.pop(track["id"], None)
+    return links
 
 
 def _enrich_hard_isrcs(songs, source_key, source_tracks):
@@ -638,9 +649,8 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
 
     links = (archive.get_links(songs, target.source, [t.get("id") for t in sp_tracks])
              if (source_provider or source_key) == "spotify" else {})
-    recovered_links = _recover_archived_links(
+    links = _recover_archived_links(
         songs, source_key, target, sp_tracks, links)
-    links = {**links, **recovered_links}  # fresh conservative archive evidence repairs stale links
     target.prefetch(sp_tracks, cache)
     expected_by_source = {
         source_id: set(target_ids)
@@ -1061,17 +1071,20 @@ def _unify_aliases(canon):
     as a duplicate each pass — and a flip between aliases reads as a user
     deletion. Matching: any exact spotify_track_keys overlap, else the same
     composite-key fuzzy tolerance the one-way removal guard trusts. Hard ids
-    never merge with each other — two ISRCs are two recordings.
+    never merge with each other — two ISRCs are two recordings. Explicit
+    recording qualifiers must agree even when the fuzzy title is a subset.
 
     `canon` values may be {cid: norm} dicts OR per-entry (cid, norm) sequences.
     Per-entry is strictly better: one identity often spans several releases with
     DIFFERENT titles ("Song" + "Song (From ...)"), and an alias may match only
     the copy a dict fold would have dropped."""
-    keysets = {}
+    keysets, versions, recordings = {}, {}, {}
     for by_cid in canon.values():
         pairs = by_cid.items() if hasattr(by_cid, "items") else by_cid
         for cid, norm in pairs:
             keysets.setdefault(cid, set()).update(spotify_track_keys(norm))
+            versions.setdefault(cid, set()).add(recording_version_signature(norm.get("name")))
+            recordings.setdefault(cid, []).append(norm)
     soft = sorted(cid for cid in keysets if cid.startswith("k:"))
     if not soft:
         return {}
@@ -1080,7 +1093,7 @@ def _unify_aliases(canon):
     by_key = {}
     for cid in hard:
         for k in keysets[cid]:
-            by_key.setdefault(k, cid)
+            by_key.setdefault(k, []).append(cid)
     # For the fuzzy comparison, the "name|artist" separator must become a space
     # (left in, it fuses different neighbor tokens on each side — "legends|woodkid"
     # vs "legends|arcane" — and blocks matches on mere credit reordering), and a
@@ -1090,15 +1103,25 @@ def _unify_aliases(canon):
         return {k, romanized(k)}
 
     flat = {cid: set().union(*(_variants(k) for k in ks)) for cid, ks in keysets.items()}
+
+    def compatible(left, right):
+        return versions[left] == versions[right] and all(
+            recording_versions_compatible(a.get("name"), a.get("artists"), b.get("name"), b.get("artists"))
+            for a in recordings[left] for b in recordings[right]
+        )
+
     alias, anchors = {}, []  # anchors: surviving k: ids (matched pairwise, never chained)
     for cid in soft:
         qs = _variants(cid[2:])
-        winner = next((by_key[k] for k in sorted(keysets[cid]) if k in by_key), None)
+        winner = next((h for k in sorted(keysets[cid]) for h in by_key.get(k, [])
+                       if compatible(cid, h)), None)
         if not winner:
-            winner = next((h for h in hard if any(fuzzy_in(q, flat[h]) for q in qs)), None)
+            winner = next((h for h in hard if any(fuzzy_in(q, flat[h]) for q in qs)
+                           and compatible(cid, h)), None)
         if not winner:
             winner = next((a for a in anchors
-                           if keysets[cid] & keysets[a] or any(fuzzy_in(q, flat[a]) for q in qs)), None)
+                           if (keysets[cid] & keysets[a] or any(fuzzy_in(q, flat[a]) for q in qs))
+                           and compatible(cid, a)), None)
         if winner:
             alias[cid] = winner
         else:

--- a/songmirror/engine/targets/deezer.py
+++ b/songmirror/engine/targets/deezer.py
@@ -18,7 +18,7 @@ from ...oauth import read_token, token_path
 from ..config import REQUEST_TIMEOUT, polite_sleep
 from ..matching import normalize_text, romanized, track_key
 from .base import MirrorTarget, TargetAuthError
-from .provider_utils import best_candidate, source_playlist_details
+from .provider_utils import best_candidate, compatible_isrc_candidates, source_playlist_details, title_with_version
 
 API = "https://api.deezer.com"
 DEFAULT_TOKEN_FILE = "data/deezer_oauth.json"
@@ -51,7 +51,7 @@ def _normalized_track(track):
                       if isinstance(album.get(key), str) and album.get(key)), "")
     return {
         "id": str(track.get("id")) if track.get("id") is not None else None,
-        "name": track.get("title", ""),
+        "name": title_with_version(track.get("title"), track.get("title_version")),
         "artist": ", ".join(artists),
         "artists": artists,
         "album": album.get("title") or album.get("displayTitle"),
@@ -411,8 +411,7 @@ class DeezerTarget(MirrorTarget):
         for track in source_tracks:
             ids = {
                 str(c["id"])
-                for c in cache["isrc"].get(track.get("isrc") or "", [])
-                if c and c.get("id")
+                for c in compatible_isrc_candidates(track, cache)
             }
             if links.get(track.get("id")):
                 ids.add(str(links[track["id"]]))
@@ -421,7 +420,7 @@ class DeezerTarget(MirrorTarget):
         return out
 
     def resolve(self, track, cache):
-        candidates = [c for c in cache["isrc"].get(track.get("isrc") or "", []) if c]
+        candidates = compatible_isrc_candidates(track, cache)
         if candidates:
             return best_candidate(track, candidates) or str(candidates[0]["id"]), "isrc"
         key = track_key(track.get("name", ""), " ".join(track.get("artists") or []))

--- a/songmirror/engine/targets/provider_utils.py
+++ b/songmirror/engine/targets/provider_utils.py
@@ -3,7 +3,32 @@
 import html
 import re
 
-from ..matching import score_candidate
+from ..matching import normalize_text, recording_versions_compatible, score_candidate
+
+
+def title_with_version(title, version):
+    """Keep separate provider recording labels visible to every identity path."""
+    title, version = str(title or ""), str(version or "").strip()
+    label = normalize_text(version)
+    if not label or f" {label} " in f" {normalize_text(title)} ":
+        return title
+    return f"{title} ({version.strip('()[] ')})".strip()
+
+
+def compatible_isrc_candidates(track, cache):
+    """Trust an ISRC crosswalk unless its title explicitly names another version.
+
+    ISRC results can outrank text or duration drift, but cannot bypass the
+    studio/live/acoustic boundary used by search and sync identity matching.
+    """
+    return [
+        candidate for candidate in cache["isrc"].get(track.get("isrc") or "", [])
+        if candidate and candidate.get("id")
+        and recording_versions_compatible(
+            track.get("name"), track.get("artists") or track.get("artist"),
+            candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
+        )
+    ]
 
 
 def source_playlist_details(playlist):

--- a/songmirror/engine/targets/qobuz.py
+++ b/songmirror/engine/targets/qobuz.py
@@ -15,7 +15,7 @@ from ...qobuz_web import parse_web_request
 from ..config import REQUEST_TIMEOUT, polite_sleep, required_env
 from ..matching import normalize_text, romanized, track_key
 from .base import MirrorTarget, TargetAuthError
-from .provider_utils import best_candidate, source_playlist_details
+from .provider_utils import best_candidate, compatible_isrc_candidates, source_playlist_details, title_with_version
 
 API = "https://www.qobuz.com/api.json/0.2"
 
@@ -41,7 +41,7 @@ def _normalized_track(track):
     return {
         "id": str(track.get("id")) if track.get("id") is not None else None,
         "relationship_id": track.get("playlist_track_id"),
-        "name": track.get("title", ""),
+        "name": title_with_version(track.get("title"), track.get("version")),
         "artist": artist,
         "artists": [artist] if artist else [""],
         "album": album.get("title"),
@@ -327,7 +327,7 @@ class QobuzTarget(MirrorTarget):
     def expected_ids(self, source_tracks, links, cache):
         out = {}
         for track in source_tracks:
-            ids = {str(c["id"]) for c in cache["isrc"].get(track.get("isrc") or "", []) if c.get("id")}
+            ids = {str(c["id"]) for c in compatible_isrc_candidates(track, cache)}
             if links.get(track.get("id")):
                 ids.add(str(links[track["id"]]))
             if ids:
@@ -335,7 +335,7 @@ class QobuzTarget(MirrorTarget):
         return out
 
     def resolve(self, track, cache):
-        candidates = cache["isrc"].get(track.get("isrc") or "", [])
+        candidates = compatible_isrc_candidates(track, cache)
         if candidates:
             return best_candidate(track, candidates) or str(candidates[0]["id"]), "isrc"
         key = track_key(track.get("name", ""), " ".join(track.get("artists") or []))

--- a/songmirror/engine/targets/tidal.py
+++ b/songmirror/engine/targets/tidal.py
@@ -25,7 +25,10 @@ from ..config import REQUEST_TIMEOUT, polite_sleep
 from ..logs import log_note, log_warn
 from ..matching import normalize_text, romanized, track_key
 from .base import MirrorTarget, TargetAuthError
-from .provider_utils import best_candidate, chunks, iso_duration_ms, source_playlist_details
+from .provider_utils import (
+    best_candidate, chunks, compatible_isrc_candidates, iso_duration_ms,
+    source_playlist_details, title_with_version,
+)
 
 API = "https://openapi.tidal.com/v2"
 MAX_ISRC_FILTER_VALUES = 20
@@ -201,7 +204,7 @@ class TidalTarget(MirrorTarget):
                 {
                     "id": str(resource.get("id") or identifier.get("id")),
                     "relationship_id": meta.get("itemId"),
-                    "name": attrs.get("title", ""),
+                    "name": title_with_version(attrs.get("title"), attrs.get("version")),
                     "artist": ", ".join(artists),
                     "artists": artists or [""],
                     "album": album or None,
@@ -538,7 +541,7 @@ class TidalTarget(MirrorTarget):
     def expected_ids(self, source_tracks, links, cache):
         out = {}
         for track in source_tracks:
-            ids = {str(c["id"]) for c in cache["isrc"].get(track.get("isrc") or "", []) if c.get("id")}
+            ids = {str(c["id"]) for c in compatible_isrc_candidates(track, cache)}
             if links.get(track.get("id")):
                 ids.add(str(links[track["id"]]))
             if ids:
@@ -546,7 +549,7 @@ class TidalTarget(MirrorTarget):
         return out
 
     def resolve(self, track, cache):
-        candidates = cache["isrc"].get(track.get("isrc") or "", [])
+        candidates = compatible_isrc_candidates(track, cache)
         if candidates:
             return best_candidate(track, candidates) or str(candidates[0]["id"]), "isrc"
         key = track_key(track.get("name", ""), " ".join(track.get("artists") or []))

--- a/songmirror/engine/targets/ytmusic.py
+++ b/songmirror/engine/targets/ytmusic.py
@@ -29,7 +29,10 @@ import requests
 
 from ..config import REQUEST_TIMEOUT, polite_sleep
 from ..logs import log, log_note, log_warn
-from ..matching import normalize_text, romanized, score_candidate, track_key
+from ..matching import (
+    featured_artists, normalize_text, recording_version_signature,
+    recording_versions_compatible, romanized, score_candidate, track_key,
+)
 from .base import MirrorTarget, TargetAuthError
 from .provider_utils import source_playlist_details
 
@@ -45,6 +48,8 @@ _TITLE_SEPARATOR = r"(?:\s+-\s+|\s*[–—]\s*|\s+\|\s+|:\s+)"
 _TITLE_PREFIX_RE = re.compile(
     rf"^(?P<prefix>.+?){_TITLE_SEPARATOR}(?P<title>.+)$"
 )
+_COLLABORATOR_RE = re.compile(r"\s+(?:x|×|&|feat\.?|ft\.?)\s+|\s*,\s*", re.IGNORECASE)
+_PUBLISHER_RE = re.compile(r"\b(?:production|productions|records|recordings)\b")
 _TRAILING_BRACKET_RE = re.compile(
     r"\s*(?:\((?P<paren>[^()]*)\)|\[(?P<bracket>[^\[\]]*)\]|\{(?P<brace>[^{}]*)\})\s*$"
 )
@@ -72,6 +77,7 @@ _VIDEO_PRODUCTION_TAGS = {
     "official music clip",
     "official music video",
     "official music video clip",
+    "official performance video",
     "official mv",
     "official video",
     "official video clip",
@@ -81,11 +87,19 @@ _VIDEO_PRODUCTION_TAGS = {
     "video clip",
     "visualiser",
     "visualizer",
+    "visualizer music video",
+    "visualiser music video",
+    "resmi muzik videosu",
+    "resmi ai muzik videosu",
+    "resmi video",
+    "resmi video klip",
+    "resmi klip",
+    "sarki sozleri",
 }
 _VIDEO_QUALITY_TAGS = {
     "4k", "8k", "720p", "1080p", "1440p", "2160p", "hd", "hq", "uhd",
 }
-_PRODUCER_CREDIT_RE = re.compile(r"prod(?:uced)?\s+by\s+.+")
+_PRODUCER_CREDIT_RE = re.compile(r"(?:prod\s+(?:by\s+)?|produced\s+by\s+).+")
 
 
 ROTATE_URL = "https://accounts.youtube.com/RotateCookies"
@@ -204,7 +218,7 @@ def _channel_name_keys(channel):
 
 
 def _is_video_production_tag(value):
-    normalized = normalize_text(value)
+    normalized = romanized(value)
     if _PRODUCER_CREDIT_RE.fullmatch(normalized):
         return True
     words = normalized.split()
@@ -214,25 +228,65 @@ def _is_video_production_tag(value):
     )
 
 
-def _clean_data_api_video_title(title, channel):
-    """Turn an unstructured Data API video title into a search-safe track name.
+def _credit_matches(credit, artist):
+    """Accept a credited artist's channel spelling or longer display name."""
+    key = normalize_text(credit)
+    compact = key.replace(" ", "")
+    return any(
+        compact == channel.replace(" ", "")
+        or (len(compact) >= 4 and channel.startswith(key + " "))
+        for channel in _channel_name_keys(artist)
+    )
 
-    Prefix removal is gated on the owner channel, so a legitimate title such as
-    ``Love - Hate`` is never split just because it contains a dash. Production
-    labels are removed only when they occupy a complete trailing bracket or a
-    separator-delimited suffix. Creative recording qualifiers (live, acoustic,
-    remix, remaster, featured artists) deliberately remain for match safety.
+
+def _clean_video_metadata(title, artists):
+    """Separate confirmed music credits from an unstructured video title.
+
+    A channel can name one collaborator, a longer artist display name, or a
+    publisher. Whole credited band names take precedence over splitting an
+    ampersand. Production labels are removable; recording qualifiers are not.
     """
     raw = str(title or "").strip()
     if not raw:
-        return ""
+        return "", artists
 
     cleaned = raw
+    prefix_guests = []
     prefix = _TITLE_PREFIX_RE.match(cleaned)
-    if prefix and normalize_text(prefix.group("prefix")) in _channel_name_keys(channel):
-        candidate = prefix.group("title").strip()
-        if candidate:
-            cleaned = candidate
+    if prefix:
+        credit = prefix.group("prefix").strip()
+        if any(_credit_matches(credit, artist) for artist in artists):
+            credits = [credit]
+        else:
+            credits = [part.strip() for part in _COLLABORATOR_RE.split(credit) if part.strip()]
+        confirmed = any(
+            _credit_matches(part, artist) for part in credits for artist in artists
+        )
+        publisher = any(_PUBLISHER_RE.search(romanized(artist)) for artist in artists)
+        production = _TRAILING_BRACKET_RE.search(raw)
+        collaboration = len(credits) > 1 and production is not None and any(
+            value is not None and _is_video_production_tag(value)
+            for value in production.groups()
+        )
+        if confirmed or publisher or collaboration:
+            cleaned = prefix.group("title").strip()
+            artists = credits
+            # A feature is recording information as well as an artist credit.
+            # Keep it in the normalized title when the video puts it first.
+            prefix_guests = featured_artists(credit)
+
+    # Some uploader titles concatenate an uppercase artist credit and a song
+    # without punctuation. Require the complete credit at a word boundary.
+    if cleaned == raw:
+        for boundary in re.finditer(r"\s+", raw):
+            credit = raw[:boundary.start()]
+            if credit.isupper() and any(
+                normalize_text(credit).replace(" ", "")
+                in {key.replace(" ", "") for key in _channel_name_keys(artist)}
+                for artist in artists
+            ):
+                cleaned = raw[boundary.end():]
+                break
 
     while cleaned:
         bracket = _TRAILING_BRACKET_RE.search(cleaned)
@@ -246,11 +300,18 @@ def _clean_data_api_video_title(title, channel):
                 )
                 if value is not None
             )
-            if _is_video_production_tag(tag):
+            parts = re.split(r"\s*(?:[|·]|\s+-\s+)\s*", tag)
+            remaining = [part for part in parts if not _is_video_production_tag(part)]
+            if not remaining:
                 candidate = cleaned[:bracket.start()].rstrip(" -–—|:")
                 if candidate:
                     cleaned = candidate
                     continue
+            elif len(remaining) != len(parts):
+                # "Version 2.0 - Resmi Müzik Videosu" still identifies a
+                # different recording after the production label is removed.
+                start = next(i for i in range(bracket.start(), bracket.end()) if cleaned[i] in "([{")
+                cleaned = cleaned[:start + 1] + " - ".join(remaining) + cleaned[-1]
 
         suffix = _TRAILING_SEPARATOR_RE.match(cleaned)
         if suffix and _is_video_production_tag(suffix.group("tag")):
@@ -260,33 +321,68 @@ def _clean_data_api_video_title(title, channel):
                 continue
         break
 
-    return cleaned or raw
+    if prefix_guests and not featured_artists(cleaned):
+        cleaned += f" (feat. {', '.join(prefix_guests)})"
+    return cleaned or raw, artists
 
 
-def _normalized_data_api_playlist_item(item):
+def _clean_data_api_video_title(title, channel):
+    return _clean_video_metadata(title, [channel])[0]
+
+
+def _normalized_data_api_playlist_item(item, music_metadata=None):
     video_id = item.get("contentDetails", {}).get("videoId")
     if not video_id:
         return None
     snippet = item.get("snippet", {})
     artist = _artist_from_channel(snippet.get("videoOwnerChannelTitle", ""))
+    name, artists = _clean_video_metadata(snippet.get("title", ""), [artist] if artist else [""])
     thumbnails = snippet.get("thumbnails") or {}
     image = next((
         (thumbnails.get(size) or {}).get("url")
         for size in ("medium", "high", "default")
         if (thumbnails.get(size) or {}).get("url")
     ), "")
-    return {
+    track = {
         "id": video_id,
         "videoId": video_id,
         "playlistItemId": item.get("id"),
-        "name": _clean_data_api_video_title(snippet.get("title", ""), artist),
-        "artist": artist,
-        "artists": [artist] if artist else [""],
+        "name": name,
+        "artist": ", ".join(artists),
+        "artists": artists,
         "album": None,
         "duration_ms": None,
         "added_at": snippet.get("publishedAt") or "",
         "image": image,
     }
+    if (
+        isinstance(music_metadata, dict)
+        and music_metadata.get("videoId") == video_id
+        and isinstance(music_metadata.get("title"), str)
+        and isinstance(music_metadata.get("artists"), list)
+        and all(
+            isinstance(credit, dict) and isinstance(credit.get("name"), str)
+            for credit in music_metadata["artists"]
+        )
+    ):
+        music = _normalized_youtubei_playlist_track(music_metadata)
+        if music and music["name"] and any(music["artists"]):
+            raw_name, raw_artists = _clean_video_metadata(snippet.get("title", ""), music["artists"])
+            # The same video can appear in Music with its studio title. Keep
+            # explicit live/remix/version information from the original video.
+            raw_markers, raw_details = recording_version_signature(raw_name)
+            music_markers, music_details = recording_version_signature(music["name"])
+            keep_raw = (raw_markers - music_markers or raw_details - music_details) or (
+                featured_artists(raw_name) and not recording_versions_compatible(
+                    raw_name, raw_artists, music["name"], music["artists"],
+                )
+            )
+            track.update({
+                "name": raw_name if keep_raw else music["name"],
+                "artist": music["artist"], "artists": music["artists"],
+                "album": music["album"], "duration_ms": music["duration_ms"],
+            })
+    return track
 
 
 def _normalized_youtubei_playlist_track(track):
@@ -301,6 +397,7 @@ def _normalized_youtubei_playlist_track(track):
         )
         if artist
     ]
+    name, artists = _clean_video_metadata(track.get("title", ""), artists or [""])
     album = track.get("album")
     duration_seconds = track.get("duration_seconds")
     thumbnails = track.get("thumbnails") or []
@@ -313,7 +410,7 @@ def _normalized_youtubei_playlist_track(track):
         "id": video_id,
         "videoId": video_id,
         "setVideoId": track.get("setVideoId"),
-        "name": track.get("title", ""),
+        "name": name,
         "artist": ", ".join(artists),
         "artists": artists or [""],
         "album": album.get("name") if isinstance(album, dict) else None,
@@ -510,22 +607,43 @@ class YTMusicTarget(MirrorTarget):
             raise RuntimeError(
                 "YouTube Music playlist read incomplete: an empty page advertised more tracks"
             )
+        return self._playlist_items(playlist["playlistId"], items), next_cursor
+
+    def _playlist_items(self, playlist_id, items):
+        """Use Music's credits for matching, retaining Data API occurrences.
+
+        Public metadata is optional: private playlists and an unavailable Music
+        endpoint still use the successful authenticated read. Match by video id,
+        never position, since unavailable videos can shift the public listing.
+        Progressive reads request only the prefix needed for the current page.
+        """
+        music = {}
+        public = getattr(self, "_ytm", None)
+        if public is not None and items:
+            positions = [item.get("snippet", {}).get("position") for item in items]
+            limit = max([len(items), *(position + 1 for position in positions if isinstance(position, int))])
+            try:
+                data = public.get_playlist(str(playlist_id), limit=limit)
+                music = {
+                    row["videoId"]: row for row in data.get("tracks") or []
+                    if isinstance(row, dict) and row.get("videoId")
+                }
+            except Exception:
+                pass  # The authenticated Data API remains authoritative.
         return [
-            track
-            for item in items
-            if (track := _normalized_data_api_playlist_item(item)) is not None
-        ], next_cursor
+            track for item in items
+            if (track := _normalized_data_api_playlist_item(
+                item, music.get(item.get("contentDetails", {}).get("videoId"))
+            )) is not None
+        ]
 
     def playlist_tracks(self, playlist):
-        return [
-            track
-            for item in self._paged("playlistItems", {
-                "part": "snippet,contentDetails",
-                "playlistId": playlist["playlistId"],
-                "maxResults": 50,
-            })
-            if (track := _normalized_data_api_playlist_item(item)) is not None
-        ]
+        items = list(self._paged("playlistItems", {
+            "part": "snippet,contentDetails",
+            "playlistId": playlist["playlistId"],
+            "maxResults": 50,
+        }))
+        return self._playlist_items(playlist["playlistId"], items)
 
     def _liked_playlist_id(self):
         data = self._request(

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -91,17 +91,17 @@ def test_scan_does_not_consume_identity_rebinding_history(tmp_path):
     conn.close()
 
 
-def test_version_boundary_folds_are_held_not_removed(tmp_path):
-    # A live video (fuzzy key, no ISRC) folds into the studio identity so the
-    # sync stays quiet — but the studio copy must NEVER be deleted as its
-    # "duplicate": the version markers differ, so it lands in `held`.
+def test_version_boundaries_remain_distinct_and_are_not_removed(tmp_path):
+    # A live video and a studio track are separate desired recordings. Neither
+    # may be folded into or deleted as a duplicate of the other.
     conn = archive.connect(str(tmp_path / "s.db"))
     yt = _Peer("ytmusic", [_t("v-live", "American Pie (Live)", "Don McLean"),
                            _t("v-studio", "American Pie", "Don McLean", isrc="S1")])
     entries, _ = dedupe.scan([yt], {"ytmusic": {"id": "y"}}, _caches("ytmusic"), conn, "mix")
     plan, held = dedupe.dup_plan([yt], entries)
     assert plan["ytmusic"] == []
-    assert [raw["id"] for _, _, raw, _ in held["ytmusic"]] == ["v-studio"]
+    assert held["ytmusic"] == []
+    assert len({entry[0] for entry in entries["ytmusic"]}) == 2
     # …while a same-recording decoration ("Official Audio") still dedupes:
     yt2 = _Peer("ytmusic", [_t("v1", "stevie (Official Audio)", "Kasabian"),
                             _t("v2", "stevie", "Kasabian", isrc="K1")])

--- a/tests/test_recording_versions.py
+++ b/tests/test_recording_versions.py
@@ -1,0 +1,162 @@
+"""A different recording is not a substitute for a source track."""
+
+import pytest
+
+from songmirror.engine import archive
+from songmirror.engine.matching import compute_diff, same_catalog_recording, score_candidate, track_key
+from songmirror.engine.targets.base import _normalize, _recover_archived_links, _unify_aliases
+from songmirror.engine.targets.amazon_music import AmazonMusicTarget
+from songmirror.engine.targets.apple import AppleMusicTarget
+from songmirror.engine.targets.deezer import DeezerTarget, _normalized_track
+from songmirror.engine.targets.qobuz import QobuzTarget
+from songmirror.engine.targets.tidal import TidalTarget
+
+
+@pytest.mark.parametrize("label", ["Acoustic", "Akustik", "Acústico", "Acoustique", "Unplugged", "Stripped"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_studio_and_acoustic_recordings_never_match(label, reverse):
+    source, candidate = "A Song", f"A Song ({label})"
+    if reverse:
+        source, candidate = candidate, source
+    assert not score_candidate(source, ["Artist"], 180000, candidate, "Artist", 180000)[1]
+
+
+def test_featured_credit_does_not_hide_a_recording_version_in_the_cache_key():
+    assert track_key("A Song feat. Guest (Acoustic)", "Artist") != track_key(
+        "A Song feat. Guest", "Artist"
+    )
+
+
+@pytest.mark.parametrize("label", ["Acoustic", "Akustik"])
+@pytest.mark.parametrize("hard_studio", [True, False])
+def test_fuzzy_sync_identity_does_not_fold_acoustic_into_studio(label, hard_studio):
+    studio = _normalize({"name": "A Song", "artists": ["Artist"]}, "spotify")
+    acoustic = _normalize({"name": f"A Song ({label})", "artists": ["Artist"]}, "ytmusic")
+    hard, soft = (studio, acoustic) if hard_studio else (acoustic, studio)
+    soft_id = "k:" + track_key(soft["name"], "Artist")
+    assert _unify_aliases({"spotify": {"i:recording": hard}, "ytmusic": {soft_id: soft}}) == {}
+
+
+def test_deezer_separate_version_field_is_visible_to_the_matcher():
+    track = _normalized_track({
+        "id": 1, "title": "A Song", "title_version": "(Acoustic)",
+        "artist": {"name": "Artist"}, "duration": 180,
+    })
+    assert not score_candidate("A Song", ["Artist"], 180000, track["name"], track["artist"], track["duration_ms"])[1]
+
+
+@pytest.mark.parametrize("target_class", [DeezerTarget, QobuzTarget, TidalTarget, AmazonMusicTarget, AppleMusicTarget])
+@pytest.mark.parametrize("qualifier", ["Acoustic", "Dub", "feat. Guest", "First DJ Remix"])
+def test_isrc_fallback_does_not_ignore_an_explicit_recording_conflict(target_class, qualifier):
+    target = target_class.__new__(target_class)
+    target._search = lambda *_args: None  # Apple's search; others use the cached miss.
+    cache = {
+        "isrc": {"ISRC1": [{"id": "variant", "name": f"A Song ({qualifier})", "artist": "Artist", "duration_ms": 180000}]},
+        "search": {track_key("A Song", "Artist"): None},
+    }
+    track = {"id": "source", "name": "A Song", "artists": ["Artist"], "duration_ms": 180000, "isrc": "ISRC1"}
+
+    assert target.resolve(track, cache)[0] is None
+    assert target.expected_ids([track], {}, cache) == {}
+
+    cache["isrc"]["ISRC1"].append({"id": "studio", "name": "A Song", "artist": "Artist", "duration_ms": 180000})
+    assert target.resolve(track, cache) == ("studio", "isrc")
+    assert target.expected_ids([track], {}, cache) == {"source": {"studio"}}
+
+
+@pytest.mark.parametrize("label", [
+    "Dub", "Club Mix", "Extended Mix", "Radio Edit", "Single Edit", "VIP",
+    "A Cappella", "Orchestral", "Re-recorded", "Slowed + Reverb", "Nightcore",
+    "Instrumental", "Demo", "Karaoke", "Cover", "Solo Version", "Remix",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_studio_and_other_recording_variants_never_match(label, reverse):
+    source, candidate = "A Song", f"A Song ({label})"
+    if reverse:
+        source, candidate = candidate, source
+    assert not score_candidate(source, ["Artist"], 180000, candidate, "Artist", 180000)[1]
+
+
+@pytest.mark.parametrize(("source", "candidate"), [
+    ("A Song (First DJ Remix)", "A Song (Second DJ Remix)"),
+    ("A Song (Live at Wembley)", "A Song (Live at Glastonbury)"),
+    ("A Song (Version 1)", "A Song (Version 2)"),
+    ("A Song (Radio Edit)", "A Song (Single Edit)"),
+])
+def test_different_variants_within_the_same_family_do_not_match(source, candidate):
+    assert not score_candidate(source, ["Artist"], 180000, candidate, "Artist", 180000)[1]
+
+
+@pytest.mark.parametrize(("source", "source_artists", "candidate", "candidate_artist", "expected"), [
+    ("A Song", ["Artist"], "A Song (feat. Guest)", "Artist", False),
+    ("A Song (feat. Guest)", ["Artist"], "A Song", "Artist", False),
+    ("A Song (feat. First Guest)", ["Artist"], "A Song (feat. Second Guest)", "Artist", False),
+    ("A Song (feat. Guest)", ["Artist"], "A Song", "Artist, Guest", True),
+    ("A Song", ["Artist", "Guest"], "A Song (feat. Guest)", "Artist", True),
+    ("A Song feat. Guest (Acoustic)", ["Artist"], "A Song (Acoustic) [ft. Guest]", "Artist", True),
+    ("A Song (feat. Live)", ["Artist"], "A Song", "Artist, Live", True),
+    ("A Song (Acoustic Version)", ["Artist"], "A Song - Akustik", "Artist", True),
+])
+def test_featured_credit_and_variant_spelling_must_describe_the_same_recording(
+    source, source_artists, candidate, candidate_artist, expected,
+):
+    assert score_candidate(source, source_artists, 180000, candidate, candidate_artist, 180000)[1] is expected
+
+
+def test_featured_recording_has_a_distinct_cache_key_unless_the_artist_credit_agrees():
+    assert track_key("A Song (feat. Guest)", "Artist") != track_key("A Song", "Artist")
+    assert track_key("A Song (feat. Guest)", "Artist") == track_key("A Song", "Artist, Guest")
+
+
+def test_featured_variant_does_not_suppress_an_add_or_become_a_duplicate():
+    studio = {"id": "studio", "name": "A Song", "artists": ["Artist"], "duration_ms": 180000}
+    featured = {"id": "feature", "name": "A Song (feat. Guest)", "artist": "Artist", "artists": ["Artist"], "duration_ms": 180000}
+    assert compute_diff([studio], [featured], {}, lambda track: track["id"])[0] == [studio]
+    assert not same_catalog_recording(studio, featured)
+
+
+@pytest.mark.parametrize("qualifier", ["Dub", "feat. Guest", "First DJ Remix"])
+def test_sync_identity_does_not_fold_other_recording_variants(qualifier):
+    studio = _normalize({"name": "A Song", "artists": ["Artist"]}, "spotify")
+    variant = _normalize({"name": f"A Song ({qualifier})", "artists": ["Artist"]}, "ytmusic")
+    soft_id = "k:" + track_key(variant["name"], "Artist")
+    assert _unify_aliases({"spotify": {"i:recording": studio}, "ytmusic": {soft_id: variant}}) == {}
+
+
+def test_other_providers_preserve_separate_version_fields():
+    from songmirror.engine.targets.qobuz import _normalized_track as qobuz_track
+    assert qobuz_track({"id": 1, "title": "A Song", "version": "Dub"})["name"] == "A Song (Dub)"
+    track = TidalTarget._tracks_from_body({"data": [{
+        "id": "1", "type": "tracks", "attributes": {"title": "A Song", "version": "Acoustic"},
+    }]})[0]
+    assert track["name"] == "A Song (Acoustic)"
+    # A provider may already have included the same label in its display title.
+    assert _normalized_track({"title": "A Song (Acoustic)", "title_version": "(Acoustic)"})["name"] == "A Song (Acoustic)"
+
+
+def test_a_wrong_archived_link_does_not_suppress_the_correct_recording(tmp_path):
+    target = DeezerTarget.__new__(DeezerTarget)
+    source = {"id": "source", "name": "A Song", "artists": ["Artist"], "duration_ms": 180000}
+    variant = {"id": "variant", "name": "A Song (Dub)", "artist": "Artist", "artists": ["Artist"], "duration_ms": 180000}
+    conn = archive.connect(str(tmp_path / "songs.db"))
+    try:
+        archive.upsert_many(conn, "deezer", [variant])
+        assert _recover_archived_links(conn, "spotify", target, [source], {"source": "variant"}) == {}
+        to_add, to_remove = compute_diff([source], [variant], {"source": {"variant"}}, target.track_id)
+        assert to_add == [source]
+        assert to_remove == [variant]
+    finally:
+        conn.close()
+
+
+def test_apple_catalog_link_validation_rechecks_the_recording_for_each_source():
+    from types import SimpleNamespace
+    target = AppleMusicTarget.__new__(AppleMusicTarget)
+    target.storefront = "us"
+    target._request = lambda *_args, **_kwargs: SimpleNamespace(json=lambda: {"data": [{
+        "id": "variant", "attributes": {"name": "A Song (Dub)", "artistName": "Artist"},
+    }]})
+    cache = {"isrc": {"ISRC1": []}}
+    source = {"name": "A Song", "artists": ["Artist"], "isrc": "ISRC1"}
+    assert target.validate_link(source, "variant", cache) == (None, None)
+    assert target.validate_link({**source, "name": "A Song (Dub)"}, "variant", cache) == ("variant", "link")

--- a/tests/test_resolve_cache.py
+++ b/tests/test_resolve_cache.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
-from songmirror.engine.runner import load_cache, save_cache
+from songmirror.engine.runner import MATCHING_CACHE_VERSION, load_cache, save_cache
 from songmirror.services.resolve_cache import (
     ResolveCacheBusy, ResolveCacheError, ResolveCacheStore,
 )
@@ -14,12 +14,30 @@ from songmirror.web import create_app
 
 
 # -- provenance round-trip ---------------------------------------------------
-def test_a_cache_written_before_provenance_loads_with_no_manual_keys(tmp_path):
+def test_legacy_automatic_matches_are_invalidated(tmp_path):
     path = tmp_path / "cache.json"
     path.write_text(json.dumps({"isrc": {}, "search": {"a|b": "1"}}), encoding="utf-8")
     cache = load_cache(str(path))
     assert cache["manual"] == set()
-    assert cache["search"] == {"a|b": "1"}
+    assert cache["search"] == {}
+    assert cache["dirty"] is True
+
+
+def test_legacy_migration_preserves_manual_choices_and_refreshes_isrc_metadata(tmp_path):
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({
+        "isrc": {"ISRC": [{"id": "version-was-omitted"}]},
+        "search": {"a|b": "automatic", "c|d": "chosen", "e|f": None},
+        "manual": ["c|d"],
+    }), encoding="utf-8")
+    cache = load_cache(path)
+    assert cache["isrc"] == {}
+    assert cache["search"] == {"c|d": "chosen"}
+    assert cache["manual"] == {"c|d"}
+    save_cache(path, cache)
+    reloaded = load_cache(path)
+    assert reloaded["search"] == {"c|d": "chosen"}
+    assert reloaded["dirty"] is False
 
 
 def test_manual_keys_round_trip_through_save_and_load(tmp_path):
@@ -33,7 +51,7 @@ def test_manual_keys_round_trip_through_save_and_load(tmp_path):
     # Serialized as a sorted list so the file stays diffable, and still carries
     # the two keys every existing reader expects.
     written = json.loads(open(path, encoding="utf-8").read())
-    assert written == {"isrc": {}, "search": {"song|artist": "trk1"}, "manual": ["song|artist"]}
+    assert written == {"matching_version": MATCHING_CACHE_VERSION, "isrc": {}, "search": {"song|artist": "trk1"}, "manual": ["song|artist"]}
     assert load_cache(path)["manual"] == {"song|artist"}
 
 
@@ -71,7 +89,7 @@ def _store(tmp_path, monkeypatch, rows, *, manual=(), provider="deezer", sync=No
         monkeypatch.setenv(env_key, str(tmp_path / f"{name}_cache.json"))
     path = str(tmp_path / f"{provider}_cache.json")
     with open(path, "w", encoding="utf-8") as f:
-        json.dump({"isrc": {}, "search": rows, "manual": list(manual)}, f)
+        json.dump({"matching_version": MATCHING_CACHE_VERSION, "isrc": {}, "search": rows, "manual": list(manual)}, f)
     return ResolveCacheStore(SettingsStore(dir=tmp_path), sync), path
 
 

--- a/tests/test_targets_accessors.py
+++ b/tests/test_targets_accessors.py
@@ -666,7 +666,9 @@ def test_apple_empty_isrc_result_keeps_only_a_live_archived_catalog_id():
     track = {"isrc": "WRONGEDITION", "duration_ms": 1000}
     cache = {"isrc": {"WRONGEDITION": []}}
 
-    target._request = lambda *args, **kwargs: object()
+    target._request = lambda *args, **kwargs: type("Response", (), {
+        "json": lambda _self: {"data": [{"id": "still-live", "attributes": {}}]},
+    })()
     assert target.validate_link(track, "still-live", cache) == ("still-live", "link")
 
     target._validated_catalog_ids.clear()

--- a/tests/test_ytmusic_metadata.py
+++ b/tests/test_ytmusic_metadata.py
@@ -1,0 +1,221 @@
+"""Source metadata failures reproduced from public music-video playlists."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from songmirror.engine.targets import ytmusic
+from songmirror.engine.targets.ytmusic import (
+    YTMusicTarget,
+    _normalized_data_api_playlist_item,
+    _normalized_youtubei_playlist_track,
+)
+
+
+def video_item(title, channel, video_id="video-1"):
+    return {
+        "id": "playlist-entry-1",
+        "contentDetails": {"videoId": video_id},
+        "snippet": {
+            "title": title,
+            "videoOwnerChannelTitle": channel,
+            "publishedAt": "2026-09-01T12:00:00Z",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("title", "channel", "name", "artists"),
+    [
+        (
+            "BLOK3 x POİZİ - ÇOK GÜZEL GÜLÜYORSUN (Official Music Video)",
+            "Blok3", "ÇOK GÜZEL GÜLÜYORSUN", ["BLOK3", "POİZİ"],
+        ),
+        (
+            "ALLAME x SAGOPA KAJMER - BİR ŞANSIM DAHA OLSA",
+            "Allame Official", "BİR ŞANSIM DAHA OLSA", ["ALLAME", "SAGOPA KAJMER"],
+        ),
+        (
+            "Tan Taşçı - Gidişat (Resmi Müzik Videosu)",
+            "Tan Taşçı", "Gidişat", ["Tan Taşçı"],
+        ),
+        (
+            "Sezen Aksu - Firuze (Lyrics | Şarkı Sözleri)",
+            "Sezen Aksu", "Firuze", ["Sezen Aksu"],
+        ),
+        (
+            "Motive & UZI - ANAKONDA'S (Official Visualizer)",
+            "S.O.S", "ANAKONDA'S", ["Motive", "UZI"],
+        ),
+        (
+            "Enis Arıkan - Lafı Mı Olur (Official Video)",
+            "Poll Production", "Lafı Mı Olur", ["Enis Arıkan"],
+        ),
+        (
+            "AURA - PES (Official Music Video)",
+            "AURA GIRLS", "PES", ["AURA"],
+        ),
+        (
+            "Murat Ceylan Wish | İYİ KÖPEK (Official Music Video)",
+            "MuratCeylanWish", "İYİ KÖPEK", ["Murat Ceylan Wish"],
+        ),
+    ],
+)
+def test_video_metadata_uses_confirmed_credits_and_removes_production_labels(
+    title, channel, name, artists,
+):
+    track = _normalized_data_api_playlist_item(video_item(title, channel))
+
+    assert track["name"] == name
+    assert track["artists"] == artists
+    assert track["playlistItemId"] == "playlist-entry-1"
+
+
+def test_browser_playlist_video_metadata_can_still_need_cleanup():
+    track = _normalized_youtubei_playlist_track({
+        "videoId": "video-1", "setVideoId": "entry-1",
+        "title": "Pau - Kehanet", "artists": [{"name": "Pau"}],
+    })
+
+    assert track["name"] == "Kehanet"
+    assert track["artists"] == ["Pau"]
+    assert track["setVideoId"] == "entry-1"
+
+
+@pytest.mark.parametrize(
+    ("title", "channel", "name", "artists"),
+    [
+        ("Hadise - Ara Beni | Official Visualizer", "Hadise Acikgoz", "Ara Beni", ["Hadise"]),
+        ("Can Demir - Gel Dedim Geldin", "netd müzik", "Gel Dedim Geldin", ["Candemirtheater"]),
+    ],
+)
+def test_data_api_playlist_uses_music_credits_for_the_same_video(
+    title, channel, name, artists,
+):
+    target = YTMusicTarget.__new__(YTMusicTarget)
+    target._paged = lambda *_args: iter([video_item(title, channel)])
+    target._ytm = SimpleNamespace(get_playlist=lambda *_args, **_kwargs: {
+        "tracks": [{
+            "videoId": "video-1", "title": name,
+            "artists": [{"name": artist} for artist in artists],
+        }],
+    })
+
+    tracks = target.playlist_tracks({"playlistId": "public-chart"})
+
+    assert len(tracks) == 1
+    assert tracks[0]["name"] == name
+    assert tracks[0]["artists"] == artists
+    assert tracks[0]["playlistItemId"] == "playlist-entry-1"
+    assert tracks[0]["added_at"] == "2026-09-01T12:00:00Z"
+
+
+@pytest.mark.parametrize(
+    ("title", "artist", "name", "artists"),
+    [
+        ("Earth, Wind & Fire - September (Official Video)", "Earth, Wind & Fire", "September", ["Earth, Wind & Fire"]),
+        ("Love - Hate (Official Video)", "Roxy Music", "Love - Hate", ["Roxy Music"]),
+        ("Queen of Hearts", "Queen", "Queen of Hearts", ["Queen"]),
+        ("BLOK3 - KAYIP KALP (Live at Wembley) [4K]", "BLOK3", "KAYIP KALP (Live at Wembley)", ["BLOK3"]),
+        ("Tan Taşçı - Gidişat (Version 2.0 - Resmi Müzik Videosu)", "Tan Taşçı", "Gidişat (Version 2.0)", ["Tan Taşçı"]),
+    ],
+)
+def test_cleanup_preserves_bands_titles_and_recording_versions(title, artist, name, artists):
+    track = _normalized_data_api_playlist_item(video_item(title, artist))
+    assert track["name"] == name
+    assert track["artists"] == artists
+
+
+@pytest.mark.parametrize("metadata", [
+    {"videoId": "other-video", "title": "Another song", "artists": [{"name": "Another artist"}]},
+    {"videoId": "video-1", "title": "Another song", "artists": [None]},
+    {"videoId": "video-1", "title": 42, "artists": [{"name": "Another artist"}]},
+    {"videoId": "video-1", "title": "Another song", "artists": []},
+])
+def test_unrelated_or_malformed_music_metadata_does_not_replace_the_video(metadata):
+    item = video_item("BLOK3 - KAYIP KALP (Official Music Video)", "BLOK3")
+    assert _normalized_data_api_playlist_item(item, metadata) == _normalized_data_api_playlist_item(item)
+
+
+@pytest.mark.parametrize("qualifier", [
+    "Live at Wembley", "Akustik", "Dub", "Club Mix", "First DJ Remix", "feat. Guest",
+])
+def test_music_metadata_cannot_erase_an_explicit_recording_variant(qualifier):
+    track = _normalized_data_api_playlist_item(
+        video_item(f"BLOK3 - KAYIP KALP ({qualifier})", "BLOK3"),
+        {"videoId": "video-1", "title": "Kayıp Kalp", "artists": [{"name": "BLOK3"}]},
+    )
+    assert track["name"] == f"KAYIP KALP ({qualifier})"
+
+
+def test_music_metadata_cannot_replace_a_named_remix_with_another_remix():
+    track = _normalized_data_api_playlist_item(
+        video_item("Artist - Song (First DJ Remix)", "Artist"),
+        {"videoId": "video-1", "title": "Song (Second DJ Remix)", "artists": [{"name": "Artist"}]},
+    )
+    assert track["name"] == "Song (First DJ Remix)"
+
+
+def test_featured_artist_prefix_preserves_the_featured_recording():
+    track = _normalized_data_api_playlist_item(video_item("Artist feat. Guest - Song (Official Audio)", "Artist"))
+    assert track["name"] == "Song (feat. Guest)"
+    assert track["artists"] == ["Artist", "Guest"]
+
+
+@pytest.mark.parametrize(("title", "expected"), [
+    ("kozzy (prod. Artz & Bugy)", "kozzy"),
+    ("Song [Visualizer Music Video]", "Song"),
+    ("Song (Live) [Official Performance Video]", "Song (Live)"),
+])
+def test_production_credits_are_not_recording_variants(title, expected):
+    track = _normalized_data_api_playlist_item(video_item(title, "Artist"))
+    assert track["name"] == expected
+
+
+def test_private_playlist_keeps_the_authenticated_read_when_public_metadata_fails():
+    target = YTMusicTarget.__new__(YTMusicTarget)
+    target._paged = lambda *_args: iter([video_item("BLOK3 - KAYIP KALP", "BLOK3")])
+
+    def unavailable(*_args, **_kwargs):
+        raise KeyError("contents")
+
+    target._ytm = SimpleNamespace(get_playlist=unavailable)
+    assert target.playlist_tracks({"playlistId": "private"})[0]["name"] == "KAYIP KALP"
+
+
+def test_progressive_data_api_read_bounds_metadata_and_matches_video_ids():
+    item = video_item("Hadise - Ara Beni", "Hadise Acikgoz")
+    item["snippet"]["position"] = 500
+    calls = []
+
+    def metadata(playlist_id, *, limit):
+        calls.append((playlist_id, limit))
+        return {"tracks": [
+            {"videoId": "unrelated", "title": "Wrong song", "artists": [{"name": "Wrong artist"}]},
+            {"videoId": "video-1", "title": "Ara Beni", "artists": [{"name": "Hadise"}]},
+        ]}
+
+    target = YTMusicTarget.__new__(YTMusicTarget)
+    target._request = lambda *_args, **_kwargs: SimpleNamespace(json=lambda: {
+        "items": [item], "nextPageToken": "next-page",
+    })
+    target._ytm = SimpleNamespace(get_playlist=metadata)
+    tracks, cursor = target.playlist_tracks_page({"playlistId": "chart"}, "previous-page")
+
+    assert calls == [("chart", 501)]
+    assert cursor == "next-page"
+    assert len(tracks) == 1
+    assert tracks[0]["name"] == "Ara Beni"
+    assert tracks[0]["playlistItemId"] == "playlist-entry-1"
+
+
+def test_authenticated_data_api_failure_is_not_hidden_by_public_metadata():
+    target = YTMusicTarget.__new__(YTMusicTarget)
+
+    def denied(*_args, **_kwargs):
+        raise ytmusic.TargetAuthError("expired")
+
+    target._paged = denied
+    target._ytm = SimpleNamespace(get_playlist=lambda *_args, **_kwargs: pytest.fail("must not replace the failed source read"))
+    with pytest.raises(ytmusic.TargetAuthError, match="expired"):
+        target.playlist_tracks({"playlistId": "chart"})

--- a/tests/test_ytmusic_stub.py
+++ b/tests/test_ytmusic_stub.py
@@ -90,8 +90,8 @@ def test_data_api_playlist_title_cleanup_is_conservative(title, channel, expecte
     assert track["name"] == expected
 
 
-def test_native_youtubei_titles_are_not_reparsed_as_raw_video_titles():
-    title = "BLOK3 - KAYIP KALP (Official Music Video)"
+def test_native_youtubei_preserves_a_song_title_with_a_separator_and_version():
+    title = "Love - Hate (Acoustic)"
 
     track = _normalized_youtubei_playlist_track({
         "videoId": "video-1",


### PR DESCRIPTION
YouTube playlist transfers were searching raw video titles and uploader names, and several matching paths could treat studio, acoustic, dub, remix, or featured-artist recordings as interchangeable.

This change enriches authenticated YouTube playlist rows with public Music metadata for the same video id, cleans confirmed artist credits and production labels, and preserves recording qualifiers. Shared recording checks now cover search, sync aliases, duplicate/diff guards, ISRC fallbacks, and archived-link validation. Named remixes and live venues must agree; featured credits can move between a title and the artist list without changing identity.

Legacy automatic resolution caches are refreshed once so older wrong matches and misses are searched again. Manual choices are preserved. Public metadata remains optional for private playlists, and authenticated read failures still propagate.

Closes #44. Issue #45 was already fixed and separately validated locally.

Validation:
- 762 backend tests passed, 1 skipped; all 17 changed Python files compiled.
- Frontend lint and production build passed; the existing bundle-size warning remains.
- Read-only replay of the captured 100-entry Turkey chart: **40 → 85 matches**, 3 duplicate skips, 12 unresolved, zero errors or remote writes. Raw public video metadata was replayed in the Data API item shape, joined to the captured Music playlist, then passed through the real transfer engine and Deezer resolver. Previously captured catalog responses were reused; new queries used the live public catalog.
- Regression coverage includes localized acoustic/live labels, dubs, edits, different named remixes, featured-artist differences, version suffixes after features, provider version fields, stale caches/links, and private/paged YouTube reads.

The remaining ambiguous or unavailable recordings stay unresolved. Incomplete version or guest metadata can require a manual choice rather than substituting another recording.

