### PR TITLE
fix(sync): prevent recording mismatches and playlist resurrection

### DIFF
--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -546,6 +546,40 @@ def get_identities(conn, source, track_ids):
               "AND track_id IN ({marks})", [source], track_ids)
 
 
+def get_identity_snapshots(conn, sources, canonical_ids):
+    """Archived reference metadata for hard identities in selected accounts.
+
+    Prefer native ISRC evidence over learned bindings. Keep every reference for
+    an identity because separate catalog releases can expose different credits.
+    """
+    wanted = sorted({cid for cid in canonical_ids if cid.startswith("i:")})
+    direct, learned = {}, {}
+    for source in dict.fromkeys(sources):
+        for offset in range(0, len(wanted), 400):
+            chunk = wanted[offset:offset + 400]
+            marks = ",".join("?" * len(chunk))
+            native_cid = "('i:' || upper(replace(replace(trim(s.isrc), '-', ''), ' ', '')))"
+            rows = conn.execute(
+                f"SELECT {native_cid}, i.canonical_id, s.meta FROM songs s "
+                "LEFT JOIN track_identity i ON i.source = s.source AND i.track_id = s.id "
+                f"WHERE s.source = ? AND ({native_cid} IN ({marks}) "
+                f"OR i.canonical_id IN ({marks}))",
+                [source, *chunk, *chunk],
+            )
+            for native, remembered, meta in rows:
+                try:
+                    snapshot = json.loads(meta)
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(snapshot, dict) or not str(snapshot.get("name") or "").strip():
+                    continue
+                if native in chunk:
+                    direct.setdefault(native, []).append(snapshot)
+                if remembered in chunk:
+                    learned.setdefault(remembered, []).append(snapshot)
+    return {cid: direct.get(cid) or snapshots for cid, snapshots in (learned | direct).items()}
+
+
 def get_identity_crosswalk(conn, source, target, source_track_ids):
     """{source_track_id: target_track_id} joined through a proven hard identity.
 
@@ -756,14 +790,15 @@ def set_playlist_state(conn, playlist, source, canonical_ids):
         conn, playlist, {source: canonical_ids}, {source: set()})
 
 
-def set_reconcile_identities(conn, playlist, repaired_states, learned_identities):
+def set_reconcile_identities(conn, playlist, repaired_states, learned_identities, *, preserve_pending=()):
     """Atomically persist identity learning and any source-local baseline repair.
 
     A stable physical entry can move from one hard canonical id to another as
     provider metadata improves. Committing the new ``track_identity`` without
     remapping its old playlist baseline loses the evidence of that transition
     and makes the next pass look like a deletion. Keep both sides in one SQLite
-    transaction, after every provider read has succeeded.
+    transaction, after every provider read has succeeded. Disputed recordings
+    retain their pending deletion evidence even when unrelated identities move.
     """
     now = _now()
     try:
@@ -781,9 +816,10 @@ def set_reconcile_identities(conn, playlist, repaired_states, learned_identities
                 "INSERT OR IGNORE INTO playlist_state VALUES (?, ?, ?)",
                 [(playlist, source, cid) for cid in canonical_ids],
             )
-            conn.execute(
-                "DELETE FROM playlist_pending_removal WHERE playlist = ? AND source = ?",
-                (playlist, source),
+            conn.executemany(
+                "DELETE FROM playlist_pending_removal WHERE playlist = ? AND source = ? AND canonical_id = ?",
+                [(playlist, source, cid) for cid in
+                 get_pending_removals(conn, playlist, source) - set(preserve_pending)],
             )
         rows = [
             (source, track_id, canonical_id, now)

--- a/songmirror/engine/archive.py
+++ b/songmirror/engine/archive.py
@@ -494,16 +494,27 @@ def get_isrcs_from_sources(conn, sources, ids):
 
     Spotify catalog ids are shared by its accounts, but a track may only have
     been archived through a custom profile. Preserve source order on the rare
-    conflicting row and stop querying once every requested id is satisfied.
+    conflicting row. Web snapshots may omit ISRCs, so fall back to the current
+    hard identity learned for that exact catalog id after checking every
+    selected account's snapshots. A reverse link must keep identifying the same
+    recording even after it disappears from the Spotify playlist.
     """
     wanted = [track_id for track_id in ids if track_id]
+    sources = tuple(dict.fromkeys(source for source in sources if source))
     out = {}
-    for source in dict.fromkeys(source for source in sources if source):
+    for source in sources:
         remaining = [track_id for track_id in wanted if track_id not in out]
         if not remaining:
             break
         for track_id, isrc in get_isrcs(conn, source, remaining).items():
             out.setdefault(track_id, isrc)
+    for source in sources:
+        remaining = [track_id for track_id in wanted if track_id not in out]
+        if not remaining:
+            break
+        for track_id, cid in get_identities(conn, source, remaining).items():
+            if cid.startswith("i:") and cid[2:]:
+                out.setdefault(track_id, cid[2:])
     return out
 
 

--- a/songmirror/engine/matching.py
+++ b/songmirror/engine/matching.py
@@ -5,8 +5,8 @@ cached link) first, then a fuzzy search scored against title/artist/duration.
 The fuzzy layer is RapidFuzz `token_set_ratio` (order/subset/decoration
 tolerant) plus Jaro-Winkler (short strings, transliteration near-misses), run
 over both raw and romanized (anyascii) variants so different scripts match. The
-duration anchor gates the looser matching so a different version or a
-wrong-artist cover is rejected when its length disagrees.
+performer, version, and duration gates prevent a similar title from outweighing
+evidence that the candidate is a different recording.
 """
 
 import math
@@ -31,7 +31,11 @@ CATALOG_TAG = r"(?:(?:\d{4}\s+)?re-?master(?:ed)?(?:\s+\d{4})?|clean|explicit)"
 BRACKETED_CATALOG_TAG_RE = re.compile(rf"[\(\[]\s*(?:{CATALOG_TAG})\s*[\)\]]", re.IGNORECASE)
 TRAILING_CATALOG_TAG_RE = re.compile(rf"\s*[-–—]\s*(?:{CATALOG_TAG})\s*$", re.IGNORECASE)
 FROM_RELEASE_RE = re.compile(
-    r'\s*(?:[-–—]\s*from|[\(\[]\s*from)\s+["“][^"”]+["”]\s*[\)\]]?\s*$',
+    r'''\s*(?:[-–—]\s*from|[\(\[]\s*from)\s+(?:"[^"]+"|'[^']+'|“[^”]+”|‘[^’]+’)\s*[\)\]]?\s*$''',
+    re.IGNORECASE,
+)
+BONUS_TRACK_SUFFIX_RE = re.compile(
+    r"(?:\s+[-–—/]\s*bonus\s+track|\s*[\(\[]\s*bonus\s+track\s*[\)\]])\s*$",
     re.IGNORECASE,
 )
 CREATIVE_VERSION_PATTERNS = (
@@ -178,7 +182,7 @@ def catalog_name(name):
     qualifiers (remix, acoustic, live, piano, radio edit, etc.) deliberately
     remain, so genuinely different recordings never collapse merely by title.
     """
-    cleaned = str(name or "")
+    cleaned = BONUS_TRACK_SUFFIX_RE.sub("", str(name or ""))
     while True:
         previous = cleaned
         cleaned = BRACKETED_CATALOG_TAG_RE.sub(" ", cleaned)
@@ -186,7 +190,15 @@ def catalog_name(name):
         cleaned = FROM_RELEASE_RE.sub(" ", cleaned)
         if cleaned == previous:
             break
-    return loose_name(cleaned)
+    normalized = loose_name(cleaned)
+    markers = creative_version_markers(cleaned)
+    if markers and markers != {"alternate-version"}:
+        # Acoustic / Acoustic Version name the same variant. The compatibility
+        # gate still compares named mixes, venues, and other version details.
+        for _marker, pattern in CREATIVE_VERSION_PATTERNS:
+            normalized = re.sub(rf"({pattern.pattern})\s+version\b", r"\1", normalized,
+                                flags=re.IGNORECASE)
+    return " ".join(normalized.split())
 
 
 def creative_version_markers(name):
@@ -238,6 +250,7 @@ def recording_version_signature(name):
     concerts. Compare explicit qualifiers before fuzzy scoring, while allowing
     label spelling differences such as Acoustic Version / Akustik.
     """
+    name = BONUS_TRACK_SUFFIX_RE.sub("", str(name or ""))
     markers = frozenset(creative_version_markers(name))
     details = set()
     for part in re.split(r"\s+[-–—]\s+|[()\[\]{}]", _without_feature_credits(name))[1:]:
@@ -324,8 +337,94 @@ def _artist_variants(track):
     return variants
 
 
+def _artist_names(track):
+    artists = track.get("artists") or track.get("artist") or []
+    if isinstance(artists, str):
+        artists = [artists]
+    # Auto-generated channel placeholders convey no performer evidence. They
+    # cannot validate a search result or contradict a previously proven ID.
+    unavailable = {"", "release", "release topic", "unknown artist", "various artists"}
+    return [str(artist).strip() for artist in artists
+            if romanized(str(artist or "")) not in unavailable]
+
+
 def _artist_similarity(track, candidate):
-    return _best(_sim_loose, _artist_variants(track), _artist_variants(candidate))
+    """Compare complete performer credits, allowing a provider's primary credit.
+
+    Token subsets make "AURORA Tribute Band" a perfect match for "AURORA".
+    Split only credit separators, then compare whole names. When both sides
+    expose joined credits, require a complete credit set to match, not just a
+    common fragment of two different comma-containing band names.
+    """
+    names, candidates = _artist_names(track), _artist_names(candidate)
+    tribute = re.compile(r"\b(?:tribute|karaoke|covers?|renditions?)\b")
+    left_markers = set(tribute.findall(romanized(" ".join(names))))
+    right_markers = set(tribute.findall(romanized(" ".join(candidates))))
+    if left_markers != right_markers:
+        return 0.0
+
+    def split_credits(values):
+        return [part.strip() for value in values
+                for part in re.split(r"\s*(?:,|;|&|\b(?:feat|ft)\.?\s|\bfeaturing\s|\band\b|\bwith\b)\s*", value,
+                                     flags=re.IGNORECASE) if part.strip()]
+
+    def variants(values):
+        out = {v for value in values for v in _artist_variants({"artist": value})}
+        # Soundtrack brands may add "Music" to an otherwise complete multiword
+        # credit ("League of Legends Music"). Do not shorten compact stage names.
+        out.update(v.removesuffix(" music") for v in list(out)
+                   if v.endswith(" music") and len(v.split()) >= 4)
+        return out
+
+    def similarity(left, right):
+        return _best(lambda a, b: fuzz.token_sort_ratio(a, b) / 100.0, left, right)
+
+    def all_credits(left, right):
+        right_variants = variants(right)
+        return min((similarity(variants([name]), right_variants) for name in left), default=0.0)
+
+    left_parts, right_parts = split_credits(names), split_credits(candidates)
+    if not left_parts or not right_parts:
+        return 0.0
+    # Fuzzy aggregate strings can hide one conflicting performer in a long
+    # shared credit. Only exact formatting equivalence or a complete subset of
+    # credited names is sufficient; a shared guest alone is not.
+    if variants([" ".join(names)]) & variants([" ".join(candidates)]):
+        return 1.0
+    return max(
+        all_credits(left_parts, right_parts),
+        all_credits(right_parts, left_parts),
+    )
+
+
+def recording_metadata_compatible(track, candidate):
+    """Reject explicit recording conflicts, including on ID and archive paths.
+
+    Missing metadata cannot disprove a hard identifier. Known performer or
+    length disagreements can: older automatic mappings are not independent
+    evidence that overrides the provider's actual recording metadata.
+    """
+    if not recording_versions_compatible(
+        track.get("name"), track.get("artists") or track.get("artist"),
+        candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
+    ):
+        return False
+    return recording_performance_compatible(track, candidate)
+
+
+def recording_performance_compatible(track, candidate):
+    """Whether usable performer and duration evidence can describe the same audio.
+
+    Historical hard identities tolerate mutable version labels, but must not
+    equate a different performer or a materially different recording length.
+    """
+    if _artist_names(track) and _artist_names(candidate) and _artist_similarity(track, candidate) < FUZZY_THRESHOLD:
+        return False
+    duration, candidate_duration = track.get("duration_ms"), candidate.get("duration_ms")
+    if duration is not None and candidate_duration is not None:
+        if duration > 0 and candidate_duration > 0:
+            return abs(duration - candidate_duration) <= CATALOG_DURATION_TOLERANCE_MS
+    return True
 
 
 def fuzzy_in(key, keys, threshold=FUZZY_THRESHOLD):
@@ -337,7 +436,9 @@ def fuzzy_in(key, keys, threshold=FUZZY_THRESHOLD):
 def score_candidate(name, artists, duration_ms, cand_name, cand_artist, cand_duration_ms):
     """(score in 0..1, acceptable) for a search-result candidate vs the wanted
     track — the fuzzy fallback when no ISRC/link resolves it."""
-    if not recording_versions_compatible(name, artists, cand_name, cand_artist):
+    wanted = {"name": name, "artists": artists, "duration_ms": duration_ms}
+    candidate = {"name": cand_name, "artist": cand_artist, "duration_ms": cand_duration_ms}
+    if not recording_metadata_compatible(wanted, candidate):
         return 0.0, False
     if isinstance(artists, str):
         artists = [artists]
@@ -345,10 +446,7 @@ def score_candidate(name, artists, duration_ms, cand_name, cand_artist, cand_dur
     name_strict = _best(_sim_strict, q_names, c_names)
     name_loose = _best(_sim_loose, q_names, c_names)
 
-    joined = " ".join(artists)
-    q_art = {normalize_text(joined), romanized(joined)}
-    c_art = {normalize_text(cand_artist), romanized(cand_artist)}
-    artist_sim = _best(_sim_loose, q_art, c_art)  # subset-tolerant: services list the primary artist
+    artist_sim = _artist_similarity(wanted, candidate)
 
     if duration_ms is not None and cand_duration_ms is not None:
         delta = abs(duration_ms - cand_duration_ms)
@@ -359,8 +457,8 @@ def score_candidate(name, artists, duration_ms, cand_name, cand_artist, cand_dur
 
     name_sim = max(name_strict, name_loose) if duration_close else name_strict
     score = 0.45 * name_sim + 0.35 * artist_sim + 0.20 * duration_score
-    strong = duration_close and name_sim >= 0.78 and artist_sim >= 0.58
-    fuzzy = name_strict >= 0.88 and artist_sim >= 0.60
+    strong = duration_close and name_sim >= 0.78 and artist_sim >= FUZZY_THRESHOLD
+    fuzzy = name_strict >= 0.88 and artist_sim >= FUZZY_THRESHOLD
     return score, (strong or fuzzy)
 
 
@@ -378,10 +476,7 @@ def same_catalog_recording(track, candidate):
     it) near-identical duration. It catches alternate catalog releases without
     treating an acoustic/live/remix/version as the ordinary track.
     """
-    if not recording_versions_compatible(
-        track.get("name"), track.get("artists") or track.get("artist"),
-        candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
-    ):
+    if not recording_metadata_compatible(track, candidate):
         return False
     wanted = catalog_name(track.get("name"))
     existing = catalog_name(candidate.get("name"))
@@ -451,10 +546,7 @@ def compute_diff(sp_tracks, target_tracks, expected_by_sp, target_id_of, thresho
         target_by_key.setdefault(track_key(track["name"], track["artist"]), []).append(track)
 
     def compatible(source, target):
-        return recording_versions_compatible(
-            source.get("name"), source.get("artists") or source.get("artist"),
-            target.get("name"), target.get("artists") or target.get("artist"),
-        )
+        return recording_metadata_compatible(source, target)
 
     expected_all = set()
     sp_by_version = {}

--- a/songmirror/engine/runner.py
+++ b/songmirror/engine/runner.py
@@ -55,7 +55,7 @@ def _save_json(path, data):
         json.dump(data, f)
 
 
-MATCHING_CACHE_VERSION = 1
+MATCHING_CACHE_VERSION = 2
 
 
 def load_cache(cache_file):
@@ -64,7 +64,7 @@ def load_cache(cache_file):
 
     `manual` is a set of `search` keys a person chose in the conflict editor.
     Old automatic results must be searched again when matching rules change:
-    they contain only ids, so recording-version conflicts cannot be checked
+    they contain only ids, so recording-metadata conflicts cannot be checked
     offline. Manual choices survive migration. ISRC candidates are refetched
     as older normalizers could discard the provider's separate version field.
     """

--- a/songmirror/engine/spotify_cookie.py
+++ b/songmirror/engine/spotify_cookie.py
@@ -671,6 +671,8 @@ def _normalized_content_tracks(items):
             "added_at": (it.get("addedAt") or {}).get("isoString") or "",
             "image": image,
         })
+        if it.get("uid"):
+            out[-1]["playlistItemId"] = it["uid"]
     return out
 
 
@@ -781,14 +783,33 @@ def remove(playlist, track_ids):
         _pf("removeFromPlaylist", {"playlistUri": _puri(playlist), "uids": uids})
 
 
-def remove_positions(playlist, positions):
-    """Remove the items at these 0-based positions. ponytail: evaluated against a
-    fresh contents read, not the caller's read-time snapshot — acceptable because
-    reconcile position-removes within one short pass; revisit if drift bites."""
-    items = contents(playlist)
-    uids = [items[p]["uid"] for p in positions if 0 <= p < len(items) and items[p]["uid"]]
+def remove_uids(playlist, uids):
+    """Remove exact playlist occurrences, independent of intervening order edits."""
+    uids = list(dict.fromkeys(uids))
+    if any(not uid for uid in uids):
+        raise RuntimeError("Spotify did not return an occurrence id for a selected track")
     if uids:
         _pf("removeFromPlaylist", {"playlistUri": _puri(playlist), "uids": uids})
+
+
+def remove_positions(playlist, positions, *, expected_track_ids=None):
+    """Resolve legacy selections against the same visible tracks used by reads.
+
+    Hidden/local/episode rows still occupy raw contents positions. Including
+    them here shifts every later selection away from the normalized read. New
+    reads retain occurrence ids and bypass this positional fallback entirely.
+    """
+    positions = list(positions)
+    items = [item for item in contents(playlist)
+             if (item.get("uri") or "").startswith("spotify:track:")]
+    if any(position < 0 or position >= len(items) for position in positions):
+        raise RuntimeError("Spotify playlist changed; refresh it before removing tracks")
+    selected = [items[position] for position in positions]
+    if expected_track_ids is not None:
+        expected = [_turi(track_id) for track_id in expected_track_ids]
+        if [item["uri"] for item in selected] != expected:
+            raise RuntimeError("Spotify playlist changed; refresh it before removing tracks")
+    remove_uids(playlist, [item.get("uid") for item in selected])
 
 
 def _spc_headers():

--- a/songmirror/engine/targets/apple.py
+++ b/songmirror/engine/targets/apple.py
@@ -13,7 +13,7 @@ from ..config import (
     AMP, DEFAULT_CACHE_FILE, REQUEST_TIMEOUT, polite_sleep, required_env,
 )
 from ..logs import log, log_warn
-from ..matching import normalize_text, recording_versions_compatible, romanized, score_candidate
+from ..matching import normalize_text, recording_metadata_compatible, romanized, score_candidate
 from .base import (
     MirrorTarget,
     TargetAuthError,
@@ -507,9 +507,10 @@ class AppleMusicTarget(MirrorTarget):
             )
             self._validated_catalog_ids = validated
         attrs = validated[target_id]
-        if attrs is not None and recording_versions_compatible(
-            track.get("name"), track.get("artists"), attrs.get("name"), attrs.get("artistName"),
-        ):
+        if attrs is not None and recording_metadata_compatible(track, {
+            "name": attrs.get("name"), "artist": attrs.get("artistName"),
+            "duration_ms": attrs.get("durationInMillis"),
+        }):
             self._remember_resolution(track, target_id, cache)
             return target_id, "link"
         return None, None

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -974,21 +974,25 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
     but cannot overwrite proven memory; the memory otherwise covers for a read
     too degraded to derive one."""
     ids = [target.track_id(t) for t in tracks]
+    known = {tid: normalize_canonical_id(cid)
+             for tid, cid in archive.get_identities(songs, target.source, ids).items()}
     rev = ({} if _target_provider(target) == "spotify"
            else archive.get_reverse_links(songs, target.source, ids))
-    if rev:
+    # A remembered Spotify identity still names that exact catalog entry even
+    # if its resolve-cache link was later evicted. Upgrade it through the same
+    # ISRC evidence as a live reverse link instead of splitting one recording.
+    spotify_ids = set(rev.values()) | {cid[2:] for cid in known.values() if cid.startswith("s:")}
+    if spotify_ids:
         archive_sources = getattr(target, "archive_sources", None)
         spotify_sources = (
             archive_sources("spotify") if callable(archive_sources) else ("spotify",)
         )
         sp_isrc = archive.get_isrcs_from_sources(
-            songs, spotify_sources, list(rev.values())
+            songs, spotify_sources, spotify_ids
         )
     else:
         sp_isrc = {}
     id2isrc = target.native_isrc_map(cache)  # provider-supplied track_id -> ISRC (Apple, future providers)
-    known = {tid: normalize_canonical_id(cid)
-             for tid, cid in archive.get_identities(songs, target.source, ids).items()}
     history = {
         tid: {normalize_canonical_id(cid) for cid in canonical_ids}
         for tid, canonical_ids in archive.get_identity_history(
@@ -1009,7 +1013,8 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
         native_isrc = normalize_isrc(id2isrc.get(tid))
         inferred_isrc = normalize_isrc(next(
             (key2isrc[k] for k in keys if k in key2isrc), None))
-        sp_id = rev.get(tid)
+        previous = known.get(tid)
+        sp_id = rev.get(tid) or (previous[2:] if previous and previous.startswith("s:") else None)
         linked_isrc = normalize_isrc(sp_isrc.get(sp_id)) if sp_id else ""
         if direct_isrc:
             cid, provenance = f"i:{direct_isrc}", "direct"
@@ -1022,7 +1027,6 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
             cid, provenance = f"i:{inferred_isrc}", "inferred"
         else:
             cid, provenance = f"k:{track_key(norm['name'], norm['artist'])}", "soft"
-        previous = known.get(tid)
         if cid.startswith("k:"):
             cid = previous or cid           # yield to whatever this entry already earned
         elif tid and previous != cid:
@@ -1219,7 +1223,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     state so differently-named paired playlists share one logical identity;
     otherwise the casefolded display name is used (implicit same-name pairing).
     Returns a stats dict; `clean` is True when every side applied with no guard
-    tripped (only then is the canonical snapshot advanced)."""
+    tripped. Held changes retain removal evidence while recording newly observed
+    membership, so an old addition cannot override a later user deletion."""
     authorities = None if authority_sources is None else frozenset(authority_sources)
     peer_sources = {p.source for p in peers}
     if authorities is not None:
@@ -2017,13 +2022,14 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         for p in peers:
             archive.delete_links(songs, p.source, rejected_link_ids[p.source])
             archive.set_links(songs, p.source, new_links[p.source])
-        # Advance every baseline when reads were trusted and no membership
-        # change was held. When additions are incomplete or a removal is capped,
-        # established peers stay frozen, but a newly connected peer must still
-        # graduate from bootstrap or its entire library looks newly added forever.
+        # A held change must retain previous membership as removal evidence,
+        # but cannot prevent us from remembering tracks actually observed now.
+        # Otherwise an old addition on another authority wins over a later user
+        # deletion forever. Only observed membership is added: unresolved or
+        # newly written matches still need a provider read before entering state.
         if not collapsed and not interrupted:
             persist = new_state if not baseline_blocked else {
-                src: ids for src, ids in new_state.items() if src not in initialized}
+                src: prev.get(src, set()) | ids for src, ids in new_state.items()}
             pending_sources = initialized if authorities is None else initialized & authorities
             pending_updates = (
                 {src: missing_by_source.get(src, set()) | applied_removals.get(src, set())
@@ -2034,7 +2040,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             archive.commit_reconcile_membership(
                 songs, key, persist, pending_updates, physical_playlist_ids)
             if baseline_blocked:
-                for src in persist:
+                for src in persist.keys() - initialized:
                     label = next((p.name for p in peers if p.source == src), src)
                     log_note(f"{name}: initialized {label} baseline despite held changes", tag="sync")
 

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -348,6 +348,10 @@ class MirrorTarget:
         """Locate copies appended by a failed staging pass for rollback."""
         after = list(self.playlist_tracks(playlist))
         if self.stable_occurrence_ids:
+            if any(self.occurrence_id(track) is None for track in [*before, *after]):
+                raise RuntimeError(
+                    f"{self.name} returned incomplete occurrence ids; cannot safely identify staged copies"
+                )
             old = Counter(
                 occurrence_id for track in before
                 if (occurrence_id := self.occurrence_id(track)) is not None
@@ -502,11 +506,30 @@ def _chronology_replay_tail(ordered_keys, current_by_key, additions_by_key):
 
 def _fit_chronology_writes(ordered_keys, current_by_key, additions, addition_key,
                            max_writes, *, addition_target_id=lambda item: item[0],
-                           replay_write_cost=len, can_replay=True):
+                           replay_write_cost=len, can_replay=True, preserve_chronology=True,
+                           order_evidence=None):
     """Fit new membership plus any required chronology suffix under one write cap."""
     additions = list(additions)
     if not can_replay:
-        selected = additions[:max(0, max_writes)]
+        eligible = additions
+        if preserve_chronology:
+            positions = {key: position for position, key in enumerate(ordered_keys)}
+
+            def chronology_key(key):
+                evidence = (order_evidence or {}).get(key)
+                if evidence is not None:
+                    # Equal timestamps are not evidence that one song predates
+                    # another; provider rank merely breaks their sorting tie.
+                    return evidence[:2] if evidence[0] == 0 else evidence
+                return (2, positions.get(key, -1))
+
+            existing = [chronology_key(key) for key in current_by_key if key in positions]
+            last_existing = max(existing) if existing else None
+            # Missing old tracks must not become the newest entries merely
+            # because a provider cannot safely replay the newer suffix.
+            eligible = [item for item in additions
+                        if last_existing is None or chronology_key(addition_key(item)) >= last_existing]
+        selected = eligible[:max(0, max_writes)]
         return selected, [], len(additions) - len(selected), len(additions)
 
     full_by_key = {addition_key(item): addition_target_id(item) for item in additions}
@@ -768,6 +791,9 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
         max_adds,
         replay_write_cost=replay_write_cost,
         can_replay=can_replay,
+        preserve_chronology=not is_favorite_resource,
+        order_evidence={id(track): track_addition_order_key(track, playlist_position=position)
+                        for position, track in enumerate(ordered_source)},
     )
     chronology_replayed = sum(1 for _target_id, original in chronology_replay
                               if original is not None)
@@ -778,6 +804,12 @@ def mirror_pair(target, sp_tracks, sp_playlist, tgt_playlist, cache, songs, *, e
             log_warn(
                 f"preserving Recently Added order would require {full_write_cost} ordered writes; "
                 f"--max-adds={max_adds}, deferring {cap_deferred} addition(s)",
+                tag=tag,
+            )
+        elif not can_replay and not is_favorite_resource:
+            log_warn(
+                f"deferring {cap_deferred} addition(s): older playlist gaps require an ordered "
+                f"repair before they can be filled (write cap {max_adds})",
                 tag=tag,
             )
         else:
@@ -1738,20 +1770,18 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             present_recordings[p.source].setdefault(catalog_name(norm["name"]), []).append((None, norm))
             additions.append((cid, tid, method or "search", norm))
 
-        ordered_desired = sorted(
-            desired,
-            key=lambda cid: (
-                addition_order.get(
-                    cid,
-                    track_addition_order_key(
-                        repr_.get(cid, {}),
-                        source_rank=len(peers),
-                        playlist_position=repr_.get(cid, {}).get("_playlist_position", 0),
-                    ),
-                ),
+        order_evidence = {
+            cid: addition_order.get(
                 cid,
-            ),
-        )
+                track_addition_order_key(
+                    repr_.get(cid, {}),
+                    source_rank=len(peers),
+                    playlist_position=repr_.get(cid, {}).get("_playlist_position", 0),
+                ),
+            )
+            for cid in desired
+        }
+        ordered_desired = sorted(desired, key=lambda cid: (order_evidence[cid], cid))
         current_by_cid = {}
         for current_cid, current_norm in per_entry[p.source]:
             current_cid = alias.get(current_cid, current_cid)
@@ -1788,13 +1818,11 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
         can_replay = callable(getattr(p, "replay_chronology", None)) and not is_favorite_resource
         replay_write_cost = getattr(p, "chronology_replay_write_cost", len)
         if chronology_collision and additions:
-            # Only the ambiguous entries are blocked. Replaying existing rows
-            # would rely on their disputed identities, but independently resolved
-            # additions can safely append in source order. A later pass can
-            # recover older gaps once the conflicting matches are corrected.
+            # Disputed identities prevent suffix replay. Only additions newer
+            # than the current playlist can append without changing chronology.
             log_warn(
-                f"{p.name}/{name}: appending valid additions without reordering existing "
-                "tracks while conflicting matches are held",
+                f"{p.name}/{name}: holding older recoveries while conflicting matches "
+                "prevent an ordered repair",
                 tag=p.tag,
             )
         can_replay = can_replay and not chronology_collision
@@ -1807,6 +1835,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             addition_target_id=lambda item: item[1],
             replay_write_cost=replay_write_cost,
             can_replay=can_replay,
+            preserve_chronology=not is_favorite_resource,
+            order_evidence=order_evidence,
         )
         chronology_replayed = sum(1 for _target_id, original in chronology_replay
                                   if original is not None)
@@ -1817,6 +1847,12 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                     f"{p.name}/{name}: preserving Recently Added order would require "
                     f"{full_write_cost} ordered writes; --max-adds={max_adds}, "
                     f"deferring {cap_deferred} addition(s)",
+                    tag=p.tag,
+                )
+            elif not can_replay and not is_favorite_resource:
+                log_warn(
+                    f"{p.name}/{name}: deferring {cap_deferred} addition(s): older playlist gaps "
+                    f"require an ordered repair before they can be filled (write cap {max_adds})",
                     tag=p.tag,
                 )
             else:

--- a/songmirror/engine/targets/base.py
+++ b/songmirror/engine/targets/base.py
@@ -21,7 +21,7 @@ from ..matching import (
     catalog_name, compute_diff, fuzzy_in, match_unresolved_removals,
     protect_removals, romanized,
     normalize_canonical_id, normalize_isrc, same_catalog_recording,
-    recording_version_signature, recording_versions_compatible,
+    recording_metadata_compatible, recording_performance_compatible, recording_version_signature,
     spotify_track_keys, track_addition_order_key, track_key, tracks_oldest_first,
 )
 
@@ -479,7 +479,9 @@ def _ordered_current_matches(source_tracks, target_tracks, expected_by_source, t
             candidates.extend(by_id.get(str(expected_id), ()))
         for key in _track_match_keys(source_track):
             candidates.extend(by_key.get(key, ()))
-        position = next((candidate for candidate in sorted(set(candidates)) if candidate in unused), None)
+        position = next((candidate for candidate in sorted(set(candidates))
+                         if candidate in unused
+                         and recording_metadata_compatible(source_track, target_tracks[candidate])), None)
         if position is None:
             continue
         unused.remove(position)
@@ -616,10 +618,7 @@ def _recover_archived_links(songs, source_key, target, source_tracks, known):
     links = {**known, **recovered}
     for track in source_tracks:
         candidate = by_id.get(str(links.get(track.get("id"))))
-        if candidate and not recording_versions_compatible(
-            track.get("name"), track.get("artists") or track.get("artist"),
-            candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
-        ):
+        if candidate and not recording_metadata_compatible(track, candidate):
             links.pop(track["id"], None)
     return links
 
@@ -1014,16 +1013,21 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
     # if its resolve-cache link was later evicted. Upgrade it through the same
     # ISRC evidence as a live reverse link instead of splitting one recording.
     spotify_ids = set(rev.values()) | {cid[2:] for cid in known.values() if cid.startswith("s:")}
+    archive_sources = getattr(target, "archive_sources", None)
+    spotify_sources = tuple(
+        archive_sources("spotify") if callable(archive_sources) else ("spotify",)
+    )
+    sp_snapshots = {}
+    for source in spotify_sources:
+        for tid, snapshot in archive.get_snapshots(songs, source, spotify_ids).items():
+            sp_snapshots.setdefault(tid, []).append(snapshot)
     if spotify_ids:
-        archive_sources = getattr(target, "archive_sources", None)
-        spotify_sources = (
-            archive_sources("spotify") if callable(archive_sources) else ("spotify",)
-        )
         sp_isrc = archive.get_isrcs_from_sources(
             songs, spotify_sources, spotify_ids
         )
     else:
         sp_isrc = {}
+    references = archive.get_identity_snapshots(songs, spotify_sources, known.values())
     id2isrc = target.native_isrc_map(cache)  # provider-supplied track_id -> ISRC (Apple, future providers)
     history = {
         tid: {normalize_canonical_id(cid) for cid in canonical_ids}
@@ -1043,8 +1047,11 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
         keys = [track_key(norm["name"], norm["artist"]), *sorted(spotify_track_keys(norm))]
         direct_isrc = normalize_isrc(norm["isrc"])
         native_isrc = normalize_isrc(id2isrc.get(tid))
-        inferred_isrc = normalize_isrc(next(
-            (key2isrc[k] for k in keys if k in key2isrc), None))
+        inferred_candidates = {
+            isrc for key_ in keys for isrc, candidate in key2isrc.get(key_, [])
+            if recording_metadata_compatible(norm, candidate)
+        }
+        inferred_isrc = next(iter(inferred_candidates)) if len(inferred_candidates) == 1 else ""
         previous = known.get(tid)
         sp_id = rev.get(tid) or (previous[2:] if previous and previous.startswith("s:") else None)
         linked_isrc = normalize_isrc(sp_isrc.get(sp_id)) if sp_id else ""
@@ -1059,6 +1066,15 @@ def _entry_cids(target, tracks, songs, cache, key2isrc, rebindings=None, remembe
             cid, provenance = f"i:{inferred_isrc}", "inferred"
         else:
             cid, provenance = f"k:{track_key(norm['name'], norm['artist'])}", "soft"
+        historical = sp_snapshots.get(sp_id, []) if sp_id else references.get(previous, [])
+        if (not direct_isrc and not native_isrc and historical
+                and not any(recording_performance_compatible(norm, ref) for ref in historical)):
+            # Do not turn rejection of a stale binding into a synthetic user
+            # deletion. Retain its baseline identity but mark the read untrusted
+            # until native evidence can migrate it or its mapping is corrected.
+            norm["_identity_conflict"] = True
+            out.append((previous or cid, norm))
+            continue
         if cid.startswith("k:"):
             cid = previous or cid           # yield to whatever this entry already earned
         elif tid and previous != cid:
@@ -1142,7 +1158,7 @@ def _unify_aliases(canon):
 
     def compatible(left, right):
         return versions[left] == versions[right] and all(
-            recording_versions_compatible(a.get("name"), a.get("artists"), b.get("name"), b.get("artists"))
+            recording_metadata_compatible(a, b)
             for a in recordings[left] for b in recordings[right]
         )
 
@@ -1311,7 +1327,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     rebindings = {}    # source -> old hard id -> new hard ids for stable physical entries
     learned_identities = {}  # source -> physical id -> newly proven hard canonical id
     present = {}       # source -> set of ALL current target ids (not canonical-deduped)
-    key2isrc = {}      # track_key -> ISRC, seeded by every ISRC-bearing provider before canonicalization
+    key2isrc = {}      # track_key -> [(ISRC, metadata)], retaining conflicting recordings for validation
     raw_by_source = {}
     unreadable = {}
     for p in peers:
@@ -1363,7 +1379,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             isrc = normalize_isrc(norm.get("isrc") or native.get(p.track_id(track)))
             if isrc:
                 for key_ in spotify_track_keys(norm):
-                    key2isrc.setdefault(key_, isrc)
+                    key2isrc.setdefault(key_, []).append((isrc, norm))
 
     for p in peers:
         raw = raw_by_source[p.source]
@@ -1385,7 +1401,16 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     # retired alias is never mistaken for a deletion. Unification sees every
     # PHYSICAL entry's keys — an identity spanning differently-titled releases
     # must expose all of their names for aliases to land on.
-    alias = _unify_aliases(per_entry)
+    conflicting_sources = {
+        source: sum(bool(norm.get("_identity_conflict")) for _cid, norm in entries)
+        for source, entries in per_entry.items()
+        if any(norm.get("_identity_conflict") for _cid, norm in entries)
+    }
+    alias = _unify_aliases({src: [(cid, norm) for cid, norm in entries
+                                if not norm.get("_identity_conflict")]
+                            for src, entries in per_entry.items()})
+    conflicting_cids = {alias.get(cid, cid) for entries in per_entry.values()
+                        for cid, norm in entries if norm.get("_identity_conflict")}
     if alias:
         for src, by_cid in canon.items():
             merged = {}
@@ -1416,10 +1441,20 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     repr_ = {}  # canonical_id -> representative track (peers are ordered spotify-first for ISRC-rich reprs)
     for p in peers:
         for cid, norm in canon[p.source].items():
-            repr_.setdefault(cid, norm)
+            if not norm.get("_identity_conflict"):
+                repr_.setdefault(cid, norm)
 
     collapsed = set(unreadable)
     read_failures = []
+    for source, count in conflicting_sources.items():
+        read_anomalies += count
+        diagnostics.append({
+            "category": "conflicting_identity", "playlist": name,
+            "provider": peer_names.get(source, source), "count": count,
+            "evidence": "historical matches conflict with current performer or duration; those recordings are held",
+        })
+        log_warn(f"{name}: {source} has {count} historical recording conflict(s); "
+                 "holding those recordings until their identities can be verified", tag="sync")
     for source, reason in unreadable.items():
         read_anomalies += 1
         read_failures.append({"playlist": name, "error": reason})
@@ -1477,7 +1512,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             )
             continue
         remap = {old: next(iter(news)) for old, news in changes.items()
-                 if len(news) == 1 and old in prev.get(src, set()) and old not in current}
+                 if len(news) == 1 and old in prev.get(src, set()) and old not in current
+                 and old not in conflicting_cids and not (news & conflicting_cids)}
         if remap:
             prev[src] = {remap.get(cid, cid) for cid in prev[src]}
             baseline_repairs[src] = prev[src]
@@ -1499,7 +1535,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                             if src not in collapsed}
         if baseline_repairs or trusted_learning:
             archive.set_reconcile_identities(
-                songs, key, baseline_repairs, trusted_learning)
+                songs, key, baseline_repairs, trusted_learning,
+                preserve_pending=conflicting_cids)
 
     # A single successful snapshot is still not enough evidence that a missing
     # member was intentionally deleted: a provider can return a small partial
@@ -1517,7 +1554,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             alias.get(normalize_canonical_id(cid), normalize_canonical_id(cid))
             for cid in archive.get_pending_removals(songs, key, src)
         }
-        missing = prev.get(src, set()) - cur[src]
+        missing = prev.get(src, set()) - cur[src] - conflicting_cids
         first_seen = missing - pending
         confirmed = missing & pending
         missing_by_source[src] = missing
@@ -1539,6 +1576,14 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
 
     _, unconfirmed_plan = _merge(prev, cur, collapsed, authorities)
     desired, plan = _merge(prev, effective_cur, collapsed, authorities)
+    # A suspect historical binding is neither a user addition nor a deletion.
+    # Freeze only the disputed recordings, preserving unrelated synchronization
+    # and their exact previous membership until stronger identity evidence arrives.
+    desired |= conflicting_cids
+    plan = {src: (adds - conflicting_cids, removes - conflicting_cids)
+            for src, (adds, removes) in plan.items()}
+    unconfirmed_plan = {src: (adds - conflicting_cids, removes - conflicting_cids)
+                       for src, (adds, removes) in unconfirmed_plan.items()}
     addition_order = _addition_order_by_cid(
         peers, per_entry, prev, cur, collapsed, alias, authorities)
     desired_recordings = {}
@@ -1551,7 +1596,8 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
     awaiting_confirmation = sum(len(ids) for ids in first_seen_removals.values())
     confirmed_absence_count = sum(len(ids) for ids in confirmed_removals.values())
     authority_bootstrap = authorities is not None and bool(authorities - initialized)
-    stats = {"clean": execute and not collapsed and not awaiting_confirmation and not authority_bootstrap,
+    stats = {"clean": execute and not collapsed and not conflicting_cids
+                      and not awaiting_confirmation and not authority_bootstrap,
              "added": 0, "removed": 0, "missing": 0,
              "held": 0, "uncertain_matches": 0, "chronology_replayed": 0,
              "deferred": 0, "removals_skipped": 0, "held_removals": [],
@@ -1670,8 +1716,15 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             current_key_matches = set().union(*(
                 present_cids_by_key[p.source].get(match_key, set()) for match_key in norm_keys
             )) if norm_keys else set()
-            if current_key_matches:
-                protected_remove_ids |= current_key_matches
+            matching_entries = [
+                (alias.get(current_cid, current_cid), current_norm)
+                for current_cid, current_norm in per_entry[p.source]
+                if alias.get(current_cid, current_cid) in current_key_matches
+                and norm_keys & spotify_track_keys(current_norm)
+                and recording_metadata_compatible(norm, current_norm)
+            ]
+            if matching_entries:
+                protected_remove_ids |= {current_cid for current_cid, _ in matching_entries}
                 current_candidates_by_cid[cid] = [
                     (
                         p.track_id(current_norm["_raw"]),
@@ -1680,8 +1733,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                             current_norm["_raw"],
                         ),
                     )
-                    for current_cid, current_norm in per_entry[p.source]
-                    if alias.get(current_cid, current_cid) in current_key_matches
+                    for current_cid, current_norm in matching_entries
                 ]
                 continue  # song already on the provider under a different id — no dupe, and no wasted search
             queued_key_matches = [item for match_key in norm_keys
@@ -1730,11 +1782,14 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
             if tid in originally_present:
                 current_cids = present_cids_by_tid[p.source].get(tid, set())
                 protected_remove_ids |= current_cids
-                current_norms = [canon[p.source][current_cid] for current_cid in current_cids
-                                 if current_cid in canon[p.source]]
-                equivalent = any(current_cid == cid for current_cid in current_cids) or any(
-                    same_catalog_recording(norm, current_norm) for current_norm in current_norms
-                )
+                equivalent_entries = [
+                    current_norm for current_cid, current_norm in per_entry[p.source]
+                    if p.track_id(current_norm["_raw"]) == tid
+                    and recording_metadata_compatible(norm, current_norm)
+                    and (alias.get(current_cid, current_cid) == cid
+                         or same_catalog_recording(norm, current_norm))
+                ]
+                equivalent = bool(equivalent_entries)
                 if not equivalent:
                     add_blockers.add("a resolved addition collided with a different current track")
                     chronology_collision = True
@@ -1753,8 +1808,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                                 current_norm["_raw"],
                             ),
                         )
-                        for _current_cid, current_norm in per_entry[p.source]
-                        if p.track_id(current_norm["_raw"]) == tid
+                        for current_norm in equivalent_entries
                     ]
                     if norm["_source"] == "spotify" and norm["_raw"].get("id"):
                         new_links[p.source][norm["_raw"]["id"]] = tid
@@ -1825,7 +1879,7 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 "prevent an ordered repair",
                 tag=p.tag,
             )
-        can_replay = can_replay and not chronology_collision
+        can_replay = can_replay and not chronology_collision and not (cur[p.source] & conflicting_cids)
         additions, chronology_replay, cap_deferred, full_write_cost = _fit_chronology_writes(
             ordered_desired,
             current_by_cid,
@@ -2073,6 +2127,12 @@ def reconcile(peers, name, playlists, caches, songs, *, execute, max_removals, m
                 if baseline_blocked else
                 {src: set() for src in pending_sources}
             )
+            if conflicting_cids:
+                persist = {src: (ids - conflicting_cids) | (prev.get(src, set()) & conflicting_cids)
+                           for src, ids in persist.items()}
+                for src in pending_updates:
+                    pending_updates[src] |= (
+                        archive.get_pending_removals(songs, key, src) & conflicting_cids)
             archive.commit_reconcile_membership(
                 songs, key, persist, pending_updates, physical_playlist_ids)
             if baseline_blocked:

--- a/songmirror/engine/targets/provider_utils.py
+++ b/songmirror/engine/targets/provider_utils.py
@@ -3,7 +3,7 @@
 import html
 import re
 
-from ..matching import normalize_text, recording_versions_compatible, score_candidate
+from ..matching import normalize_text, recording_metadata_compatible, score_candidate
 
 
 def title_with_version(title, version):
@@ -16,18 +16,15 @@ def title_with_version(title, version):
 
 
 def compatible_isrc_candidates(track, cache):
-    """Trust an ISRC crosswalk unless its title explicitly names another version.
+    """Use an ISRC crosswalk only when its known recording metadata agrees.
 
-    ISRC results can outrank text or duration drift, but cannot bypass the
-    studio/live/acoustic boundary used by search and sync identity matching.
+    A cached identifier cannot bypass performer, version, or duration conflicts
+    that would reject the same candidate during a fresh search.
     """
     return [
         candidate for candidate in cache["isrc"].get(track.get("isrc") or "", [])
         if candidate and candidate.get("id")
-        and recording_versions_compatible(
-            track.get("name"), track.get("artists") or track.get("artist"),
-            candidate.get("name"), candidate.get("artists") or candidate.get("artist"),
-        )
+        and recording_metadata_compatible(track, candidate)
     ]
 
 

--- a/songmirror/engine/targets/spotify_target.py
+++ b/songmirror/engine/targets/spotify_target.py
@@ -29,6 +29,10 @@ class SpotifyTarget(MirrorTarget):
     source = "spotify"
     favorite_tracks_name = "Liked Songs"
 
+    @property
+    def stable_occurrence_ids(self):
+        return spotify_write_backend() == "cookie"
+
     @classmethod
     def resolve_cache_path(cls, opts=None):
         return getattr(opts, "spotify_cache_file", None) or os.getenv(
@@ -262,7 +266,15 @@ class SpotifyTarget(MirrorTarget):
 
     def remove_occurrences(self, playlist, positioned):
         if spotify_write_backend() == "cookie":
-            spotify_cookie.remove_positions(playlist["id"], [pos for pos, _ in positioned])
+            positioned = list(positioned)
+            uids = [raw.get("playlistItemId") for _, raw in positioned]
+            if all(uids):
+                spotify_cookie.remove_uids(playlist["id"], uids)
+            else:
+                spotify_cookie.remove_positions(
+                    playlist["id"], [pos for pos, _ in positioned],
+                    expected_track_ids=[self.track_id(raw) for _, raw in positioned],
+                )
             return
         # Position-addressed removal against the read-time snapshot: with the
         # same uri present twice, remove() would drop BOTH copies. All positions
@@ -274,3 +286,9 @@ class SpotifyTarget(MirrorTarget):
             self._write(lambda chunk=items[i:i + 100]: self._sp.playlist_remove_specific_occurrences_of_items(
                 playlist["id"], chunk, snapshot_id=snapshot), "remove occurrences")
             polite_sleep(0.3)
+
+    def remove_occurrence(self, playlist, track_id, occurrence_id):
+        if spotify_write_backend() == "cookie":
+            spotify_cookie.remove_uids(playlist["id"], [occurrence_id])
+            return
+        super().remove_occurrence(playlist, track_id, occurrence_id)

--- a/songmirror/services/transfers.py
+++ b/songmirror/services/transfers.py
@@ -180,7 +180,8 @@ def transfer(source, dest, src_pl, dest_pl, cache, *, execute, max_adds, preserv
     def fit(budget, ordered):
         return _fit_chronology_writes(
             ordered_keys, current_by_source, requested, lambda item: id(item[1]),
-            budget, replay_write_cost=replay_write_cost, can_replay=ordered)
+            budget, replay_write_cost=replay_write_cost, can_replay=ordered,
+            preserve_chronology=False)
 
     if can_replay:
         additions, chronology_replay, deferred, ordered_cost = fit(max_adds, True)

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1497,6 +1497,37 @@ def test_unrelated_catalog_collision_does_not_block_valid_new_songs(max_adds, ex
     conn.close()
 
 
+@pytest.mark.parametrize("collision", [False, True])
+def test_older_recoveries_wait_when_playlist_order_cannot_be_repaired(collision):
+    def track(tid, name, date):
+        return dict(id=tid, name=name, isrc=tid.upper(), artists=["Artist"],
+                    duration_ms=180000, added_at=date)
+
+    recovered = track("recovered", "Older song", "2020-01-01T00:00:00Z")
+    cutoff = track("cutoff", "Last intentional addition", "2026-09-04T00:00:00Z")
+    new = track("new", "New intentional addition", "2026-09-10T00:00:00Z")
+    conflict = track("conflict", "Unrelated recording", "2021-01-01T00:00:00Z")
+
+    class Mirror(_ManyPeer):
+        replay_chronology = None
+
+    conn = archive.connect(":memory:")
+    source = _ManyPeer("spotify", [recovered, *([conflict] if collision else []), cutoff, new],
+                       lambda norm: norm["_raw"]["id"])
+    destinations = [Mirror(provider, [cutoff], lambda norm:
+                           "cutoff" if norm["isrc"] == "CONFLICT" else norm["_raw"]["id"])
+                    for provider in ("apple", "ytmusic", "tidal", "deezer", "amazon", "qobuz")]
+    peers = [source, *destinations]
+    stats = reconcile(peers, "Mix", {p.source: {"id": p.source} for p in peers},
+                      _caches(*(p.source for p in peers)), conn, execute=True,
+                      authority_sources={"spotify", "apple"}, max_adds=200, max_removals=200)
+
+    assert all(peer.added == ["new"] for peer in destinations)
+    assert all(peer.removed == [] for peer in peers)
+    assert stats["deferred"] == 6 * (2 if collision else 1)
+    conn.close()
+
+
 def test_same_key_queued_additions_stay_distinct_when_audio_differs(tmp_path):
     conn = archive.connect(str(tmp_path / "queued-key-collision.db"))
     for src in ("spotify", "tidal"):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1075,6 +1075,39 @@ def test_held_removal_still_initializes_a_new_peer_without_resurrection(tmp_path
     conn.close()
 
 
+def test_unresolved_match_does_not_forget_observed_additions_or_user_removals(tmp_path):
+    class MissingMatchPeer(_P):
+        def resolve(self, norm, cache):
+            if norm["isrc"] == "X":
+                return None, None
+            return super().resolve(norm, cache)
+
+    conn = archive.connect(str(tmp_path / "observed-removal.db"))
+    key = "group:apple,spotify:aurora"
+    archive.set_playlist_state(conn, key, "spotify", {f"i:{i}" for i in "ABCX"})
+    archive.set_playlist_state(conn, key, "apple", {f"i:{i}" for i in "ABC"})
+    sp = _P("spotify", list("ABCXD"))
+    apple = MissingMatchPeer("apple", list("ABCD"))
+    peers = [sp, apple]
+    playlists = {p.source: {"id": p.source} for p in peers}
+
+    def run():
+        return reconcile(peers, "Aurora", playlists, _caches("spotify", "apple"), conn,
+                         execute=True, max_removals=25, max_adds=200,
+                         authority_sources={"spotify", "apple"})
+
+    # X cannot be matched on Apple, but D was actually observed on both sides.
+    # Freezing all history here makes Apple's D look newly added forever.
+    assert run()["clean"] is False
+    sp._isrcs.remove("D")
+    for _ in range(3):
+        run()
+        assert sp.added == []
+    assert "i:D" in archive.get_playlist_state(conn, key, "spotify")
+    assert archive.get_pending_removals(conn, key, "spotify") == {"i:D"}
+    conn.close()
+
+
 class _VariantPeer:
     """Peer holding ONE copy of a song under provider-flavored metadata
     (decorated title, partial or embellished artist credits). resolve() returns
@@ -1138,6 +1171,69 @@ class _ManyPeer:
 
     def remove(self, pl, raw):
         self.removed.append(raw)
+
+
+@pytest.mark.parametrize("profiled", [False, True])
+@pytest.mark.parametrize("remembered_link_only", [False, True])
+def test_removed_song_is_not_resurrected_by_a_link_without_snapshot_isrc(
+    tmp_path, profiled, remembered_link_only,
+):
+    # Spotify's web snapshots omit ISRCs. Apple still links to the original
+    # Spotify catalog id, whose learned ISRC survives in track_identity. Treating
+    # that link as a separate s: identity restores a song the user just removed.
+    conn = archive.connect(str(tmp_path / "linked-removal.db"))
+    sp_source = "profile_default_spotify" if profiled else "spotify"
+    ap_source = "profile_default_apple" if profiled else "apple"
+    authorities = {sp_source, ap_source}
+    key = f"group:{','.join(sorted(authorities))}:aurora"
+    retained = [
+        {"id": f"sp-{isrc}", "name": name, "artist": artist, "isrc": isrc}
+        for isrc, name, artist in [
+            ("A", "Older Song", "Other Artist"),
+            ("B", "Reverse Psychology", "Temper City"),
+            ("C", "Self Aware", "Temper City"),
+        ]
+    ]
+    removed = {"id": "sp-original", "name": "Runaway - Piano Version",
+               "artist": "AURORA", "isrc": None}
+    apple_copy = {"id": "ap-piano", "name": "Runaway (Piano Acoustic)",
+                  "artist": "AURORA", "isrc": None}
+    archive.upsert_many(conn, sp_source, [removed])
+    archive.set_identities(conn, sp_source, {"sp-original": "i:GBUM72100931"})
+    archive.set_identities(conn, ap_source, {"ap-piano": "s:sp-original"})
+    if not remembered_link_only:
+        archive.set_links(conn, ap_source, {"sp-original": "ap-piano"})
+    baseline = {"i:A", "i:B", "i:C"}
+    archive.set_playlist_state(conn, key, sp_source, baseline | {"i:GBUM72100931"})
+    archive.set_playlist_state(conn, key, ap_source, baseline | {"s:sp-original"})
+    spotify = _ManyPeer(sp_source, retained, lambda _norm: "sp-reissue")
+    apple = _ManyPeer(ap_source, [*retained, apple_copy], lambda _norm: None)
+    spotify.provider, apple.provider = "spotify", "apple"
+    apple.archive_sources = lambda _provider: (sp_source,)
+    peers = [spotify, apple]
+    playlists = {peer.source: {"id": peer.source} for peer in peers}
+    for _ in range(2):
+        reconcile(peers, "Aurora", playlists, _caches(sp_source, ap_source), conn,
+                  execute=True, max_removals=25, max_adds=200,
+                  authority_sources=authorities)
+        assert spotify.added == []
+    assert apple.removed == [apple_copy]
+    conn.close()
+
+
+def test_linked_isrc_prefers_snapshot_evidence_across_selected_profiles(tmp_path):
+    conn = archive.connect(str(tmp_path / "linked-isrc.db"))
+    archive.set_identities(conn, "profile_spotify_one", {
+        "snapshot": "i:OLD", "remembered": "i:KNOWN", "soft": "s:other-id",
+    })
+    archive.upsert_many(conn, "profile_spotify_two", [{"id": "snapshot", "isrc": "CURRENT"}])
+    archive.set_identities(conn, "unselected_profile", {"unselected": "i:UNSELECTED"})
+
+    assert archive.get_isrcs_from_sources(
+        conn, iter(["profile_spotify_one", "profile_spotify_two"]),
+        ["snapshot", "remembered", "soft", "unselected"],
+    ) == {"snapshot": "CURRENT", "remembered": "KNOWN"}
+    conn.close()
 
 
 def _replacement_peers(*, same_metadata=False, spotify_resolve="sp-new"):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1337,6 +1337,37 @@ def test_catalog_recording_guard_is_conservative():
          "artist": "Cover Band"}, base)
 
 
+@pytest.mark.parametrize("provider", ["apple", "ytmusic", "tidal", "deezer", "amazon", "qobuz"])
+@pytest.mark.parametrize(("original", "release", "artist"), [
+    ("45 - Acoustic", "45 - Acoustic Version", "Shinedown"),
+    ("Black Sheep - Brie Larson Vocal Version",
+     "Black Sheep - Brie Larson Vocal Version / Bonus Track", "Metric, Brie Larson"),
+    ("KIDS RETURN", "KIDS RETURN - from 'Kids Return'", "Joe Hisaishi Ensemble"),
+])
+def test_release_label_drift_does_not_add_another_copy_on_repeated_syncs(
+    tmp_path, provider, original, release, artist,
+):
+    conn = archive.connect(str(tmp_path / "release-label.db"))
+    source = _VariantPeer("spotify", {
+        "id": "original", "name": original, "artists": [artist], "artist": artist,
+        "duration_ms": 274000, "isrc": "ORIGINAL", "added_at": "2020",
+    }, "another-source-release")
+    destination = _VariantPeer(provider, {
+        "id": "release", "name": release, "artists": [artist], "artist": artist,
+        "duration_ms": 274000, "isrc": "REISSUE", "added_at": "2020",
+    }, "another-destination-release")
+    peers = [source, destination]
+    try:
+        for _ in range(3):
+            stats = reconcile(peers, "Mix", {p.source: {"id": p.source} for p in peers},
+                              _caches(*(p.source for p in peers)), conn,
+                              execute=True, max_removals=25, max_adds=200)
+            assert stats["added"] == stats["removed"] == 0
+        assert source.added == destination.added == []
+    finally:
+        conn.close()
+
+
 def test_isrc_format_drift_does_not_remove_a_present_song(tmp_path):
     # Live false-removal shape: Spotify/YouTube learned a lowercase, punctuated
     # ISRC while newer peers report the standard uppercase compact form. The
@@ -1394,10 +1425,9 @@ def test_equivalent_catalog_alias_does_not_remove_the_existing_copy(tmp_path):
     conn.close()
 
 
-def test_exact_key_satisfying_an_add_protects_that_current_track_from_removal(tmp_path):
-    # Title/artist equality can satisfy a desired add even when duration proves
-    # the two hard identities are not catalog-equivalent. The existing entry is
-    # then the add's explicit stand-in and cannot be removed in the same pass.
+def test_exact_key_does_not_prevent_a_confirmed_recording_replacement(tmp_path):
+    # A confirmed user replacement must select the new recording even if its
+    # title and artist match. The materially different length disproves a dupe.
     conn = archive.connect(str(tmp_path / "key-satisfied-replacement.db"))
     _seed_replacement_baseline(conn)
     sp, tidal = _replacement_peers(same_metadata=True)
@@ -1407,8 +1437,8 @@ def test_exact_key_satisfying_an_add_protects_that_current_track_from_removal(tm
                       _caches(*(p.source for p in peers)), conn,
                       execute=True, max_removals=25, max_adds=200)
 
-    assert stats["added"] == 0 and stats["removed"] == 0
-    assert sp.added == [] and sp.removed == []
+    assert stats["added"] == 1 and stats["removed"] == 1
+    assert sp.added == ["sp-new"] and len(sp.removed) == 1
     conn.close()
 
 
@@ -2025,7 +2055,7 @@ def test_inferred_isrc_cannot_rebind_a_remembered_hard_identity(tmp_path):
              "duration_ms": 1000, "isrc": None, "added_at": "2020"}
     ap = _VariantPeer("apple", track, "ap-cat")
     changes = {}
-    inferred = {track_key("Song", "A"): "INFERRED"}
+    inferred = {track_key("Song", "A"): [("INFERRED", track)]}
 
     entries = _entry_cids(ap, ap.playlist_tracks(None), conn, {}, inferred,
                           rebindings=changes)
@@ -2033,6 +2063,113 @@ def test_inferred_isrc_cannot_rebind_a_remembered_hard_identity(tmp_path):
     assert [cid for cid, _ in entries] == ["i:PROVEN"]
     assert changes == {}
     assert archive.get_identities(conn, "apple", ["ap-lib"]) == {"ap-lib": "i:PROVEN"}
+    conn.close()
+
+
+@pytest.mark.parametrize("binding", ["reverse", "remembered"])
+@pytest.mark.parametrize("conflict", ["performer", "duration"])
+def test_conflicting_historical_identity_is_held_without_inventing_a_deletion(tmp_path, binding, conflict):
+    conn = archive.connect(str(tmp_path / "historical-conflict.db"))
+    source = {"id": "source", "name": "A Song", "artists": ["Original Artist"],
+              "artist": "Original Artist", "duration_ms": 180000, "isrc": "ORIGINAL",
+              "added_at": "2020-01-01T00:00:00Z"}
+    cover = {**source, "id": "cover", "isrc": None}
+    if conflict == "performer":
+        cover.update(artists=["Different Artist"], artist="Different Artist")
+    else:
+        cover["duration_ms"] = 230000
+    archive.upsert_many(conn, "spotify", [source])
+    if binding == "reverse":
+        archive.set_links(conn, "ytmusic", {"source": "cover"})
+    else:
+        archive.set_identities(conn, "ytmusic", {"cover": "i:ORIGINAL"})
+    peers = [_ManyPeer("spotify", [source], lambda _: "source"),
+             _ManyPeer("apple", [source], lambda _: "source"),
+             _ManyPeer("ytmusic", [cover], lambda _: "correct")]
+    key = "group:apple,spotify:mix"
+    for p in peers:
+        archive.set_playlist_state(conn, key, p.source, {"i:ORIGINAL"})
+    for _ in range(3):
+        stats = reconcile(peers, "Mix", {p.source: {"id": p.source} for p in peers},
+                          _caches(*(p.source for p in peers)), conn, execute=True,
+                          max_adds=200, max_removals=25, authority_sources={"spotify", "apple"})
+        assert not stats["clean"]
+        assert any(d["category"] == "conflicting_identity" for d in stats["change_diagnostics"])
+        assert all(not p.added and not p.removed for p in peers)
+        assert archive.get_playlist_state(conn, key, "ytmusic") == {"i:ORIGINAL"}
+        assert archive.get_pending_removals(conn, key, "ytmusic") == set()
+    # A disputed older match must not disable the provider or replay that row
+    # when the user adds an unrelated newer recording.
+    new = {**source, "id": "new", "name": "New Song", "isrc": "NEW", "added_at": "2030-01-01T00:00:00Z"}
+    peers[0]._tracks.append(new)
+    stats = reconcile(peers, "Mix", {p.source: {"id": p.source} for p in peers},
+                      _caches(*(p.source for p in peers)), conn, execute=True,
+                      max_adds=200, max_removals=25, authority_sources={"spotify", "apple"})
+    assert peers[-1].added == ["correct"]
+    assert not peers[-1].removed
+    assert "i:NEW" in archive.get_playlist_state(conn, key, "spotify")
+    conn.close()
+
+
+def test_same_title_and_artist_cannot_infer_the_identity_of_a_different_length_recording(tmp_path):
+    conn = archive.connect(str(tmp_path / "inference-conflict.db"))
+    original = {"id": "source", "name": "A Song", "artists": ["Artist"],
+                "artist": "Artist", "duration_ms": 180000, "isrc": "ORIGINAL"}
+    variant = {**original, "id": "variant", "isrc": None, "duration_ms": 230000}
+    sp, yt = _ManyPeer("spotify", [original], lambda _: "source"), _ManyPeer("ytmusic", [variant], lambda _: "correct")
+    stats = reconcile([sp, yt], "Mix", {p.source: {"id": p.source} for p in (sp, yt)},
+                      _caches("spotify", "ytmusic"), conn, execute=True, max_adds=200, max_removals=25)
+    assert archive.get_identities(conn, "ytmusic", ["variant"]) == {}
+    assert not stats["clean"] and stats["deferred"] > 0
+    conn.close()
+
+
+def test_an_unrelated_identity_repair_keeps_disputed_deletion_evidence(tmp_path):
+    conn = archive.connect(str(tmp_path / "repair-disputed-pending.db"))
+    original = {"id": "original", "name": "A Song", "artist": "Original Artist", "isrc": "ORIGINAL"}
+    cover = {"id": "cover", "name": "A Song", "artist": "Different Artist"}
+    fixed = {"id": "stable", "name": "Another Song", "artist": "Another Artist", "isrc": "NEW"}
+    archive.set_playlist_state(conn, "mix", "spotify", {"i:ORIGINAL", "i:NEW"})
+    archive.set_playlist_state(conn, "mix", "ytmusic", {"i:ORIGINAL", "i:OLD"})
+    archive.set_identities(conn, "ytmusic", {"cover": "i:ORIGINAL", "stable": "i:OLD"})
+    archive.commit_reconcile_membership(conn, "mix", {}, {"ytmusic": {"i:ORIGINAL"}})
+    peers = [_ManyPeer("spotify", [original, fixed], lambda _: None),
+             _ManyPeer("ytmusic", [cover, fixed], lambda _: None)]
+    reconcile(peers, "Mix", {p.source: {"id": p.source} for p in peers},
+              _caches("spotify", "ytmusic"), conn, execute=True, max_adds=200, max_removals=25)
+    assert archive.get_playlist_state(conn, "mix", "ytmusic") == {"i:ORIGINAL", "i:NEW"}
+    assert archive.get_pending_removals(conn, "mix", "ytmusic") == {"i:ORIGINAL"}
+    assert all(not p.added and not p.removed for p in peers)
+    conn.close()
+
+
+def test_same_key_on_a_mirror_does_not_satisfy_a_different_recording(tmp_path):
+    conn = archive.connect(str(tmp_path / "current-key-conflict.db"))
+    original = {"id": "source", "name": "A Song", "artists": ["Artist"],
+                "artist": "Artist", "duration_ms": 180000, "isrc": "ORIGINAL"}
+    variant = {**original, "id": "variant", "isrc": "VARIANT", "duration_ms": 230000}
+    peers = [_ManyPeer("spotify", [original], lambda _: "source"),
+             _ManyPeer("apple", [original], lambda _: "source"),
+             _ManyPeer("ytmusic", [variant], lambda _: "correct")]
+    stats = reconcile(peers, "Mix", {p.source: {"id": p.source} for p in peers},
+                      _caches(*(p.source for p in peers)), conn, execute=True,
+                      max_adds=200, max_removals=25, authority_sources={"spotify", "apple"})
+    assert stats["added"] == 1
+    assert peers[-1].added == ["correct"]
+    conn.close()
+
+
+def test_queued_recordings_with_a_shared_guest_are_both_added(tmp_path):
+    conn = archive.connect(str(tmp_path / "queued-credit-conflict.db"))
+    original = {"id": "source", "name": "A Song", "artists": ["Original Artist", "Shared Guest"],
+                "artist": "Original Artist, Shared Guest", "duration_ms": 180000, "isrc": "ORIGINAL"}
+    cover = {**original, "id": "cover", "artists": ["Different Artist", "Shared Guest"],
+             "artist": "Different Artist, Shared Guest", "isrc": "COVER"}
+    sp = _ManyPeer("spotify", [original, cover], lambda n: n["isrc"])
+    yt = _ManyPeer("ytmusic", [], lambda n: n["isrc"])
+    reconcile([sp, yt], "Mix", {p.source: {"id": p.source} for p in (sp, yt)},
+              _caches("spotify", "ytmusic"), conn, execute=True, max_adds=200, max_removals=25)
+    assert set(yt.added) == {"ORIGINAL", "COVER"}
     conn.close()
 
 

--- a/tests/test_recording_search.py
+++ b/tests/test_recording_search.py
@@ -1,0 +1,71 @@
+"""Every provider rechecks old automatic matches through its real resolver."""
+
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from songmirror.engine.runner import load_cache
+from songmirror.engine.targets import target_class
+
+
+def resolver(monkeypatch, provider, candidate):
+    cls = target_class(provider)
+    target = cls.__new__(cls)
+    monkeypatch.setattr(importlib.import_module(cls.__module__), "polite_sleep", lambda *_: None)
+    if provider == "spotify":
+        target._query = lambda *_: [{**candidate, "artists": [{"name": candidate["artist"]}]}]
+    elif provider == "ytmusic":
+        target._ytm = SimpleNamespace(search=lambda *_a, **_k: [{
+            "videoId": candidate["id"], "title": candidate["name"],
+            "artists": [{"name": candidate["artist"]}],
+            "duration_seconds": candidate["duration_ms"] / 1000,
+        }])
+    elif provider == "apple":
+        target.storefront = "us"
+        target._search_throttled = False
+        target._request = lambda *_a, **_k: SimpleNamespace(json=lambda: {"results": {"songs": {"data": [{
+            "id": candidate["id"], "attributes": {
+                "name": candidate["name"], "artistName": candidate["artist"],
+                "durationInMillis": candidate["duration_ms"],
+            },
+        }]}}})
+    elif provider == "deezer":
+        target._catalog_get = lambda *_a, **_k: {"data": [{
+            "id": candidate["id"], "title": candidate["name"],
+            "artist": {"name": candidate["artist"]}, "duration": candidate["duration_ms"] / 1000,
+        }]}
+    elif provider == "tidal":
+        target.country = "US"
+        target._request = lambda *_a, **_k: SimpleNamespace(json=lambda: {})
+        target._tracks_from_body = lambda *_: [candidate]
+    else:
+        target._search = lambda *_: [candidate]
+    return target
+
+
+@pytest.mark.parametrize("provider", ["spotify", "apple", "ytmusic", "tidal", "deezer", "amazon", "qobuz"])
+@pytest.mark.parametrize("conflict", ["performer", "duration", "tribute", "shared_guest", None])
+def test_resolvers_refresh_old_automatic_matches_and_require_the_correct_recording(
+    tmp_path, monkeypatch, provider, conflict,
+):
+    source = {"id": "source", "name": "A Song", "artists": ["Original Artist"],
+              "duration_ms": 180000, "isrc": None}
+    candidate = {"id": "123", "name": "A Song", "artist": "Original Artist", "duration_ms": 180000}
+    if conflict == "performer":
+        candidate["artist"] = "Different Artist"
+    elif conflict == "duration":
+        candidate["duration_ms"] = 230000
+    elif conflict == "tribute":
+        candidate["artist"] = "Original Artist Tribute Band"
+    elif conflict == "shared_guest":
+        source["artists"] = ["Original Artist", "Shared Guest"]
+        candidate["artist"] = "Different Artist, Shared Guest"
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({"matching_version": 1, "isrc": {},
+                                "search": {"a song|original artist": "old-wrong-match"}}), encoding="utf-8")
+    cache = load_cache(path)
+    target = resolver(monkeypatch, provider, candidate)
+    for _ in range(2):
+        assert target.resolve(source, cache)[0] == (None if conflict else "123")

--- a/tests/test_recording_versions.py
+++ b/tests/test_recording_versions.py
@@ -12,6 +12,100 @@ from songmirror.engine.targets.qobuz import QobuzTarget
 from songmirror.engine.targets.tidal import TidalTarget
 
 
+@pytest.mark.parametrize(("artist", "candidate_artist", "duration", "candidate_duration"), [
+    ("Black Pistol Fire", "Black Math", 229320, 208000),
+    ("Black Pistol Fire", "Black Math", 229320, 229320),
+    ("AURORA", "AURORA Tribute Band", 248826, 248826),
+    ("Artist", "Artist", 180000, 230000),
+])
+def test_search_rejects_conflicting_performer_or_recording_length(
+    artist, candidate_artist, duration, candidate_duration,
+):
+    assert not score_candidate(
+        "A Song", [artist], duration, "A Song", candidate_artist, candidate_duration,
+    )[1]
+
+
+@pytest.mark.parametrize("target_class", [DeezerTarget, QobuzTarget, TidalTarget, AmazonMusicTarget, AppleMusicTarget])
+@pytest.mark.parametrize("conflict", ["performer", "duration"])
+def test_isrc_cache_cannot_override_conflicting_recording_metadata(target_class, conflict):
+    target = target_class.__new__(target_class)
+    target._search = lambda *_args: None
+    source = {"id": "source", "name": "A Song", "artists": ["Artist"],
+              "duration_ms": 180000, "isrc": "ISRC1"}
+    candidate = {"id": "wrong", "name": "A Song", "artist": "Different Performer",
+                 "duration_ms": 180000}
+    if conflict == "duration":
+        candidate.update(artist="Artist", duration_ms=230000)
+    cache = {"isrc": {"ISRC1": [candidate]}, "search": {track_key("A Song", "Artist"): None}}
+    assert target.resolve(source, cache)[0] is None
+    assert target.expected_ids([source], {}, cache) == {}
+
+
+def test_duplicate_guard_does_not_treat_a_tribute_performer_as_the_original():
+    source = {"name": "Runaway", "artists": ["AURORA"], "duration_ms": 248826}
+    cover = {"name": "Runaway", "artist": "AURORA Tribute Band", "duration_ms": 248826}
+    assert not same_catalog_recording(source, cover)
+
+
+def test_a_shared_guest_cannot_hide_a_different_primary_performer():
+    source = {"name": "A Song", "artists": ["Original Artist", "Shared Guest"], "duration_ms": 180000}
+    cover = {"name": "A Song", "artist": "Different Artist, Shared Guest", "duration_ms": 180000}
+    assert not same_catalog_recording(source, cover)
+    assert not score_candidate(source["name"], source["artists"], 180000,
+                               cover["name"], cover["artist"], 180000)[1]
+
+
+@pytest.mark.parametrize("separator", ["ft.", "with", "feat.", "&", ","])
+def test_explicit_credit_separators_allow_a_providers_primary_credit(separator):
+    assert score_candidate("A Song", [f"Original Artist {separator} Guest"], 180000,
+                           "A Song", "Original Artist", 180000)[1]
+
+
+def test_release_normalization_keeps_a_literal_version_word_in_the_song_title():
+    source = {"name": "Version - Acoustic", "artists": ["Artist"], "duration_ms": 180000}
+    other = {**source, "name": "Acoustic"}
+    assert not same_catalog_recording(source, other)
+
+
+def test_shared_long_title_cannot_alias_a_different_performer():
+    name = "The Same Long Song Title From The Original Motion Picture Soundtrack"
+    original = _normalize({"name": name, "artists": ["Original Artist"], "duration_ms": 180000}, "spotify")
+    cover = _normalize({"name": name, "artists": ["Different Artist"], "duration_ms": 180000}, "ytmusic")
+    soft_id = "k:" + track_key(name, "Different Artist")
+    assert _unify_aliases({"spotify": {"i:ORIGINAL": original}, "ytmusic": {soft_id: cover}}) == {}
+
+
+def test_wrong_performer_in_an_archived_link_is_rejected(tmp_path):
+    target = DeezerTarget.__new__(DeezerTarget)
+    source = {"id": "source", "name": "A Song", "artists": ["Original Artist"], "duration_ms": 180000}
+    cover = {"id": "cover", "name": "A Song", "artist": "Cover Artist", "duration_ms": 180000}
+    conn = archive.connect(str(tmp_path / "wrong-performer.db"))
+    try:
+        archive.upsert_many(conn, "deezer", [cover])
+        assert _recover_archived_links(conn, "spotify", target, [source], {"source": "cover"}) == {}
+        assert compute_diff([source], [cover], {"source": {"cover"}}, target.track_id)[0] == [source]
+    finally:
+        conn.close()
+
+
+def test_historical_recording_references_prefer_native_evidence_and_selected_accounts(tmp_path):
+    conn = archive.connect(str(tmp_path / "reference-evidence.db"))
+    try:
+        for profile, track in [
+            ("selected", {"id": "native", "name": "A Song", "artist": "Original", "isrc": "US-ABC-26-00001"}),
+            ("selected", {"id": "learned", "name": "A Song", "artist": "Wrong"}),
+            ("other", {"id": "unselected", "name": "A Song", "artist": "Other", "isrc": "UNSELECTED"}),
+        ]:
+            archive.upsert_many(conn, profile, [track])
+        archive.set_identities(conn, "selected", {"learned": "i:USABC2600001"})
+        refs = archive.get_identity_snapshots(conn, ["selected"], ["i:USABC2600001", "i:UNSELECTED"])
+        assert set(refs) == {"i:USABC2600001"}
+        assert [t["id"] for t in refs["i:USABC2600001"]] == ["native"]
+    finally:
+        conn.close()
+
+
 @pytest.mark.parametrize("label", ["Acoustic", "Akustik", "Acústico", "Acoustique", "Unplugged", "Stripped"])
 @pytest.mark.parametrize("reverse", [False, True])
 def test_studio_and_acoustic_recordings_never_match(label, reverse):

--- a/tests/test_resolve_cache.py
+++ b/tests/test_resolve_cache.py
@@ -23,6 +23,22 @@ def test_legacy_automatic_matches_are_invalidated(tmp_path):
     assert cache["dirty"] is True
 
 
+def test_recording_match_upgrade_invalidates_previous_automatic_ids(tmp_path):
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({
+        "matching_version": 1,
+        "isrc": {"ISRC": [{"id": "wrong-performer"}]},
+        "search": {"song|artist": "old-automatic", "chosen|artist": "user-choice"},
+        "manual": ["chosen|artist"],
+    }), encoding="utf-8")
+    cache = load_cache(path)
+    assert cache["isrc"] == {}
+    assert cache["search"] == {"chosen|artist": "user-choice"}
+    assert cache["manual"] == {"chosen|artist"}
+    save_cache(path, cache)
+    assert json.loads(path.read_text("utf-8"))["matching_version"] > 1
+
+
 def test_legacy_migration_preserves_manual_choices_and_refreshes_isrc_metadata(tmp_path):
     path = tmp_path / "cache.json"
     path.write_text(json.dumps({

--- a/tests/test_spotify_cookie.py
+++ b/tests/test_spotify_cookie.py
@@ -42,9 +42,9 @@ def test_writes_route_to_cookie_when_enabled(monkeypatch):
 
     assert pl == {"id": "new"}
     assert [c[0] for c in calls] == ["create", "add", "remove", "remove_positions"]
-    # add is batched (one call, both ids); positions are forwarded verbatim
+    # Legacy positions carry track ids so a changed playlist fails closed.
     assert calls[1] == ("add", ("pl1", ["t1", "t2"]), {})
-    assert calls[3] == ("remove_positions", ("pl1", [0, 2]), {})
+    assert calls[3] == ("remove_positions", ("pl1", [0, 2]), {"expected_track_ids": ["t1", "t2"]})
 
 
 def test_oauth_write_rejection_remains_an_auth_error(monkeypatch):
@@ -63,6 +63,80 @@ def test_oauth_write_rejection_remains_an_auth_error(monkeypatch):
         target.create({"name": "Mix", "description": ""})
 
     assert not isinstance(exc_info.value, TargetDirectoryIncompleteError)
+
+
+def test_cookie_position_removal_skips_hidden_playlist_entries(monkeypatch):
+    from songmirror.engine import spotify_cookie as sc
+
+    monkeypatch.setattr(sc, "contents", lambda _: [
+        {"uid": "hidden", "uri": None},
+        {"uid": "keep", "uri": "spotify:track:go"},
+        {"uid": "remove", "uri": "spotify:track:extra"},
+    ])
+    writes = []
+    monkeypatch.setattr(sc, "_pf", lambda operation, payload: writes.append((operation, payload)))
+
+    sc.remove_positions("playlist", [1])
+
+    assert writes == [("removeFromPlaylist", {
+        "playlistUri": "spotify:playlist:playlist", "uids": ["remove"],
+    })]
+
+
+def test_cookie_playlist_read_retains_occurrence_uid():
+    from songmirror.engine import spotify_cookie as sc
+
+    rows = sc._normalized_content_tracks([
+        {"uid": "hidden", "itemV2": {"data": {}}},
+        {"uid": "selected-copy", "itemV2": {"data": {"uri": "spotify:track:song"}}},
+    ])
+
+    assert len(rows) == 1
+    assert rows[0]["playlistItemId"] == "selected-copy"
+
+
+def test_cookie_removal_uses_selected_copy_after_playlist_order_changes(monkeypatch):
+    monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "cookie")
+    writes = []
+    monkeypatch.setattr(st.spotify_cookie, "_pf", lambda operation, payload: writes.append((operation, payload)))
+    monkeypatch.setattr(st.spotify_cookie, "contents", lambda _: pytest.fail("stable removal must not resolve fresh positions"))
+    target = SpotifyTarget(_BoomSp(), "cache.json")
+
+    target.remove_occurrences({"id": "playlist"}, [(1, {"id": "song", "playlistItemId": "selected-copy"})])
+    target.remove_occurrence({"id": "playlist"}, "song", "other-copy")
+
+    assert target.stable_occurrence_ids
+    assert [payload["uids"] for _, payload in writes] == [["selected-copy"], ["other-copy"]]
+    monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "oauth")
+    assert not target.stable_occurrence_ids
+
+
+@pytest.mark.parametrize("positions,expected", [([0, 1], ["keep", "removed"]), ([0, 2], ["keep", "extra"])])
+def test_cookie_legacy_removal_validates_every_selection_before_writing(monkeypatch, positions, expected):
+    from songmirror.engine import spotify_cookie as sc
+
+    monkeypatch.setattr(sc, "contents", lambda _: [
+        {"uid": "keep", "uri": "spotify:track:keep"},
+        {"uid": "extra", "uri": "spotify:track:extra"},
+    ])
+    monkeypatch.setattr(sc, "_pf", lambda *_: pytest.fail("changed selections must not delete anything"))
+
+    with pytest.raises(RuntimeError, match="playlist changed"):
+        sc.remove_positions("playlist", positions, expected_track_ids=expected)
+
+
+@pytest.mark.parametrize("before_uid,after_uid", [(None, "original"), ("original", None)])
+def test_cookie_chronology_rollback_refuses_incomplete_occurrence_ids(monkeypatch, before_uid, after_uid):
+    monkeypatch.setenv("SPOTIFY_WRITE_BACKEND", "cookie")
+    target = SpotifyTarget(_BoomSp(), "cache.json")
+    before = [{"id": "kept", "playlistItemId": before_uid}]
+    monkeypatch.setattr(target, "playlist_tracks", lambda _: [
+        {"id": "kept", "playlistItemId": after_uid},
+        {"id": "new", "playlistItemId": "staged"},
+    ])
+
+    with pytest.raises(RuntimeError, match="occurrence ids"):
+        target._chronology_entries_added_since({"id": "playlist"}, before)
 
 
 def test_cookie_sync_read_never_requires_the_developer_catalog_api(monkeypatch):


### PR DESCRIPTION
Removed songs could return after sync, and older recoveries could appear above a playlist's last intentional addition. Spotify cookie reads omitted ISRCs, allowing one recording to split into multiple identities, while held changes prevented observed membership from reaching the removal baseline. Recover identities from selected Spotify profiles, retain observed membership during held passes, and defer older recoveries when an ordered repair is unavailable or blocked.

Automatic matching also accepted covers or different recordings with similar titles, while old cached IDs bypassed metadata checks. Validate performer credits, duration, and creative versions across search, ISRC candidates, archived links, identity inference, and duplicate checks for all seven providers. Normalize harmless release and bonus-track labels, reject a shared guest as sufficient performer evidence, and invalidate old automatic caches while preserving manual choices.

When historical bindings conflict with current recording evidence, hold those recordings and their baseline membership without inventing user deletions. Unrelated newer additions continue to sync. Native evidence can still repair identities atomically. Spotify occurrence UIDs also ensure selected copies are removed correctly when hidden entries affect playlist positions; incomplete rollback evidence is rejected.

Validation: **914 passed, 1 skipped**. Regressions cover all seven real resolver paths, repeated reconciliation across the six mirror providers, identity migration, held deletion evidence, conflicting historical bindings, shared artist credits, release-label duplicates, hidden Spotify entries, and duplicate occurrences. The failing cases were reproduced before their fixes. Independent compilation and focused verification passed.
